### PR TITLE
Introduce the rescheduler

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"regexp"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -19,8 +21,6 @@ import (
 	"github.com/kubernetes-incubator/kube-aws/model/derived"
 	"github.com/kubernetes-incubator/kube-aws/netutil"
 	yaml "gopkg.in/yaml.v2"
-	"regexp"
-	"sort"
 )
 
 const (
@@ -104,6 +104,7 @@ func NewDefaultCluster() *Cluster {
 			ClusterAutoscalerImage:      model.Image{Repo: "gcr.io/google_containers/cluster-proportional-autoscaler-amd64", Tag: "1.0.0", RktPullDocker: false},
 			KubeDnsImage:                model.Image{Repo: "gcr.io/google_containers/kubedns-amd64", Tag: "1.9", RktPullDocker: false},
 			KubeDnsMasqImage:            model.Image{Repo: "gcr.io/google_containers/kube-dnsmasq-amd64", Tag: "1.4", RktPullDocker: false},
+			KubeReschedulerImage:        model.Image{Repo: "gcr.io/google-containers/rescheduler", Tag: "v0.2.2", RktPullDocker: false},
 			DnsMasqMetricsImage:         model.Image{Repo: "gcr.io/google_containers/dnsmasq-metrics-amd64", Tag: "1.0", RktPullDocker: false},
 			ExecHealthzImage:            model.Image{Repo: "gcr.io/google_containers/exechealthz-amd64", Tag: "1.2", RktPullDocker: false},
 			HeapsterImage:               model.Image{Repo: "gcr.io/google_containers/heapster", Tag: "v1.3.0", RktPullDocker: false},
@@ -366,6 +367,7 @@ type DeploymentSettings struct {
 	MapPublicIPs        bool              `yaml:"mapPublicIPs,omitempty"`
 	ElasticFileSystemID string            `yaml:"elasticFileSystemId,omitempty"`
 	SSHAuthorizedKeys   []string          `yaml:"sshAuthorizedKeys,omitempty"`
+	Addons              Addons            `yaml:"addons"`
 	Experimental        Experimental      `yaml:"experimental"`
 	ManageCertificates  bool              `yaml:"manageCertificates,omitempty"`
 	WaitSignal          WaitSignal        `yaml:"waitSignal"`
@@ -380,6 +382,7 @@ type DeploymentSettings struct {
 	ClusterAutoscalerImage      model.Image `yaml:"clusterAutoscalerImage,omitempty"`
 	KubeDnsImage                model.Image `yaml:"kubeDnsImage,omitempty"`
 	KubeDnsMasqImage            model.Image `yaml:"kubeDnsMasqImage,omitempty"`
+	KubeReschedulerImage        model.Image `yaml:"kubeReschedulerImage,omitempty"`
 	DnsMasqMetricsImage         model.Image `yaml:"dnsMasqMetricsImage,omitempty"`
 	ExecHealthzImage            model.Image `yaml:"execHealthzImage,omitempty"`
 	HeapsterImage               model.Image `yaml:"heapsterImage,omitempty"`
@@ -450,6 +453,14 @@ type Cluster struct {
 	HostedZoneID           string `yaml:"hostedZoneId,omitempty"`
 	ProvidedEncryptService EncryptService
 	CustomSettings         map[string]interface{} `yaml:"customSettings,omitempty"`
+}
+
+type Addons struct {
+	Rescheduler Rescheduler `yaml:"rescheduler"`
+}
+
+type Rescheduler struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 type Experimental struct {

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -367,7 +367,7 @@ type DeploymentSettings struct {
 	MapPublicIPs        bool              `yaml:"mapPublicIPs,omitempty"`
 	ElasticFileSystemID string            `yaml:"elasticFileSystemId,omitempty"`
 	SSHAuthorizedKeys   []string          `yaml:"sshAuthorizedKeys,omitempty"`
-	Addons              Addons            `yaml:"addons"`
+	Addons              model.Addons      `yaml:"addons"`
 	Experimental        Experimental      `yaml:"experimental"`
 	ManageCertificates  bool              `yaml:"manageCertificates,omitempty"`
 	WaitSignal          WaitSignal        `yaml:"waitSignal"`
@@ -453,14 +453,6 @@ type Cluster struct {
 	HostedZoneID           string `yaml:"hostedZoneId,omitempty"`
 	ProvidedEncryptService EncryptService
 	CustomSettings         map[string]interface{} `yaml:"customSettings,omitempty"`
-}
-
-type Addons struct {
-	Rescheduler Rescheduler `yaml:"rescheduler"`
-}
-
-type Rescheduler struct {
-	Enabled bool `yaml:"enabled"`
 }
 
 type Experimental struct {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1079,6 +1079,28 @@ write_files:
             initialDelaySeconds: 15
             timeoutSeconds: 15
 
+  - path: /etc/kubernetes/manifests/kube-rescheduler.yaml
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: rescheduler-v0.2.2
+        namespace: kube-system
+        labels:
+          k8s-app: rescheduler
+          version: v0.2.2
+          kubernetes.io/cluster-service: "true"
+          kubernetes.io/name: "Rescheduler"
+      spec:
+        hostNetwork: true
+        containers:
+        - name: rescheduler
+          image: gcr.io/google-containers/rescheduler:v0.2.2
+          # TODO: Make resource requirements depend on the size of the cluster
+          resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi
 
   - path: /srv/kubernetes/manifests/kube-dns-autoscaler-de.yaml
     content: |

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1096,7 +1096,6 @@ write_files:
         containers:
         - name: kube-rescheduler
           image: {{ .KubeReschedulerImage.RepoWithTag }}
-          # TODO: Make resource requirements depend on the size of the cluster
           resources:
             requests:
               cpu: 10m

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -471,6 +471,12 @@ write_files:
           "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services"
       done
 
+      {{- if .Addons.Rescheduler.Enabled }}
+      mfdir=/srv/kubernetes/manifests
+      post_yaml "@$mfdir/kube-rescheduler-de.yaml" \
+      "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
+      {{- end }}
+
       {{if .Experimental.Plugins.Rbac.Enabled}}
       # k8s > 1.5 already have this clusterRole, so we accept http.code != 200
       mfdir=/srv/kubernetes/rbac
@@ -1080,10 +1086,10 @@ write_files:
             timeoutSeconds: 15
 
   {{- if .Addons.Rescheduler.Enabled }}
-  - path: /etc/kubernetes/manifests/kube-rescheduler.yaml
+  - path: /srv/kubernetes/manifests/kube-rescheduler-de.yaml
     content: |
-      apiVersion: v1
-      kind: Pod
+      apiVersion: extensions/v1beta1
+      kind: Deployment
       metadata:
         name: kube-rescheduler
         namespace: kube-system
@@ -1092,14 +1098,23 @@ write_files:
           kubernetes.io/cluster-service: "true"
           kubernetes.io/name: "Rescheduler"
       spec:
-        hostNetwork: true
-        containers:
-        - name: kube-rescheduler
-          image: {{ .KubeReschedulerImage.RepoWithTag }}
-          resources:
-            requests:
-              cpu: 10m
-              memory: 100Mi
+        # `replicas` should always be the default of 1, rescheduler crashes otherwise
+        template:
+          metadata:
+            labels:
+              k8s-app: kube-rescheduler
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+              scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+          spec:
+            hostNetwork: true
+            containers:
+            - name: kube-rescheduler
+              image: {{ .KubeReschedulerImage.RepoWithTag }}
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 100Mi
   {{- end }}
 
   - path: /srv/kubernetes/manifests/kube-dns-autoscaler-de.yaml

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1079,28 +1079,29 @@ write_files:
             initialDelaySeconds: 15
             timeoutSeconds: 15
 
+  {{- if .Addons.Rescheduler.Enabled }}
   - path: /etc/kubernetes/manifests/kube-rescheduler.yaml
     content: |
       apiVersion: v1
       kind: Pod
       metadata:
-        name: rescheduler-v0.2.2
+        name: kube-rescheduler
         namespace: kube-system
         labels:
-          k8s-app: rescheduler
-          version: v0.2.2
+          k8s-app: kube-rescheduler
           kubernetes.io/cluster-service: "true"
           kubernetes.io/name: "Rescheduler"
       spec:
         hostNetwork: true
         containers:
-        - name: rescheduler
-          image: gcr.io/google-containers/rescheduler:v0.2.2
+        - name: kube-rescheduler
+          image: {{ .KubeReschedulerImage.RepoWithTag }}
           # TODO: Make resource requirements depend on the size of the cluster
           resources:
             requests:
               cpu: 10m
               memory: 100Mi
+  {{- end }}
 
   - path: /srv/kubernetes/manifests/kube-dns-autoscaler-de.yaml
     content: |

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -712,6 +712,12 @@ worker:
 #  tag: 1.4
 #  rktPullDocker: false
 
+# kube rescheduler image repository to use.
+#kubeReschedulerImage:
+#  repo: gcr.io/google-containers/rescheduler
+#  tag: v0.3.0
+#  rktPullDocker: false
+
 # DNS Masq metrics image repository to use.
 #dnsMasqMetricsImage:
 #  gcr.io/google_containers/dnsmasq-metrics-amd64
@@ -782,6 +788,12 @@ worker:
 #waitSignal:
 #  enabled: true
 #   maxBatchSize: 1
+
+# Addon features
+addons:
+  # When enabled, Kubernetes rescheduler is deployed to the cluster controller(s)
+  rescheduler:
+    enabled: false
 
 # Experimental features will change in backward-incompatible ways
 # experimental:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -715,7 +715,7 @@ worker:
 # kube rescheduler image repository to use.
 #kubeReschedulerImage:
 #  repo: gcr.io/google-containers/rescheduler
-#  tag: v0.3.0
+#  tag: v0.2.2
 #  rktPullDocker: false
 
 # DNS Masq metrics image repository to use.

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -792,6 +792,7 @@ worker:
 # Addon features
 addons:
   # When enabled, Kubernetes rescheduler is deployed to the cluster controller(s)
+  # This feature is experimental currently so may not be production ready
   rescheduler:
     enabled: false
 

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -5,11 +5,12 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
+
 	controlplane "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	nodepool "github.com/kubernetes-incubator/kube-aws/core/nodepool/config"
 	"github.com/kubernetes-incubator/kube-aws/model"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 )
 
 type UnmarshalledConfig struct {
@@ -88,8 +89,10 @@ func ConfigFromBytes(data []byte) (*Config, error) {
 		{c.Etcd, "etcd"},
 		{c.Controller, "controller"},
 		{c.Controller.AutoScalingGroup, "controller.autoScalingGroup"},
-		{c.Controller.ClusterAutoscaler, "controller.ClusterAutoscaler"},
+		{c.Controller.ClusterAutoscaler, "controller.clusterAutoscaler"},
 		{c.Experimental, "experimental"},
+		{c.Addons, "addons"},
+		{c.Addons.Rescheduler, "addons.rescheduler"},
 	}); err != nil {
 		return nil, err
 	}

--- a/model/addons.go
+++ b/model/addons.go
@@ -1,0 +1,11 @@
+package model
+
+type Addons struct {
+	Rescheduler Rescheduler `yaml:"rescheduler"`
+	UnknownKeys `yaml:",inline"`
+}
+
+type Rescheduler struct {
+	Enabled     bool `yaml:"enabled"`
+	UnknownKeys `yaml:",inline"`
+}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -2,16 +2,17 @@ package integration
 
 import (
 	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
 	"github.com/kubernetes-incubator/kube-aws/cfnstack"
 	controlplane_config "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	"github.com/kubernetes-incubator/kube-aws/core/root"
 	"github.com/kubernetes-incubator/kube-aws/core/root/config"
 	"github.com/kubernetes-incubator/kube-aws/model"
 	"github.com/kubernetes-incubator/kube-aws/test/helper"
-	"os"
-	"reflect"
-	"strings"
-	"testing"
 )
 
 type ConfigTester func(c *config.Config, t *testing.T)
@@ -2817,6 +2818,23 @@ worker:
       baz: 1
 `,
 			expectedErrorMessage: "unknown keys found in worker.nodePools[0].clusterAutoscaler: baz",
+		},
+		{
+			context: "WithUnknownKeyInAddons",
+			configYaml: minimalValidConfigYaml + `
+addons:
+  blah: 5
+`,
+			expectedErrorMessage: "unknown keys found in addons: blah",
+		},
+		{
+			context: "WithUnknownKeyInReschedulerAddon",
+			configYaml: minimalValidConfigYaml + `
+addons:
+  rescheduler:
+    foo: yeah
+`,
+			expectedErrorMessage: "unknown keys found in addons.rescheduler: foo",
 		},
 		{
 			context: "WithTooLongControllerIAMRoleName",


### PR DESCRIPTION
For https://github.com/coreos/kube-aws/issues/118.

- Currently using raw Pod as per [salt setup](https://github.com/kubernetes/kubernetes/blob/master/cluster/saltbase/salt/rescheduler/rescheduler.manifest)
- Introduced `addons` section for components like this and future components mentioned in https://github.com/kubernetes-incubator/kube-aws/issues/118 (e.g. kube-state-metrics)
- Logging routed via standard streams, in the future we could support other log routing
- gcr image used, not sure if hyperkube has the rescheduler
- Aligned to https://github.com/kubernetes-incubator/kube-aws/pull/390 by allowing
image repo/tag to be overridden