### PR TITLE
Allow a custom KMS key with encrypted etcd volume

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -891,6 +891,10 @@ func (c Cluster) valid() error {
 		return err
 	}
 
+	if err := c.EtcdSettings.Valid(); err != nil {
+		return err
+	}
+
 	if c.WorkerTenancy != "default" && c.WorkerSpotPrice != "" {
 		return fmt.Errorf("selected worker tenancy (%s) is incompatible with spot instances", c.WorkerTenancy)
 	}
@@ -1170,6 +1174,14 @@ func (c ControllerSettings) Valid() error {
 
 	if err := c.Controller.Validate(); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (e EtcdSettings) Valid() error {
+	if !e.EtcdDataVolumeEncrypted && e.Etcd.KMSKeyARN() != "" {
+		return fmt.Errorf("`etcd.kmsKeyArn` can only be specified when `etcdDataVolumeEncrypted` is enabled")
 	}
 
 	return nil

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -357,6 +357,10 @@ worker:
 #    fqdn: etcd1.<internalDomainName>
 #  - name: etcd2
 #    fqdn: etcd2.<internalDomainName>
+#
+#  # ARN of the KMS key used to encrypt the etcd data volume. The account default key will be used if `etcdDataVolumeEncrypted`
+#  # is enable and `etcd.kmsKeyArn` is omitted.
+#  kmsKeyArn: "{{.Etcd.KMSKeyARN}}"
 
 # Instance type for etcd node
 # etcdInstanceType: t2.medium

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -276,6 +276,21 @@
                   "Effect" : "Allow",
                   "Resource" : "{{.KMSKeyARN}}"
                 },{{end}}
+                {{if $.Etcd.KMSKeyARN -}}
+                {{/* Required for mounting encrypted data volume */}}
+                {
+                "Action": [
+                  "kms:CreateGrant",
+                  "kms:Decrypt",
+                  "kms:Describe*",
+                  "kms:Encrypt",
+                  "kms:GenerateDataKey*",
+                  "kms:ReEncrypt*"
+                ],
+                "Effect": "Allow",
+                "Resource": "{{ $.Etcd.KMSKeyARN }}"
+                },
+                {{end -}}
                 {
                   "Action": "ec2:DescribeTags",
                   "Effect": "Allow",
@@ -408,6 +423,9 @@
           {{end}}
           {{if $.EtcdDataVolumeEncrypted}}
           "Encrypted": {{$.EtcdDataVolumeEncrypted}},
+          {{if $.Etcd.KMSKeyARN}}
+          "KmsKeyId": "{{$.Etcd.KMSKeyARN}}",
+          {{end}}
           {{end}}
           "VolumeType": "{{$.EtcdDataVolumeType}}",
           "Tags": [

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -68,3 +68,7 @@ func (e Etcd) HostedZoneLogicalName() (string, error) {
 	}
 	return "EtcdHostedZone", nil
 }
+
+func (e Etcd) KMSKeyARN() string {
+	return e.Cluster.KMSKeyARN
+}

--- a/model/etcd_cluster.go
+++ b/model/etcd_cluster.go
@@ -7,6 +7,7 @@ type EtcdCluster struct {
 	MemberIdentityProvider string     `yaml:"memberIdentityProvider,omitempty"`
 	HostedZone             Identifier `yaml:"hostedZone,omitempty"`
 	ManageRecordSets       *bool      `yaml:"manageRecordSets,omitempty"`
+	KMSKeyARN              string     `yaml:"kmsKeyArn,omitempty"`
 }
 
 const (

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -415,6 +415,22 @@ etcdDataVolumeEncrypted: true
 			},
 		},
 		{
+			context: "WithEtcdDataVolumeEncryptedKMSKeyARN",
+			configYaml: minimalValidConfigYaml + `
+etcdDataVolumeEncrypted: true
+etcd:
+  kmsKeyArn: arn:aws:kms:eu-west-1:XXX:key/XXX
+`,
+			assertConfig: []ConfigTester{
+				func(c *config.Config, t *testing.T) {
+					expected := "arn:aws:kms:eu-west-1:XXX:key/XXX"
+					if c.Etcd.KMSKeyARN() != expected {
+						t.Errorf("Etcd data volume KMS Key ARN didn't match : expected=%v actual=%v", expected, c.Etcd.KMSKeyARN())
+					}
+				},
+			},
+		},
+		{
 			context: "WithEtcdMemberIdentityProviderEIP",
 			configYaml: minimalValidConfigYaml + `
 etcd:


### PR DESCRIPTION
Specify a custom KMS key ARN to use with an encrypted etcd data volume. If omitted the account default key will be used. Have also fixed up the IAM policy so encrypted volumes can be reattached to future etcd instances

Fixes #393 