### PR TITLE
China region improvements and update some deprecated vars.

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -111,6 +111,7 @@ func NewDefaultCluster() *Cluster {
 			KubeDashboardImage:          model.Image{Repo: "gcr.io/google_containers/kubernetes-dashboard-amd64", Tag: "v1.5.1", RktPullDocker: false},
 			CalicoCtlImage:              model.Image{Repo: "calico/ctl", Tag: "v1.0.0", RktPullDocker: false},
 			PauseImage:                  model.Image{Repo: "gcr.io/google_containers/pause-amd64", Tag: "3.0", RktPullDocker: false},
+			FlannelImage:                model.Image{Repo: "quay.io/coreos/flannel", Tag: "v0.6.2", RktPullDocker: false},
 		},
 		KubeClusterSettings: KubeClusterSettings{
 			DNSServiceIP: "10.3.0.10",
@@ -386,6 +387,7 @@ type DeploymentSettings struct {
 	AddonResizerImage           model.Image `yaml:"addonResizerImage,omitempty"`
 	KubeDashboardImage          model.Image `yaml:"kubeDashboardImage,omitempty"`
 	PauseImage                  model.Image `yaml:"pauseImage,omitempty"`
+	FlannelImage                model.Image `yaml:"flannelImage,omitempty"`
 }
 
 // Part of configuration which is specific to worker nodes

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -351,10 +351,12 @@ ssh_authorized_keys:
         [Unit]
         Description=Pull and tag a mirror image for pause-amd64
         Wants=docker.service
+        After=docker.service
 
         [Service]
-        Type=oneshot
+        Restart=on-failure
         RemainAfterExit=true
+        ExecStartPre=/usr/bin/systemctl is-active docker.service
         ExecStartPre=/usr/bin/docker pull {{.PauseImage.RepoWithTag}}
         ExecStart=/usr/bin/docker tag {{.PauseImage.RepoWithTag}} gcr.io/google_containers/pause-amd64:3.0
         ExecStop=/bin/true

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -87,6 +87,18 @@ coreos:
             set /coreos.com/network/config '{"Network" : "{{.PodCIDR}}", "Backend" : {"Type" : "vxlan"}}'
             TimeoutStartSec=120
 
+{{if .FlannelImage.RktPullDocker}}
+        - name: 20-flannel-custom-image.conf
+          content: |
+            [Unit]
+            PartOf=flanneld.service
+            Before=docker.service
+
+            [Service]
+            Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
+            Environment="RKT_RUN_ARGS={{.FlannelImage.Options}}"
+{{end}}
+
     - name: kubelet.service
       command: start
       runtime: true
@@ -96,9 +108,9 @@ coreos:
         After=cfn-etcd-environment.service
         [Service]
         EnvironmentFile=-/etc/etcd-environment
-        Environment=KUBELET_VERSION={{.K8sVer}}
-        Environment=KUBELET_ACI={{ .HyperkubeImage.RktRepoWithoutTag }}
-        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf {{.HyperkubeImage.Options}}\
+        Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
+        Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
+        Environment="RKT_RUN_ARGS=--volume dns,kind=host,source=/etc/resolv.conf {{.HyperkubeImage.Options}}\
         --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/ca.pem \
         --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
         --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
@@ -338,14 +350,16 @@ ssh_authorized_keys:
       content: |
         [Unit]
         Description=Pull and tag a mirror image for pause-amd64
-        After=docker.service
         Wants=docker.service
 
         [Service]
-        Restart=on-failure
+        Type=oneshot
         RemainAfterExit=true
         ExecStartPre=/usr/bin/docker pull {{.PauseImage.RepoWithTag}}
-        ExecStart=/usr/bin/docker tag  {{.PauseImage.RepoWithTag}} gcr.io/google_containers/pause-amd64:3.0
+        ExecStart=/usr/bin/docker tag {{.PauseImage.RepoWithTag}} gcr.io/google_containers/pause-amd64:3.0
+        ExecStop=/bin/true
+        [Install]
+        WantedBy=install-kube-system.service
 {{end}}
 write_files:
 {{if .Experimental.AwsEnvironment.Enabled}}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -97,8 +97,19 @@ coreos:
             [Service]
             Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
             Environment="RKT_RUN_ARGS={{.FlannelImage.Options}}"
-{{end}}
 
+    - name: flannel-docker-opts.service
+      drop-ins:
+        - name: 10-flannel-docker-options.conf
+          content: |
+            [Unit]
+            PartOf=flanneld.service
+            Before=docker.service
+
+            [Service]
+            Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
+            Environment="RKT_RUN_ARGS={{.FlannelImage.Options}} --uuid-file-save=/var/lib/coreos/flannel-wrapper2.uuid"
+{{end}}
     - name: kubelet.service
       command: start
       runtime: true

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -101,8 +101,19 @@ coreos:
             [Service]
             Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
             Environment="RKT_RUN_ARGS={{.FlannelImage.Options}}"
-{{end}}
 
+    - name: flannel-docker-opts.service
+      drop-ins:
+        - name: 10-flannel-docker-options.conf
+          content: |
+            [Unit]
+            PartOf=flanneld.service
+            Before=docker.service
+
+            [Service]
+            Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
+            Environment="RKT_RUN_ARGS={{.FlannelImage.Options}} --uuid-file-save=/var/lib/coreos/flannel-wrapper2.uuid"
+{{end}}
     - name: kubelet.service
       command: start
       runtime: true

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -429,12 +429,15 @@ ssh_authorized_keys:
         [Unit]
         Description=Pull and tag a mirror image for pause-amd64
         Wants=docker.service
+        After=docker.service
 
         [Service]
-        Type=oneshot
+        Restart=on-failure
         RemainAfterExit=true
+        ExecStartPre=/usr/bin/systemctl is-active docker.service
         ExecStartPre=/usr/bin/docker pull {{.PauseImage.RepoWithTag}}
         ExecStart=/usr/bin/docker tag {{.PauseImage.RepoWithTag}} gcr.io/google_containers/pause-amd64:3.0
+        ExecStop=/bin/true
         [Install]
         WantedBy=kubelet.service
 {{end}}

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -91,6 +91,18 @@ coreos:
             Environment="ETCD_SSL_DIR=/etc/kubernetes/ssl"
             TimeoutStartSec=120
 
+{{if .FlannelImage.RktPullDocker}}
+        - name: 20-flannel-custom-image.conf
+          content: |
+            [Unit]
+            PartOf=flanneld.service
+            Before=docker.service
+
+            [Service]
+            Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
+            Environment="RKT_RUN_ARGS={{.FlannelImage.Options}}"
+{{end}}
+
     - name: kubelet.service
       command: start
       runtime: true
@@ -100,9 +112,9 @@ coreos:
         After=cfn-etcd-environment.service
         [Service]
         EnvironmentFile=-/etc/etcd-environment
-        Environment=KUBELET_VERSION={{.K8sVer}}
-        Environment=KUBELET_ACI={{.HyperkubeImage.RktRepoWithoutTag}}
-        Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf {{.HyperkubeImage.Options}}\
+        Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
+        Environment=KUBELET_IMAGE_URL={{.HyperkubeImage.RktRepoWithoutTag}}
+        Environment="RKT_RUN_ARGS=--volume dns,kind=host,source=/etc/resolv.conf {{.HyperkubeImage.Options}}\
         --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/ca.pem \
         --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
         --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
@@ -416,14 +428,15 @@ ssh_authorized_keys:
       content: |
         [Unit]
         Description=Pull and tag a mirror image for pause-amd64
-        After=docker.service
         Wants=docker.service
 
         [Service]
-        Restart=on-failure
+        Type=oneshot
         RemainAfterExit=true
         ExecStartPre=/usr/bin/docker pull {{.PauseImage.RepoWithTag}}
         ExecStart=/usr/bin/docker tag {{.PauseImage.RepoWithTag}} gcr.io/google_containers/pause-amd64:3.0
+        [Install]
+        WantedBy=kubelet.service
 {{end}}
 write_files:
 {{if .AwsEnvironment.Enabled}}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -753,6 +753,12 @@ worker:
 #  tag: 3.0
 #  rktPullDocker: false
 
+# Flannel image repository to use.This allow pulling flannel image from a docker repo.
+#flannelImage:
+#  repo: quay.io/coreos/flannel
+#  tag: v0.6.2
+#  rktPullDocker: false
+
 # Use Calico for network policy.
 # useCalico: false
 

--- a/core/nodepool/config/deployment.go
+++ b/core/nodepool/config/deployment.go
@@ -96,6 +96,7 @@ func (c DeploymentSettings) WithDefaultsFrom(main cfg.DeploymentSettings) Deploy
 	c.AWSCliImage.MergeIfEmpty(main.AWSCliImage)
 	c.CalicoCtlImage.MergeIfEmpty(main.CalicoCtlImage)
 	c.PauseImage.MergeIfEmpty(main.PauseImage)
+	c.FlannelImage.MergeIfEmpty(main.FlannelImage)
 
 	if len(c.SSHAuthorizedKeys) == 0 {
 		c.SSHAuthorizedKeys = main.SSHAuthorizedKeys


### PR DESCRIPTION
Hi @mumoshu 
Made some small changes, mostly for China region.

1. Replace deprecated vars:
`KUBELET_VERSION` ==>   `KUBELET_IMAGE_TAG`
`KUBELET_ACI`.          ==>   `KUBELET_IMAGE_URL`
`RKT_OPT`                   ==>   `RKT_RUN_ARGS`

2. Fix `pause-amd64.service` to start at first boot.

3. Allow to pull **flannel** image from a docker repo In China region
sometimes it takes ~30 min to pull the image from quay.

Please review.

Thanks!