### PR TITLE
Automatically creates the token auth file if it isn't present

### DIFF
--- a/core/controlplane/config/token_config.go
+++ b/core/controlplane/config/token_config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -152,6 +153,12 @@ func (r *EncryptedAuthTokensOnDisk) Compact() (*CompactAuthTokens, error) {
 
 func ReadOrEncryptAuthTokens(dirname string, encryptor CachedEncryptor) (*EncryptedAuthTokensOnDisk, error) {
 	authTokenPath := filepath.Join(dirname, "tokens.csv")
+
+	// Auto-creates the auth token file, useful for those coming from previous versions of kube-aws
+	if _, err := os.Stat(authTokenPath); os.IsNotExist(err) {
+		os.OpenFile(authTokenPath, os.O_RDONLY|os.O_CREATE, 0600)
+	}
+
 	if _, err := ReadRawAuthTokens(dirname); err != nil {
 		return nil, err
 	}

--- a/core/controlplane/config/token_config_test.go
+++ b/core/controlplane/config/token_config_test.go
@@ -77,6 +77,31 @@ func TestReadOrCreateCompactEmptyAuthTokens(t *testing.T) {
 	})
 }
 
+func TestReadOrCreateCompactEmptyAuthTokens(t *testing.T) {
+	helper.WithDummyCredentials(func(dir string) {
+		kmsConfig := KMSConfig{
+			KMSKeyARN:      "keyarn",
+			Region:         model.RegionForName("us-west-1"),
+			EncryptService: &dummyEncryptService{},
+		}
+
+		if err := os.Remove(filepath.Join(dir, "tokens.csv")); err != nil {
+			t.Errorf("failed to remove tokens.csv for test setup : %v", err)
+			t.FailNow()
+		}
+
+		created, err := ReadOrCreateCompactAuthTokens(dir, kmsConfig)
+
+		if err != nil {
+			t.Errorf("failed to read or update compact auth tokens in %s : %v", dir, err)
+		}
+
+		if len(created.Contents) > 0 {
+			t.Errorf("compacted auth tokens expected to be an empty string, but was %s", created.Contents)
+		}
+	})
+}
+
 func TestReadOrCreateEmptyUnEcryptedCompactAuthTokens(t *testing.T) {
 	helper.WithDummyCredentials(func(dir string) {
 		t.Run("CachedToPreventUnnecessaryNodeReplacementOnUnencrypted", func(t *testing.T) {

--- a/core/controlplane/config/token_config_test.go
+++ b/core/controlplane/config/token_config_test.go
@@ -77,7 +77,7 @@ func TestReadOrCreateCompactEmptyAuthTokens(t *testing.T) {
 	})
 }
 
-func TestReadOrCreateCompactEmptyAuthTokens(t *testing.T) {
+func TestReadOrCreateCompactNonExistentAuthTokens(t *testing.T) {
 	helper.WithDummyCredentials(func(dir string) {
 		kmsConfig := KMSConfig{
 			KMSKeyARN:      "keyarn",


### PR DESCRIPTION
This PR improves UX after #418, hopefully avoiding issues like [this](https://github.com/kubernetes-incubator/kube-aws/issues/427#issuecomment-288551868).