### PR TITLE
Tag controller nodes appropriately

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -27,6 +27,11 @@
             "Key": "Name",
             "PropagateAtLaunch": "true",
             "Value": "{{.ClusterName}}-{{.StackName}}-kube-aws-controller"
+          },
+          {
+            "Key": "kubernetes.io/role/master",
+            "PropagateAtLaunch": "true",
+            "Value": ""
           }
         ],
         "VPCZoneIdentifier": [


### PR DESCRIPTION
with `kubernetes.io/role`.
Resolves #370