### PR TITLE
Kubelet TLS bootstrapping

### DIFF
--- a/Documentation/kubernetes-on-aws-render.md
+++ b/Documentation/kubernetes-on-aws-render.md
@@ -93,6 +93,18 @@ There will now be a `cluster.yaml` file in the asset directory. This is the main
 
 ### Render contents of the asset directory
 
+#### Auth token file
+
+* The initial token file can be created via the `render token-file` sub-command.
+
+  ```sh
+  $ kube-aws render token-file
+  ```
+
+* If you turned on the cluster TLS bootstrapping experimental feature in the `cluster.yaml` file, the generated auth token file will include a randomly generated token used during the bootstrapping, as documented [here](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/).
+
+#### TLS certificates
+
 * In the simplest case, you can have kube-aws generate both your TLS identities and certificate authority for you.
 
   ```sh
@@ -118,6 +130,8 @@ There will now be a `cluster.yaml` file in the asset directory. This is the main
   admin-key.pem       apiserver-key.pem   ca-key.pem          etcd-client-key.pem etcd-key.pem        tokens.csv          worker.pem
   admin.pem           apiserver.pem       ca.pem              etcd-client.pem     etcd.pem            worker-key.pem
   ```
+
+### Render cluster assets
 
 The next command generates the default set of cluster assets in your asset directory.
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -18,15 +18,23 @@ var (
 		SilenceUsage: true,
 	}
 
-	cmdRenderCredentials = &cobra.Command{
+	cmdRenderTLSCredentials = &cobra.Command{
 		Use:          "credentials",
-		Short:        "Render credentials",
+		Short:        "Render TLS credentials",
 		Long:         ``,
-		RunE:         runCmdRenderCredentials,
+		RunE:         runCmdRenderTLSCredentials,
 		SilenceUsage: true,
 	}
 
-	renderCredentialsOpts = config.CredentialsOptions{}
+	cmdRenderTokenFile = &cobra.Command{
+		Use:          "token-file",
+		Short:        "Render auth token file",
+		Long:         ``,
+		RunE:         runCmdRenderTokenFile,
+		SilenceUsage: true,
+	}
+
+	renderTLSCredentialsOpts = config.CredentialsOptions{}
 
 	cmdRenderStack = &cobra.Command{
 		Use:          "stack",
@@ -40,27 +48,31 @@ var (
 func init() {
 	RootCmd.AddCommand(cmdRender)
 
-	cmdRender.AddCommand(cmdRenderCredentials)
-	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.GenerateCA, "generate-ca", false, "if generating credentials, generate root CA key and cert. NOT RECOMMENDED FOR PRODUCTION USE- use '-ca-key-path' and '-ca-cert-path' options to provide your own certificate authority assets")
-	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CaKeyPath, "ca-key-path", "./credentials/ca-key.pem", "path to pem-encoded CA RSA key")
-	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CaCertPath, "ca-cert-path", "./credentials/ca.pem", "path to pem-encoded CA x509 certificate")
-
+	cmdRender.AddCommand(cmdRenderTLSCredentials)
+	cmdRender.AddCommand(cmdRenderTokenFile)
 	cmdRender.AddCommand(cmdRenderStack)
+
+	cmdRenderTLSCredentials.Flags().BoolVar(&renderTLSCredentialsOpts.GenerateCA, "generate-ca", false, "if generating credentials, generate root CA key and cert. NOT RECOMMENDED FOR PRODUCTION USE- use '-ca-key-path' and '-ca-cert-path' options to provide your own certificate authority assets")
+	cmdRenderTLSCredentials.Flags().StringVar(&renderTLSCredentialsOpts.CaKeyPath, "ca-key-path", "./credentials/ca-key.pem", "path to pem-encoded CA RSA key")
+	cmdRenderTLSCredentials.Flags().StringVar(&renderTLSCredentialsOpts.CaCertPath, "ca-cert-path", "./credentials/ca.pem", "path to pem-encoded CA x509 certificate")
 }
 func runCmdRender(cmd *cobra.Command, args []string) error {
-	fmt.Printf("WARNING: 'kube-aws render' is deprecated. See 'kube-aws render --help' for usage\n")
+	fmt.Println("WARNING: 'kube-aws render' is deprecated. See 'kube-aws render --help' for usage")
 	if len(args) != 0 {
 		return fmt.Errorf("render takes no arguments\n")
 	}
 
-	if _, err := os.Stat(renderCredentialsOpts.CaKeyPath); os.IsNotExist(err) {
-		renderCredentialsOpts.GenerateCA = true
+	if _, err := os.Stat(renderTLSCredentialsOpts.CaKeyPath); os.IsNotExist(err) {
+		renderTLSCredentialsOpts.GenerateCA = true
 	}
-	if err := runCmdRenderCredentials(cmdRenderCredentials, args); err != nil {
+	if err := runCmdRenderTokenFile(cmdRenderTLSCredentials, args); err != nil {
+		return err
+	}
+	if err := runCmdRenderTLSCredentials(cmdRenderTLSCredentials, args); err != nil {
 		return err
 	}
 
-	if err := runCmdRenderStack(cmdRenderCredentials, args); err != nil {
+	if err := runCmdRenderStack(cmdRenderTLSCredentials, args); err != nil {
 		return err
 	}
 
@@ -83,18 +95,30 @@ func runCmdRenderStack(cmd *cobra.Command, args []string) error {
 Next steps:
 1. (Optional) Validate your changes to %s with "kube-aws validate"
 2. (Optional) Further customize the cluster by modifying templates in ./stack-templates or cloud-configs in ./userdata.
-3. Start the cluster with "kube-aws up".
+3. (Optional) Add more authentication tokens in ./credentials/tokens.csv
+4. Start the cluster with "kube-aws up".
 `
 
 	fmt.Printf(successMsg, configPath)
 	return nil
 }
 
-func runCmdRenderCredentials(cmd *cobra.Command, args []string) error {
+func runCmdRenderTLSCredentials(cmd *cobra.Command, args []string) error {
+	cluster, err := root.CredentialsRendererFromFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read cluster config: %v", err)
+	}
+	return cluster.RenderTLSCerts(renderTLSCredentialsOpts)
+}
+
+func runCmdRenderTokenFile(cmd *cobra.Command, args []string) error {
 	cluster, err := root.CredentialsRendererFromFile(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to read cluster config: %v", err)
 	}
 
-	return cluster.RenderFiles(renderCredentialsOpts)
+	if err = cluster.RenderAuthTokenFile(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -57,7 +57,7 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("Creating AWS resources. Please wait. It may take a few minutes.\n")
+	fmt.Println("Creating AWS resources. Please wait. It may take a few minutes.")
 	if err := cluster.Create(); err != nil {
 		return fmt.Errorf("Error creating cluster: %v", err)
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -53,12 +53,12 @@ func runCmdValidate(cmd *cobra.Command, args []string) error {
 	if report != "" {
 		fmt.Fprintf(os.Stderr, "Validation Report: %s\n", report)
 	}
-
 	if err != nil {
 		return err
 	}
-	fmt.Printf("stack template is valid.\n\n")
 
-	fmt.Printf("Validation OK!\n")
+	fmt.Printf("stack template is valid.\n\n")
+	fmt.Println("Validation OK!")
+
 	return nil
 }

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -58,7 +58,7 @@ func NewDefaultCluster() *Cluster {
 		ClusterAutoscalerSupport: ClusterAutoscalerSupport{
 			Enabled: false,
 		},
-		ClusterTLSBootstrap: ClusterTLSBootstrap{
+		TLSBootstrap: TLSBootstrap{
 			Enabled: false,
 		},
 		EphemeralImageStorage: EphemeralImageStorage{
@@ -464,7 +464,7 @@ type Experimental struct {
 	AwsEnvironment           AwsEnvironment           `yaml:"awsEnvironment"`
 	AwsNodeLabels            AwsNodeLabels            `yaml:"awsNodeLabels"`
 	ClusterAutoscalerSupport ClusterAutoscalerSupport `yaml:"clusterAutoscalerSupport"`
-	ClusterTLSBootstrap      ClusterTLSBootstrap      `yaml:"clusterTLSBootstrap"`
+	TLSBootstrap             TLSBootstrap             `yaml:"tlsBootstrap"`
 	EphemeralImageStorage    EphemeralImageStorage    `yaml:"ephemeralImageStorage"`
 	Kube2IamSupport          Kube2IamSupport          `yaml:"kube2IamSupport,omitempty"`
 	LoadBalancer             LoadBalancer             `yaml:"loadBalancer"`
@@ -513,7 +513,7 @@ type ClusterAutoscalerSupport struct {
 	Enabled bool `yaml:"enabled"`
 }
 
-type ClusterTLSBootstrap struct {
+type TLSBootstrap struct {
 	Enabled bool `yaml:"enabled"`
 }
 
@@ -783,7 +783,7 @@ func (c Cluster) StackConfig(opts StackTemplateOptions) (*StackConfig, error) {
 	if stackConfig.UserDataEtcd, err = userdatatemplate.GetString(opts.EtcdTmplFile, stackConfig.Config); err != nil {
 		return nil, fmt.Errorf("failed to render etcd cloud config: %v", err)
 	}
-	if len(stackConfig.Config.AuthTokensConfig.KubeletBootstrapToken) == 0 && c.DeploymentSettings.Experimental.ClusterTLSBootstrap.Enabled {
+	if len(stackConfig.Config.AuthTokensConfig.KubeletBootstrapToken) == 0 && c.DeploymentSettings.Experimental.TLSBootstrap.Enabled {
 		bootstrapRecord, err := RandomBootstrapTokenRecord()
 		if err != nil {
 			return nil, err
@@ -969,7 +969,7 @@ func (c Cluster) valid() error {
 		fmt.Println(`WARNING: instance types "t2.nano" and "t2.micro" are not recommended. See https://github.com/kubernetes-incubator/kube-aws/issues/258 for more information`)
 	}
 
-	if c.Experimental.ClusterTLSBootstrap.Enabled && !c.Experimental.Plugins.Rbac.Enabled {
+	if c.Experimental.TLSBootstrap.Enabled && !c.Experimental.Plugins.Rbac.Enabled {
 		fmt.Println(`WARNING: enabling cluster-level TLS bootstrapping without RBAC is not recommended. See https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/ for more information`)
 	}
 

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -58,6 +58,9 @@ func NewDefaultCluster() *Cluster {
 		ClusterAutoscalerSupport: ClusterAutoscalerSupport{
 			Enabled: false,
 		},
+		ClusterTLSBootstrap: ClusterTLSBootstrap{
+			Enabled: false,
+		},
 		EphemeralImageStorage: EphemeralImageStorage{
 			Enabled:    false,
 			Disk:       "xvdb",
@@ -461,6 +464,7 @@ type Experimental struct {
 	AwsEnvironment           AwsEnvironment           `yaml:"awsEnvironment"`
 	AwsNodeLabels            AwsNodeLabels            `yaml:"awsNodeLabels"`
 	ClusterAutoscalerSupport ClusterAutoscalerSupport `yaml:"clusterAutoscalerSupport"`
+	ClusterTLSBootstrap      ClusterTLSBootstrap      `yaml:"clusterTLSBootstrap"`
 	EphemeralImageStorage    EphemeralImageStorage    `yaml:"ephemeralImageStorage"`
 	Kube2IamSupport          Kube2IamSupport          `yaml:"kube2IamSupport,omitempty"`
 	LoadBalancer             LoadBalancer             `yaml:"loadBalancer"`
@@ -506,6 +510,10 @@ type AwsNodeLabels struct {
 }
 
 type ClusterAutoscalerSupport struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type ClusterTLSBootstrap struct {
 	Enabled bool `yaml:"enabled"`
 }
 
@@ -744,7 +752,7 @@ func (c Cluster) StackConfig(opts StackTemplateOptions) (*StackConfig, error) {
 		}
 		stackConfig.Config.AuthTokensConfig = compactAuthTokens
 	} else {
-		rawAuthTokens, err := ReadOrCreateUnecryptedCompactAuthTokens(opts.AssetsDir)
+		rawAuthTokens, err := ReadOrCreateUnencryptedCompactAuthTokens(opts.AssetsDir)
 		if err != nil {
 			return nil, err
 		}
@@ -752,19 +760,15 @@ func (c Cluster) StackConfig(opts StackTemplateOptions) (*StackConfig, error) {
 	}
 	if c.ManageCertificates {
 		if c.AssetsEncryptionEnabled() {
-
 			compactAssets, err = ReadOrCreateCompactTLSAssets(opts.AssetsDir, KMSConfig{
 				Region:         stackConfig.Config.Region,
 				KMSKeyARN:      c.KMSKeyARN,
 				EncryptService: c.ProvidedEncryptService,
 			})
-			if err != nil {
-				return nil, err
-			}
 
 			stackConfig.Config.TLSConfig = compactAssets
 		} else {
-			rawAssets, err := ReadOrCreateUnecryptedCompactTLSAssets(opts.AssetsDir)
+			rawAssets, err := ReadOrCreateUnencryptedCompactTLSAssets(opts.AssetsDir)
 			if err != nil {
 				return nil, err
 			}
@@ -778,6 +782,13 @@ func (c Cluster) StackConfig(opts StackTemplateOptions) (*StackConfig, error) {
 	}
 	if stackConfig.UserDataEtcd, err = userdatatemplate.GetString(opts.EtcdTmplFile, stackConfig.Config); err != nil {
 		return nil, fmt.Errorf("failed to render etcd cloud config: %v", err)
+	}
+	if len(stackConfig.Config.AuthTokensConfig.KubeletBootstrapToken) == 0 && c.DeploymentSettings.Experimental.ClusterTLSBootstrap.Enabled {
+		bootstrapRecord, err := RandomBootstrapTokenRecord()
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("kubelet bootstrap token not found in ./credentials/tokens.csv\n\nTo fix this, append the following line to ./credentials.tokens.csv:\n%s", bootstrapRecord)
 	}
 
 	stackConfig.StackTemplateOptions = opts
@@ -798,11 +809,8 @@ type Config struct {
 
 	EtcdNodes []derived.EtcdNode
 
-	// Encoded auth tokens
 	AuthTokensConfig *CompactAuthTokens
-
-	// Encoded TLS assets
-	TLSConfig *CompactTLSAssets
+	TLSConfig        *CompactTLSAssets
 }
 
 // StackName returns the logical name of a CloudFormation stack resource in a root stack template
@@ -959,6 +967,10 @@ func (c Cluster) valid() error {
 
 	if c.ControllerInstanceType == "t2.micro" || c.EtcdInstanceType == "t2.micro" || c.ControllerInstanceType == "t2.nano" || c.EtcdInstanceType == "t2.nano" {
 		fmt.Println(`WARNING: instance types "t2.nano" and "t2.micro" are not recommended. See https://github.com/kubernetes-incubator/kube-aws/issues/258 for more information`)
+	}
+
+	if c.Experimental.ClusterTLSBootstrap.Enabled && !c.Experimental.Plugins.Rbac.Enabled {
+		fmt.Println(`WARNING: enabling cluster-level TLS bootstrapping without RBAC is not recommended. See https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/ for more information`)
 	}
 
 	if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.ManagedIamRoleName, c.Region.String()); e != nil {

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -722,6 +722,69 @@ experimental:
 
 }
 
+func TestClusterTLSBootstrapConfig(t *testing.T) {
+
+	validConfigs := []struct {
+		conf                string
+		clusterTLSBootstrap ClusterTLSBootstrap
+	}{
+		{
+			conf: `
+`,
+			clusterTLSBootstrap: ClusterTLSBootstrap{
+				Enabled: false,
+			},
+		},
+		{
+			conf: `
+experimental:
+  clusterTLSBootstrap:
+    enabled: false
+`,
+			clusterTLSBootstrap: ClusterTLSBootstrap{
+				Enabled: false,
+			},
+		},
+		{
+			conf: `
+experimental:
+  clusterTLSBootstrap:
+    enabled: true
+`,
+			clusterTLSBootstrap: ClusterTLSBootstrap{
+				Enabled: true,
+			},
+		},
+		{
+			conf: `
+# Settings for an experimental feature must be under the "experimental" field. Ignored.
+clusterTLSBootstrap:
+  enabled: true
+`,
+			clusterTLSBootstrap: ClusterTLSBootstrap{
+				Enabled: false,
+			},
+		},
+	}
+
+	for _, conf := range validConfigs {
+		confBody := singleAzConfigYaml + conf.conf
+		c, err := ClusterFromBytes([]byte(confBody))
+		if err != nil {
+			t.Errorf("failed to parse config %s: %v", confBody, err)
+			continue
+		}
+		if !reflect.DeepEqual(c.Experimental.ClusterTLSBootstrap, conf.clusterTLSBootstrap) {
+			t.Errorf(
+				"parsed cluster TLS bootstrap settings %+v does not match config: %s",
+				c.Experimental.ClusterTLSBootstrap,
+				confBody,
+			)
+		}
+	}
+
+}
+
 func TestRktConfig(t *testing.T) {
 	validChannels := []string{
 		"alpha",

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -722,46 +722,46 @@ experimental:
 
 }
 
-func TestClusterTLSBootstrapConfig(t *testing.T) {
+func TestTLSBootstrapConfig(t *testing.T) {
 
 	validConfigs := []struct {
-		conf                string
-		clusterTLSBootstrap ClusterTLSBootstrap
+		conf         string
+		tlsBootstrap TLSBootstrap
 	}{
 		{
 			conf: `
 `,
-			clusterTLSBootstrap: ClusterTLSBootstrap{
+			tlsBootstrap: TLSBootstrap{
 				Enabled: false,
 			},
 		},
 		{
 			conf: `
 experimental:
-  clusterTLSBootstrap:
+  tlsBootstrap:
     enabled: false
 `,
-			clusterTLSBootstrap: ClusterTLSBootstrap{
+			tlsBootstrap: TLSBootstrap{
 				Enabled: false,
 			},
 		},
 		{
 			conf: `
 experimental:
-  clusterTLSBootstrap:
+  tlsBootstrap:
     enabled: true
 `,
-			clusterTLSBootstrap: ClusterTLSBootstrap{
+			tlsBootstrap: TLSBootstrap{
 				Enabled: true,
 			},
 		},
 		{
 			conf: `
 # Settings for an experimental feature must be under the "experimental" field. Ignored.
-clusterTLSBootstrap:
+tlsBootstrap:
   enabled: true
 `,
-			clusterTLSBootstrap: ClusterTLSBootstrap{
+			tlsBootstrap: TLSBootstrap{
 				Enabled: false,
 			},
 		},
@@ -774,10 +774,10 @@ clusterTLSBootstrap:
 			t.Errorf("failed to parse config %s: %v", confBody, err)
 			continue
 		}
-		if !reflect.DeepEqual(c.Experimental.ClusterTLSBootstrap, conf.clusterTLSBootstrap) {
+		if !reflect.DeepEqual(c.Experimental.TLSBootstrap, conf.tlsBootstrap) {
 			t.Errorf(
-				"parsed cluster TLS bootstrap settings %+v does not match config: %s",
-				c.Experimental.ClusterTLSBootstrap,
+				"parsed TLS bootstrap settings %+v does not match config: %s",
+				c.Experimental.TLSBootstrap,
 				confBody,
 			)
 		}

--- a/core/controlplane/config/credential.go
+++ b/core/controlplane/config/credential.go
@@ -28,6 +28,10 @@ type CachedEncryptor struct {
 	bytesEncryptionService bytesEncryptionService
 }
 
+func (e CachedEncryptor) EncryptedBytes(raw []byte) ([]byte, error) {
+	return e.bytesEncryptionService.Encrypt(raw)
+}
+
 func (e CachedEncryptor) EncryptedCredentialFromPath(filePath string) (*EncryptedCredentialOnDisk, error) {
 	raw, err := RawCredentialFileFromPath(filePath)
 	if err != nil {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1064,6 +1064,7 @@ write_files:
           {{ end }}
           {{if .Experimental.Plugins.Rbac.Enabled}}
           - --authorization-mode=RBAC
+          - --authorization-rbac-super-user=kube-admin
           {{ end }}
           {{if .Experimental.Authentication.Webhook.Enabled}}
           - --authentication-token-webhook-config-file=/etc/kubernetes/webhooks/authentication.yaml

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -893,8 +893,7 @@ write_files:
           - nonResourceURLs: ["*"]
             verbs: ["*"]
 
-  # Grants super-user permissions to users in the group system:masters, useful for Kubernetes < 1.5.x clusters
-  # (This is already set up in Kubernetes 1.5.x+)
+  # Grants super-user permissions to the kube-admin user
   - path: /srv/kubernetes/rbac/cluster-role-bindings/kube-admin.yaml
     content: |
         kind: ClusterRoleBinding
@@ -902,8 +901,8 @@ write_files:
         metadata:
           name: kube-admin
         subjects:
-          - kind: Group
-            name: system:masters
+          - kind: User
+            name: kube-admin
         roleRef:
           kind: ClusterRole
           name: cluster-admin

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -519,7 +519,7 @@ write_files:
           "http://127.0.0.1:8080/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings"
       done
 
-      {{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+      {{ if .Experimental.TLSBootstrap.Enabled }}
       post_yaml "@${mfdir}/cluster-roles/kubelet-bootstrap.yaml" \
       "http://127.0.0.1:8080/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles" |true
 
@@ -955,7 +955,7 @@ write_files:
           name: bootstrapped-node
           apiGroup: rbac.authorization.k8s.io
 
-{{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+{{ if .Experimental.TLSBootstrap.Enabled }}
   # Only allows certificate signing requests to be performed with the bootstrap token
   - path: /srv/kubernetes/rbac/cluster-roles/kubelet-bootstrap.yaml
     content: |
@@ -1149,7 +1149,7 @@ write_files:
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
           - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          {{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+          {{ if .Experimental.TLSBootstrap.Enabled }}
           - --insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap
           - --cluster-signing-cert-file=/etc/kubernetes/ssl/ca.pem
           - --cluster-signing-key-file=/etc/kubernetes/ssl/ca-key.pem
@@ -1582,7 +1582,7 @@ write_files:
     encoding: gzip+base64
     content: {{.TLSConfig.CACert}}
 
-{{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+{{ if .Experimental.TLSBootstrap.Enabled }}
   - path: /etc/kubernetes/ssl/ca-key.pem.enc
     encoding: gzip+base64
     content: {{.TLSConfig.CAKey}}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -506,14 +506,26 @@ write_files:
           echo 'Failed to create the cluster role named "cluster-admin". It is ok if you are using k8s newer than 1.5'
       fi
 
+      for manifest in {bootstrapped-node,}; do
+          post_yaml "@${mfdir}/cluster-roles/$manifest.yaml" \
+          "http://127.0.0.1:8080/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles"
+      done
+
       post_yaml "@${mfdir}/cluster-roles/cluster-admin.yaml" \
       "http://127.0.0.1:8080/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles" |true
 
-      for manifest in {system-worker,kube-worker,kube-admin}; do
+      for manifest in {system-worker,kube-worker,kube-admin,bootstrapped-node}; do
           post_yaml "@${mfdir}/cluster-role-bindings/$manifest.yaml" \
           "http://127.0.0.1:8080/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings"
       done
 
+      {{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+      post_yaml "@${mfdir}/cluster-roles/kubelet-bootstrap.yaml" \
+      "http://127.0.0.1:8080/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles" |true
+
+      post_yaml "@${mfdir}/cluster-role-bindings/kubelet-bootstrap.yaml" \
+      "http://127.0.0.1:8080/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings" |true
+      {{ end }}
       {{ end }}
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
@@ -832,8 +844,9 @@ write_files:
            echo "done."'
 
   {{if .Experimental.Plugins.Rbac.Enabled }}
-
-  #https://github.com/coreos/kube-aws/issues/230#issuecomment-274946933
+  # Creates the cluster-admin role, useful for Kubernetes < 1.5.x clusters
+  # (This is already set up in Kubernetes 1.5.x+)
+  # https://github.com/coreos/kube-aws/issues/230#issuecomment-274946933
   - path: /srv/kubernetes/rbac/cluster-roles/cluster-admin.yaml
     content: |
         kind: ClusterRole
@@ -847,6 +860,41 @@ write_files:
           - nonResourceURLs: ["*"]
             verbs: ["*"]
 
+  # We need to give nodes a few extra permissions so that both the node
+  # draining and node labeling with AWS metadata work as expected
+  - path: /srv/kubernetes/rbac/cluster-roles/bootstrapped-node.yaml
+    content: |
+        kind: ClusterRole
+        apiVersion: rbac.authorization.k8s.io/v1alpha1
+        metadata:
+            name: bootstrapped-node
+        rules:
+          - apiGroups: ["*"]
+            resources:
+            - nodes
+            verbs:
+            - patch
+            - update
+          - apiGroups: ["*"]
+            resources:
+            - replicasets
+            verbs:
+            - get
+          - apiGroups: ["*"]
+            resources:
+            - replicationcontrollers
+            verbs:
+            - get
+          - apiGroups: ["*"]
+            resources:
+            - pods/eviction
+            verbs:
+            - create
+          - nonResourceURLs: ["*"]
+            verbs: ["*"]
+
+  # Grants super-user permissions to users in the group system:masters, useful for Kubernetes < 1.5.x clusters
+  # (This is already set up in Kubernetes 1.5.x+)
   - path: /srv/kubernetes/rbac/cluster-role-bindings/kube-admin.yaml
     content: |
         kind: ClusterRoleBinding
@@ -854,8 +902,8 @@ write_files:
         metadata:
           name: kube-admin
         subjects:
-          - kind: User
-            name: kube-admin
+          - kind: Group
+            name: system:masters
         roleRef:
           kind: ClusterRole
           name: cluster-admin
@@ -875,6 +923,7 @@ write_files:
           name: cluster-admin
           apiGroup: rbac.authorization.k8s.io
 
+  # Allows add-ons running with the default service account in kube-sytem to have super-user access
   - path: /srv/kubernetes/rbac/cluster-role-bindings/system-worker.yaml
     content: |
         kind: ClusterRoleBinding
@@ -889,6 +938,57 @@ write_files:
           kind: ClusterRole
           name: cluster-admin
           apiGroup: rbac.authorization.k8s.io
+
+  # Associates the add-on group `bootstrapped-node` to all nodes, so that extra kube-aws
+  # features like node draining work as expected
+  - path: /srv/kubernetes/rbac/cluster-role-bindings/bootstrapped-node.yaml
+    content: |
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1alpha1
+        metadata:
+          name: bootstrapped-node
+        subjects:
+          - kind: Group
+            name: system:nodes
+        roleRef:
+          kind: ClusterRole
+          name: bootstrapped-node
+          apiGroup: rbac.authorization.k8s.io
+
+{{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+  # Only allows certificate signing requests to be performed with the bootstrap token
+  - path: /srv/kubernetes/rbac/cluster-roles/kubelet-bootstrap.yaml
+    content: |
+        kind: ClusterRole
+        apiVersion: rbac.authorization.k8s.io/v1alpha1
+        metadata:
+          name: kubelet-bootstrap
+        rules:
+          - apiGroups:
+              - '*'
+            resources:
+              - certificatesigningrequests
+            verbs:
+            - create
+            - get
+            - list
+            - watch
+
+  - path: /srv/kubernetes/rbac/cluster-role-bindings/kubelet-bootstrap.yaml
+    content: |
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1alpha1
+        metadata:
+          name: kubelet-bootstrap
+        subjects:
+          - kind: Group
+            namespace: '*'
+            name: system:kubelet-bootstrap
+        roleRef:
+          kind: ClusterRole
+          name: kubelet-bootstrap
+          apiGroup: rbac.authorization.k8s.io
+{{ end }}
 {{ end }}
 
   - path: /etc/kubernetes/manifests/kube-proxy.yaml
@@ -974,6 +1074,7 @@ write_files:
           - --advertise-address=$private_ipv4
           - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }},ResourceQuota
           - --anonymous-auth=false
+          - --cert-dir=/etc/kubernetes/ssl
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
@@ -1048,6 +1149,11 @@ write_files:
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
           - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
+          {{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+          - --insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap
+          - --cluster-signing-cert-file=/etc/kubernetes/ssl/ca.pem
+          - --cluster-signing-key-file=/etc/kubernetes/ssl/ca-key.pem
+          {{ end }}
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
           resources:
@@ -1475,6 +1581,12 @@ write_files:
   - path: /etc/kubernetes/ssl/ca.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.TLSConfig.CACert}}
+
+{{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+  - path: /etc/kubernetes/ssl/ca-key.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.CAKey}}
+{{ end }}
 
   - path: /etc/kubernetes/ssl/apiserver.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1064,7 +1064,6 @@ write_files:
           {{ end }}
           {{if .Experimental.Plugins.Rbac.Enabled}}
           - --authorization-mode=RBAC
-          - --authorization-rbac-super-user=kube-admin
           {{ end }}
           {{if .Experimental.Authentication.Webhook.Enabled}}
           - --authentication-token-webhook-config-file=/etc/kubernetes/webhooks/authentication.yaml

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -170,7 +170,7 @@ coreos:
         --cluster_domain=cluster.local \
         --cloud-provider=aws \
         --cert-dir=/etc/kubernetes/ssl \
-        {{- if .Experimental.ClusterTLSBootstrap.Enabled }}
+        {{- if .Experimental.TLSBootstrap.Enabled }}
         --experimental-bootstrap-kubeconfig=/etc/kubernetes/worker-bootstrap-kubeconfig.yaml \
         {{- else }}
         --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
@@ -552,7 +552,7 @@ write_files:
     encoding: gzip+base64
     content: {{.TLSConfig.EtcdClientKey}}
 
-{{ if not .Experimental.ClusterTLSBootstrap.Enabled }}
+{{ if not .Experimental.TLSBootstrap.Enabled }}
   - path: /etc/kubernetes/ssl/worker.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.TLSConfig.WorkerCert}}
@@ -578,7 +578,7 @@ write_files:
       rkt run \
         --volume=ssl,kind=host,source=/etc/kubernetes/ssl,readOnly=false \
         --mount=volume=ssl,target=/etc/kubernetes/ssl \
-        {{- if .Experimental.ClusterTLSBootstrap.Enabled }}
+        {{- if .Experimental.TLSBootstrap.Enabled }}
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=false \
         --mount=volume=kube,target=/etc/kubernetes \
         {{- end }}
@@ -590,7 +590,7 @@ write_files:
           -ec \
           'echo decrypting assets
            shopt -s nullglob
-           for encKey in /etc/kubernetes/{ssl,{{if .Experimental.ClusterTLSBootstrap.Enabled}}auth{{end}}}/*.enc; do
+           for encKey in /etc/kubernetes/{ssl,{{if .Experimental.TLSBootstrap.Enabled}}auth{{end}}}/*.enc; do
              echo decrypting $encKey
              f=$(mktemp $encKey.XXXXXXXX)
              /usr/bin/aws \
@@ -602,7 +602,7 @@ write_files:
              mv -f $f ${encKey%.enc}
            done;
 
-           {{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+           {{ if .Experimental.TLSBootstrap.Enabled }}
            echo injecting token into the kubelet bootstrap kubeconfig file
            bootstrap_token=$(cat /etc/kubernetes/auth/kubelet-bootstrap.token);
            sed -i -e "s#\$KUBELET_BOOTSTRAP_TOKEN#$bootstrap_token#g" /etc/kubernetes/worker-bootstrap-kubeconfig.yaml
@@ -741,7 +741,7 @@ write_files:
               hostPath:
                 path: /var/run/dbus
 
-{{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+{{ if .Experimental.TLSBootstrap.Enabled }}
   - path: /etc/kubernetes/worker-bootstrap-kubeconfig.yaml
     content: |
         apiVersion: v1
@@ -795,7 +795,7 @@ write_files:
         }
 {{ end }}
 
-{{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+{{ if .Experimental.TLSBootstrap.Enabled }}
   - path: /etc/kubernetes/auth/kubelet-bootstrap.token{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.AuthTokensConfig.KubeletBootstrapToken}}

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -169,9 +169,14 @@ coreos:
         --cluster_dns={{.DNSServiceIP}} \
         --cluster_domain=cluster.local \
         --cloud-provider=aws \
-        --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+        --cert-dir=/etc/kubernetes/ssl \
+        {{- if .Experimental.ClusterTLSBootstrap.Enabled }}
+        --experimental-bootstrap-kubeconfig=/etc/kubernetes/worker-bootstrap-kubeconfig.yaml \
+        {{- else }}
         --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
-        --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
+        --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
+        {{- end }}
+        --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
         Restart=always
         RestartSec=10
         [Install]
@@ -221,7 +226,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true
-        TimeoutStopSec=30s
+        TimeoutStopSec=60s
         ExecStop=/bin/sh -c '/usr/bin/rkt run \
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
@@ -374,24 +379,22 @@ coreos:
           aws autoscaling describe-auto-scaling-groups \
           --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
           --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)\""
-        ExecStart=/bin/sh -c "/usr/bin/curl \
-          --cert   /etc/kubernetes/ssl/worker.pem \
-          --key    /etc/kubernetes/ssl/worker-key.pem \
-          --cacert /etc/kubernetes/ssl/ca.pem  \
-          --request PATCH \
-          -H 'Content-Type: application/strategic-merge-patch+json' \
-          -d'{ \
-          \"metadata\": { \
-            \"labels\": { \
-              \"kube-aws.coreos.com/autoscalinggroup\": \"${AUTOSCALINGGROUP}\", \
-              \"kube-aws.coreos.com/launchconfiguration\": \"${LAUNCHCONFIGURATION}\" \
-            }, \
-            \"annotations\": { \
-              \"kube-aws.coreos.com/securitygroups\": \"${SECURITY_GROUPS}\" \
-            } \
-          } \
-          }\"' \
-          https://{{.ExternalDNSName}}:443/api/v1/nodes/$(hostname)"
+        ExecStart=/usr/bin/docker run --rm -t --net=host \
+          -v /etc/kubernetes:/etc/kubernetes \
+          -v /etc/resolv.conf:/etc/resolv.conf \
+          -e INSTANCE_ID=${INSTANCE_ID} \
+          -e SECURITY_GROUPS=${SECURITY_GROUPS} \
+          -e AUTOSCALINGGROUP=${AUTOSCALINGGROUP} \
+          -e LAUNCHCONFIGURATION=${LAUNCHCONFIGURATION} \
+          {{.HyperkubeImage.RepoWithTag}} /bin/bash \
+            -ec 'echo "placing labels and annotations with additional AWS parameters."; \
+             kctl="/kubectl --server=https://{{.ExternalDNSName}}:443 --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml"; \
+             kctl_label="$kctl label --overwrite nodes/$(hostname)"; \
+             kctl_annotate="$kctl annotate --overwrite nodes/$(hostname)"; \
+             $kctl_label kube-aws.coreos.com/autoscalinggroup=${AUTOSCALINGGROUP}; \
+             $kctl_label kube-aws.coreos.com/launchconfiguration=${LAUNCHCONFIGURATION}; \
+             $kctl_annotate kube-aws.coreos.com/securitygroups=${SECURITY_GROUPS}; \
+             echo "done."'
 {{end}}
 
 {{if .Experimental.EphemeralImageStorage.Enabled}}
@@ -549,6 +552,7 @@ write_files:
     encoding: gzip+base64
     content: {{.TLSConfig.EtcdClientKey}}
 
+{{ if not .Experimental.ClusterTLSBootstrap.Enabled }}
   - path: /etc/kubernetes/ssl/worker.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.TLSConfig.WorkerCert}}
@@ -556,6 +560,7 @@ write_files:
   - path: /etc/kubernetes/ssl/worker-key.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.TLSConfig.WorkerKey}}
+{{ end }}
 
   - path: /etc/kubernetes/ssl/ca.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
@@ -573,15 +578,19 @@ write_files:
       rkt run \
         --volume=ssl,kind=host,source=/etc/kubernetes/ssl,readOnly=false \
         --mount=volume=ssl,target=/etc/kubernetes/ssl \
+        {{- if .Experimental.ClusterTLSBootstrap.Enabled }}
+        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=false \
+        --mount=volume=kube,target=/etc/kubernetes \
+        {{- end }}
         --uuid-file-save=/var/run/coreos/decrypt-assets.uuid \
         --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
         --trust-keys-from-https \
         {{.AWSCliImage.Options}}{{.AWSCliImage.RktRepo}} --exec=/bin/bash -- \
           -ec \
-          'echo decrypting tls assets
+          'echo decrypting assets
            shopt -s nullglob
-           for encKey in /etc/kubernetes/ssl/*.pem.enc; do
+           for encKey in /etc/kubernetes/{ssl,{{if .Experimental.ClusterTLSBootstrap.Enabled}}auth{{end}}}/*.enc; do
              echo decrypting $encKey
              f=$(mktemp $encKey.XXXXXXXX)
              /usr/bin/aws \
@@ -592,9 +601,16 @@ write_files:
              | base64 -d > $f
              mv -f $f ${encKey%.enc}
            done;
+
+           {{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+           echo injecting token into the kubelet bootstrap kubeconfig file
+           bootstrap_token=$(cat /etc/kubernetes/auth/kubelet-bootstrap.token);
+           sed -i -e "s#\$KUBELET_BOOTSTRAP_TOKEN#$bootstrap_token#g" /etc/kubernetes/worker-bootstrap-kubeconfig.yaml
+           {{ end }}
            echo done.'
 
       rkt rm --uuid-file=/var/run/coreos/decrypt-assets.uuid || :
+
 {{ end }}
 
 {{if .SpotFleet.Enabled}}
@@ -707,30 +723,45 @@ write_files:
               privileged: true
             volumeMounts:
               - mountPath: /etc/ssl/certs
-                name: "ssl-certs"
-              - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
-                name: "kubeconfig"
-                readOnly: true
-              - mountPath: /etc/kubernetes/ssl
-                name: "etc-kube-ssl"
+                name: ssl-certs
+              - mountPath: /etc/kubernetes
+                name: kubeconfig
                 readOnly: true
               - mountPath: /var/run/dbus
                 name: dbus
                 readOnly: false
           volumes:
-            - name: "ssl-certs"
+            - name: ssl-certs
               hostPath:
-                path: "/usr/share/ca-certificates"
-            - name: "kubeconfig"
+                path: /usr/share/ca-certificates
+            - name: kubeconfig
               hostPath:
-                path: "/etc/kubernetes/worker-kubeconfig.yaml"
-            - name: "etc-kube-ssl"
+                path: /etc/kubernetes
+            - name: dbus
               hostPath:
-                path: "/etc/kubernetes/ssl"
-            - hostPath:
                 path: /var/run/dbus
-              name: dbus
 
+{{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+  - path: /etc/kubernetes/worker-bootstrap-kubeconfig.yaml
+    content: |
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: local
+          cluster:
+            certificate-authority: /etc/kubernetes/ssl/ca.pem
+            server: https://{{.ExternalDNSName}}:443
+        users:
+        - name: kubelet-bootstrap
+          user:
+            token: $KUBELET_BOOTSTRAP_TOKEN
+        contexts:
+        - context:
+            cluster: local
+            user: kubelet-bootstrap
+          name: kubelet-bootstrap-context
+        current-context: kubelet-bootstrap-context
+{{ else }}
   - path: /etc/kubernetes/worker-kubeconfig.yaml
     content: |
         apiVersion: v1
@@ -750,6 +781,7 @@ write_files:
             user: kubelet
           name: kubelet-context
         current-context: kubelet-context
+{{ end }}
 
 {{ if not .UseCalico }}
   - path: /etc/kubernetes/cni/net.d/10-flannel.conf
@@ -761,4 +793,10 @@ write_files:
                 "isDefaultGateway": true
             }
         }
+{{ end }}
+
+{{ if .Experimental.ClusterTLSBootstrap.Enabled }}
+  - path: /etc/kubernetes/auth/kubelet-bootstrap.token{{if .AssetsEncryptionEnabled}}.enc{{end}}
+    encoding: gzip+base64
+    content: {{.AuthTokensConfig.KubeletBootstrapToken}}
 {{ end }}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -821,7 +821,7 @@ worker:
 #     enable: true
 #   # If enabled, instructs the controller manager to automatically issue TLS certificates to worker nodes via certificate signing requests (csr) made to the API server using the bootstrap token.
 #   # If enabled, also consider enabling the rbac plugin to limit requests using the bootstrap token to only be able to make requests related to certificate provisioning.
-#   clusterTLSBootstrap:
+#   tlsBootstrap:
 #     enable: true
 #   # This option has not yet been tested with rkt as container runtime
 #   ephemeralImageStorage:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -819,6 +819,10 @@ worker:
 #   # Will provision controller nodes with IAM permissions to run cluster-autoscaler
 #   clusterAutoscalerSupport:
 #     enable: true
+#   # If enabled, instructs the controller manager to automatically issue TLS certificates to worker nodes via certificate signing requests (csr) made to the API server using the bootstrap token.
+#   # If enabled, also consider enabling the rbac plugin to limit requests using the bootstrap token to only be able to make requests related to certificate provisioning.
+#   clusterTLSBootstrap:
+#     enable: true
 #   # This option has not yet been tested with rkt as container runtime
 #   ephemeralImageStorage:
 #     enabled: true

--- a/core/controlplane/config/tls_config.go
+++ b/core/controlplane/config/tls_config.go
@@ -230,7 +230,7 @@ func ReadRawTLSAssets(dirname string) (*RawTLSAssetsOnDisk, error) {
 		name      string
 		cert, key *RawCredentialOnDisk
 	}{
-		{"ca", &r.CACert, nil},
+		{"ca", &r.CACert, &r.CAKey},
 		{"apiserver", &r.APIServerCert, &r.APIServerKey},
 		{"worker", &r.WorkerCert, &r.WorkerKey},
 		{"admin", &r.AdminCert, &r.AdminKey},
@@ -264,7 +264,7 @@ func ReadOrEncryptTLSAssets(dirname string, encryptor CachedEncryptor) (*Encrypt
 		name      string
 		cert, key *EncryptedCredentialOnDisk
 	}{
-		{"ca", &r.CACert, nil},
+		{"ca", &r.CACert, &r.CAKey},
 		{"apiserver", &r.APIServerCert, &r.APIServerKey},
 		{"worker", &r.WorkerCert, &r.WorkerKey},
 		{"admin", &r.AdminCert, &r.AdminKey},
@@ -403,6 +403,7 @@ func (r *EncryptedTLSAssetsOnDisk) Compact() (*CompactTLSAssets, error) {
 	}
 	compactAssets := CompactTLSAssets{
 		CACert:         compact(r.CACert),
+		CAKey:          compact(r.CAKey),
 		APIServerCert:  compact(r.APIServerCert),
 		APIServerKey:   compact(r.APIServerKey),
 		WorkerCert:     compact(r.WorkerCert),
@@ -448,12 +449,7 @@ func ReadOrCreateEncryptedTLSAssets(tlsAssetsDir string, kmsConfig KMSConfig) (*
 		bytesEncryptionService: encryptionSvc,
 	}
 
-	readOrEncryptedTLSAssets, err := ReadOrEncryptTLSAssets(tlsAssetsDir, encryptor)
-	if err != nil {
-		return nil, err
-	}
-
-	return readOrEncryptedTLSAssets, nil
+	return ReadOrEncryptTLSAssets(tlsAssetsDir, encryptor)
 }
 
 func ReadOrCreateCompactTLSAssets(tlsAssetsDir string, kmsConfig KMSConfig) (*CompactTLSAssets, error) {
@@ -470,7 +466,7 @@ func ReadOrCreateCompactTLSAssets(tlsAssetsDir string, kmsConfig KMSConfig) (*Co
 	return compactAssets, nil
 }
 
-func ReadOrCreateUnecryptedCompactTLSAssets(tlsAssetsDir string) (*CompactTLSAssets, error) {
+func ReadOrCreateUnencryptedCompactTLSAssets(tlsAssetsDir string) (*CompactTLSAssets, error) {
 	unencryptedAssets, err := ReadRawTLSAssets(tlsAssetsDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read/create TLS assets: %v", err)

--- a/core/controlplane/config/tls_config_test.go
+++ b/core/controlplane/config/tls_config_test.go
@@ -162,11 +162,6 @@ func TestReadOrCreateCompactTLSAssets(t *testing.T) {
 				}
 			}
 
-			if err := os.Remove(filepath.Join(dir, "ca-key.pem.enc")); err == nil {
-				t.Error("ca-key.pem.enc should not exist")
-				t.FailNow()
-			}
-
 			regenerated, err := ReadOrCreateCompactTLSAssets(dir, kmsConfig)
 
 			if err != nil {
@@ -231,16 +226,16 @@ func TestReadOrCreateCompactTLSAssets(t *testing.T) {
 	})
 }
 
-func TestReadOrCreateUnEcryptedCompactTLSAssets(t *testing.T) {
+func TestReadOrCreateUnEncryptedCompactTLSAssets(t *testing.T) {
 	helper.WithDummyCredentials(func(dir string) {
 		t.Run("CachedToPreventUnnecessaryNodeReplacementOnUnencrypted", func(t *testing.T) {
-			created, err := ReadOrCreateUnecryptedCompactTLSAssets(dir)
+			created, err := ReadOrCreateUnencryptedCompactTLSAssets(dir)
 
 			if err != nil {
 				t.Errorf("failed to read or update compact tls assets in %s : %v", dir, err)
 			}
 
-			read, err := ReadOrCreateUnecryptedCompactTLSAssets(dir)
+			read, err := ReadOrCreateUnencryptedCompactTLSAssets(dir)
 
 			if err != nil {
 				t.Errorf("failed to read or update compact tls assets in %s : %v", dir, err)

--- a/core/controlplane/config/token_config.go
+++ b/core/controlplane/config/token_config.go
@@ -89,7 +89,7 @@ func RandomBootstrapTokenRecord() (string, error) {
 }
 
 func (c *Cluster) CreateRawAuthTokens(dirname string) error {
-	createBootstrapToken := c.DeploymentSettings.Experimental.ClusterTLSBootstrap.Enabled
+	createBootstrapToken := c.DeploymentSettings.Experimental.TLSBootstrap.Enabled
 	return CreateRawAuthTokens(createBootstrapToken, dirname)
 }
 

--- a/core/controlplane/config/token_config.go
+++ b/core/controlplane/config/token_config.go
@@ -2,11 +2,14 @@ package config
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/csv"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -15,79 +18,156 @@ import (
 	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
 )
 
-// Contents of the CSV file holding auth tokens.
-// See https://kubernetes.io/docs/admin/authentication/#static-token-file
-type AuthTokens struct {
+// Taken from https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/#apiserver-configuration
+const (
+	kubeletBootstrapGroup     = "system:kubelet-bootstrap"
+	kubeletBootstrapUser      = "kubelet-bootstrap"
+	kubeletBootstrapUserId    = "10001"
+	kubeletBootstrapTokenBits = 256
+)
+
+type RawAuthTokensOnMemory struct {
+	// Contents of the CSV file holding auth tokens.
 	Contents []byte
 }
 
-// Contents of the CSV file holding auth tokens.
 type RawAuthTokensOnDisk struct {
+	// Contents of the CSV file holding auth tokens.
 	AuthTokens RawCredentialOnDisk
+
+	// Extracted from the auth tokens file
+	KubeletBootstrapToken []byte
 }
 
-// Encrypted contents of the CSV file holding auth tokens.
 type EncryptedAuthTokensOnDisk struct {
+	// Encrypted contents of the CSV file holding auth tokens.
 	AuthTokens EncryptedCredentialOnDisk
+
+	// Encrypted version of the Kubelet bootstrap token.
+	KubeletBootstrapToken []byte
 }
 
-// Encrypted -> gzip -> base64 encoded auth token file contents.
 type CompactAuthTokens struct {
+	// Encrypted -> gzip -> base64 encoded auth token file contents.
 	Contents string
+
+	// Encrypted -> gzip -> base64 encoded version of the Kubelet auth token.
+	KubeletBootstrapToken string
 }
 
-func NewAuthTokens() AuthTokens {
+func NewAuthTokens() RawAuthTokensOnMemory {
 	// Uses an empty file as the default auth token file
-	return AuthTokens{
+	return RawAuthTokensOnMemory{
 		Contents: make([]byte, 0),
 	}
 }
 
-func NewAuthTokensOnDisk(dir string) (*RawAuthTokensOnDisk, error) {
-	authToken := NewAuthTokens()
-	if err := authToken.WriteToDir(dir); err != nil {
-		return nil, fmt.Errorf("error creating auth token file: %v", err)
+func parseAuthTokensCSV(authTokens []byte) ([][]string, error) {
+	if len(authTokens) == 0 {
+		return make([][]string, 0), nil
 	}
-	return ReadRawAuthTokens(dir)
+
+	csvReader := csv.NewReader(bytes.NewReader(authTokens))
+	return csvReader.ReadAll()
 }
 
-func validateAuthTokens(authTokens []byte) error {
-	if len(authTokens) > 0 {
-		csvReader := csv.NewReader(bytes.NewReader(authTokens))
+func RandomKubeletBootstrapTokenString(n int) (string, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}
 
-		records, err := csvReader.ReadAll()
+func RandomBootstrapTokenRecord() (string, error) {
+	randomToken, err := RandomKubeletBootstrapTokenString(kubeletBootstrapTokenBits)
+	if err != nil {
+		return "", fmt.Errorf("cannot generate a random Kubelet bootstrap token: %v", err)
+	}
+	return fmt.Sprintf("%s,%s,%s,%s", randomToken, kubeletBootstrapUser, kubeletBootstrapUserId, kubeletBootstrapGroup), nil
+}
+
+func (c *Cluster) CreateRawAuthTokens(dirname string) error {
+	createBootstrapToken := c.DeploymentSettings.Experimental.ClusterTLSBootstrap.Enabled
+	return CreateRawAuthTokens(createBootstrapToken, dirname)
+}
+
+func CreateRawAuthTokens(addBootstrapToken bool, dirname string) error {
+	tokens := RawAuthTokensOnMemory{}
+	if addBootstrapToken {
+		bootstrapToken, err := RandomBootstrapTokenRecord()
 		if err != nil {
 			return err
 		}
+		tokens.Contents = []byte(bootstrapToken)
+	}
+	return tokens.WriteToDir(dirname)
+}
 
-		for _, line := range records {
-			columns := len(line)
-			if columns < 3 {
-				return fmt.Errorf("auth token record must have at least 3 columns, but has %d: '%v'", columns, line)
-			}
-		}
+func KubeletBootstrapTokenFromRecord(csvRecord []string) (string, error) {
+	if csvRecord == nil || len(csvRecord) < 4 {
+		return "", nil
 	}
 
-	return nil
+	pattern := fmt.Sprintf(`^(?:\s*\S+\s*,\s*|\s+)?(?:%s)(?:\s*|\s*,\s*\S+\s*)+$`, kubeletBootstrapGroup)
+	match, err := regexp.MatchString(pattern, csvRecord[3])
+	if err != nil {
+		return "", fmt.Errorf("error trying to identify the Kubelet bootstrap token")
+	}
+
+	if match {
+		return csvRecord[0], nil
+	}
+
+	return "", nil
 }
 
 func ReadRawAuthTokens(dirname string) (*RawAuthTokensOnDisk, error) {
 	authTokensPath := filepath.Join(dirname, "tokens.csv")
+	kubeletBootstrapToken := make([]byte, 0)
+
+	if _, err := os.Stat(authTokensPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("auth tokens file not found: %s\n\nTo fix this, please run the following command to create it: kube-aws render token-file", authTokensPath)
+	}
 
 	data, err := RawCredentialFileFromPath(authTokensPath)
 	if err != nil {
 		return nil, err
 	}
 
-	authTokens := data.content
-	if err = validateAuthTokens(authTokens); err != nil {
-		return nil, err
+	records, err := parseAuthTokensCSV(data.content)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse auth token file: %v", err)
 	}
 
-	return &RawAuthTokensOnDisk{AuthTokens: *data}, nil
+	// Checks whether the CSV file has the expected layout
+	for _, line := range records {
+		columns := len(line)
+		if columns < 3 {
+			return nil, fmt.Errorf("auth token record must have at least 3 columns, but has %d: '%v'", columns, line)
+		}
+
+		// Keeps the first token assigned for the Kubelet bootstrap group
+		if len(kubeletBootstrapToken) == 0 && columns > 3 {
+			kubeletBootstrapTokenFromRecord, err := KubeletBootstrapTokenFromRecord(line)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(kubeletBootstrapTokenFromRecord) > 0 {
+				kubeletBootstrapToken = []byte(kubeletBootstrapTokenFromRecord)
+			}
+		}
+	}
+
+	return &RawAuthTokensOnDisk{
+		AuthTokens:            *data,
+		KubeletBootstrapToken: kubeletBootstrapToken,
+	}, nil
 }
 
-func (r AuthTokens) WriteToDir(dirname string) error {
+func (r RawAuthTokensOnMemory) WriteToDir(dirname string) error {
 	authTokensPath := filepath.Join(dirname, "tokens.csv")
 
 	if err := ioutil.WriteFile(authTokensPath, r.Contents, 0600); err != nil {
@@ -116,7 +196,8 @@ func (r *RawAuthTokensOnDisk) Compact() (*CompactAuthTokens, error) {
 	}
 
 	compactAuthTokens := &CompactAuthTokens{
-		Contents: compact(r.AuthTokens.content),
+		Contents:              compact(r.AuthTokens.content),
+		KubeletBootstrapToken: compact(r.KubeletBootstrapToken),
 	}
 	if err != nil {
 		return nil, err
@@ -143,7 +224,8 @@ func (r *EncryptedAuthTokensOnDisk) Compact() (*CompactAuthTokens, error) {
 	}
 
 	compactAuthTokens := &CompactAuthTokens{
-		Contents: compact(r.AuthTokens.content),
+		Contents:              compact(r.AuthTokens.content),
+		KubeletBootstrapToken: compact(r.KubeletBootstrapToken),
 	}
 	if err != nil {
 		return nil, err
@@ -154,16 +236,13 @@ func (r *EncryptedAuthTokensOnDisk) Compact() (*CompactAuthTokens, error) {
 func ReadOrEncryptAuthTokens(dirname string, encryptor CachedEncryptor) (*EncryptedAuthTokensOnDisk, error) {
 	authTokenPath := filepath.Join(dirname, "tokens.csv")
 
-	// Auto-creates the auth token file, useful for those coming from previous versions of kube-aws
-	if _, err := os.Stat(authTokenPath); os.IsNotExist(err) {
-		file, err := os.OpenFile(authTokenPath, os.O_RDONLY|os.O_CREATE, 0600)
-		if err != nil {
-			return nil, err
-		}
-		file.Close()
+	// Extracts and encrypts the Kubelet bootstrap token
+	authTokens, err := ReadRawAuthTokens(dirname)
+	if err != nil {
+		return nil, err
 	}
-
-	if _, err := ReadRawAuthTokens(dirname); err != nil {
+	encryptedToken, err := encryptor.EncryptedBytes(authTokens.KubeletBootstrapToken)
+	if err != nil {
 		return nil, err
 	}
 
@@ -174,30 +253,33 @@ func ReadOrEncryptAuthTokens(dirname string, encryptor CachedEncryptor) (*Encryp
 	if err := data.Persist(); err != nil {
 		return nil, err
 	}
+
 	return &EncryptedAuthTokensOnDisk{
-		AuthTokens: *data,
+		AuthTokens:            *data,
+		KubeletBootstrapToken: encryptedToken,
 	}, nil
 }
 
 func ReadOrCreateEncryptedAuthTokens(dirname string, kmsConfig KMSConfig) (*EncryptedAuthTokensOnDisk, error) {
 	var kmsSvc EncryptService
 
-	awsConfig := aws.NewConfig().
-		WithRegion(kmsConfig.Region.String()).
-		WithCredentialsChainVerboseErrors(true)
-
 	// TODO Cleaner way to inject this dependency
 	if kmsConfig.EncryptService == nil {
+		awsConfig := aws.NewConfig().
+			WithRegion(kmsConfig.Region.String()).
+			WithCredentialsChainVerboseErrors(true)
 		kmsSvc = kms.New(session.New(awsConfig))
 	} else {
 		kmsSvc = kmsConfig.EncryptService
 	}
 
+	encryptionSvc := bytesEncryptionService{
+		kmsKeyARN: kmsConfig.KMSKeyARN,
+		kmsSvc:    kmsSvc,
+	}
+
 	encryptor := CachedEncryptor{
-		bytesEncryptionService: bytesEncryptionService{
-			kmsKeyARN: kmsConfig.KMSKeyARN,
-			kmsSvc:    kmsSvc,
-		},
+		bytesEncryptionService: encryptionSvc,
 	}
 
 	return ReadOrEncryptAuthTokens(dirname, encryptor)
@@ -217,7 +299,7 @@ func ReadOrCreateCompactAuthTokens(dirname string, kmsConfig KMSConfig) (*Compac
 	return compactTokens, nil
 }
 
-func ReadOrCreateUnecryptedCompactAuthTokens(dirname string) (*CompactAuthTokens, error) {
+func ReadOrCreateUnencryptedCompactAuthTokens(dirname string) (*CompactAuthTokens, error) {
 	unencryptedTokens, err := ReadRawAuthTokens(dirname)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read/create auth token assets: %v", err)

--- a/core/controlplane/config/user_data_config_test.go
+++ b/core/controlplane/config/user_data_config_test.go
@@ -64,7 +64,9 @@ func TestCloudConfigTemplating(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed generating tls ca: %v", err)
 	}
-	opts := CredentialsOptions{}
+	opts := CredentialsOptions{
+		GenerateCA: true,
+	}
 
 	var compactAssets *CompactTLSAssets
 
@@ -100,10 +102,8 @@ func TestCloudConfigTemplating(t *testing.T) {
 
 	// Auth tokens
 	helper.WithTempDir(func(dir string) {
-		_, err := NewAuthTokensOnDisk(dir)
-		if err != nil {
-			t.Fatalf("failed to write auth tokens on disk: %v", err)
-			t.FailNow()
+		if err := CreateRawAuthTokens(false, dir); err != nil {
+			t.Fatalf("failed to create auth token file: %v", err)
 		}
 
 		encryptedAuthTokens, err := ReadOrEncryptAuthTokens(dir, cachedEncryptor)

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -89,7 +89,7 @@ func (c ProvidedConfig) StackConfig(opts StackTemplateOptions) (*StackConfig, er
 		}
 	}
 
-	if c.DeploymentSettings.Experimental.ClusterTLSBootstrap.Enabled {
+	if c.DeploymentSettings.Experimental.TLSBootstrap.Enabled {
 		if stackConfig.ComputedConfig.AssetsEncryptionEnabled() {
 			compactAuthTokens, _ := cfg.ReadOrCreateCompactAuthTokens(opts.AssetsDir, cfg.KMSConfig{
 				Region:         stackConfig.ComputedConfig.Region,
@@ -164,7 +164,7 @@ func (c *ProvidedConfig) Load(main *cfg.Config) error {
 	c.KubeClusterSettings = main.KubeClusterSettings
 
 	// Inherit cluster TLS bootstrap config from control plane stack
-	c.Experimental.ClusterTLSBootstrap = main.DeploymentSettings.Experimental.ClusterTLSBootstrap
+	c.Experimental.TLSBootstrap = main.DeploymentSettings.Experimental.TLSBootstrap
 
 	// Validate whole the inputs including inherited ones
 	if err := c.valid(); err != nil {

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -24,9 +24,12 @@ type Ref struct {
 
 type ComputedConfig struct {
 	ProvidedConfig
+
 	// Fields computed from Cluster
-	AMI       string
-	TLSConfig *cfg.CompactTLSAssets
+	AMI string
+
+	TLSConfig        *cfg.CompactTLSAssets
+	AuthTokensConfig *cfg.CompactAuthTokens
 }
 
 type ProvidedConfig struct {
@@ -37,7 +40,7 @@ type ProvidedConfig struct {
 	cfg.Experimental        `yaml:",inline"`
 	Private                 bool   `yaml:"private,omitempty"`
 	NodePoolName            string `yaml:"name,omitempty"`
-	providedEncryptService  cfg.EncryptService
+	ProvidedEncryptService  cfg.EncryptService
 }
 
 type DeploymentSettings struct {
@@ -77,14 +80,29 @@ func (c ProvidedConfig) StackConfig(opts StackTemplateOptions) (*StackConfig, er
 			compactAssets, _ := cfg.ReadOrCreateCompactTLSAssets(opts.AssetsDir, cfg.KMSConfig{
 				Region:         stackConfig.ComputedConfig.Region,
 				KMSKeyARN:      c.KMSKeyARN,
-				EncryptService: c.providedEncryptService,
+				EncryptService: c.ProvidedEncryptService,
 			})
-
 			stackConfig.ComputedConfig.TLSConfig = compactAssets
 		} else {
-			rawAssets, _ := cfg.ReadOrCreateUnecryptedCompactTLSAssets(opts.AssetsDir)
+			rawAssets, _ := cfg.ReadOrCreateUnencryptedCompactTLSAssets(opts.AssetsDir)
 			stackConfig.ComputedConfig.TLSConfig = rawAssets
 		}
+	}
+
+	if c.DeploymentSettings.Experimental.ClusterTLSBootstrap.Enabled {
+		if stackConfig.ComputedConfig.AssetsEncryptionEnabled() {
+			compactAuthTokens, _ := cfg.ReadOrCreateCompactAuthTokens(opts.AssetsDir, cfg.KMSConfig{
+				Region:         stackConfig.ComputedConfig.Region,
+				KMSKeyARN:      c.KMSKeyARN,
+				EncryptService: c.ProvidedEncryptService,
+			})
+			stackConfig.ComputedConfig.AuthTokensConfig = compactAuthTokens
+		} else {
+			rawAuthTokens, _ := cfg.ReadOrCreateUnencryptedCompactAuthTokens(opts.AssetsDir)
+			stackConfig.ComputedConfig.AuthTokensConfig = rawAuthTokens
+		}
+	} else {
+		stackConfig.ComputedConfig.AuthTokensConfig = &cfg.CompactAuthTokens{}
 	}
 
 	if stackConfig.UserDataWorker, err = userdatatemplate.GetString(opts.WorkerTmplFile, stackConfig.ComputedConfig); err != nil {
@@ -145,6 +163,9 @@ func (c *ProvidedConfig) Load(main *cfg.Config) error {
 	// Inherit parameters from the control plane stack
 	c.KubeClusterSettings = main.KubeClusterSettings
 
+	// Inherit cluster TLS bootstrap config from control plane stack
+	c.Experimental.ClusterTLSBootstrap = main.DeploymentSettings.Experimental.ClusterTLSBootstrap
+
 	// Validate whole the inputs including inherited ones
 	if err := c.valid(); err != nil {
 		return err
@@ -195,7 +216,7 @@ func ClusterFromBytesWithEncryptService(data []byte, main *cfg.Config, encryptSe
 	if err != nil {
 		return nil, err
 	}
-	cluster.providedEncryptService = encryptService
+	cluster.ProvidedEncryptService = encryptService
 	return cluster, nil
 }
 

--- a/core/nodepool/config/deployment.go
+++ b/core/nodepool/config/deployment.go
@@ -99,7 +99,7 @@ func (c DeploymentSettings) WithDefaultsFrom(main cfg.DeploymentSettings) Deploy
 	c.FlannelImage.MergeIfEmpty(main.FlannelImage)
 
 	// Inherit main TLS bootstrap config
-	c.Experimental.ClusterTLSBootstrap = main.Experimental.ClusterTLSBootstrap
+	c.Experimental.TLSBootstrap = main.Experimental.TLSBootstrap
 
 	if len(c.SSHAuthorizedKeys) == 0 {
 		c.SSHAuthorizedKeys = main.SSHAuthorizedKeys

--- a/core/nodepool/config/deployment.go
+++ b/core/nodepool/config/deployment.go
@@ -98,6 +98,9 @@ func (c DeploymentSettings) WithDefaultsFrom(main cfg.DeploymentSettings) Deploy
 	c.PauseImage.MergeIfEmpty(main.PauseImage)
 	c.FlannelImage.MergeIfEmpty(main.FlannelImage)
 
+	// Inherit main TLS bootstrap config
+	c.Experimental.ClusterTLSBootstrap = main.Experimental.ClusterTLSBootstrap
+
 	if len(c.SSHAuthorizedKeys) == 0 {
 		c.SSHAuthorizedKeys = main.SSHAuthorizedKeys
 	}

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -54,12 +54,12 @@ func ConfigFromBytes(data []byte) (*Config, error) {
 	}
 	c.HyperkubeImage.Tag = c.K8sVer
 
-	cpCluser := &c.Cluster
-	if err := cpCluser.Load(); err != nil {
+	cpCluster := &c.Cluster
+	if err := cpCluster.Load(); err != nil {
 		return nil, err
 	}
 
-	cpConfig, err := cpCluser.Config()
+	cpConfig, err := cpCluster.Config()
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func ConfigFromBytes(data []byte) (*Config, error) {
 		}
 	}
 
-	cfg := &Config{Cluster: cpCluser, NodePools: nodePools}
+	cfg := &Config{Cluster: cpCluster, NodePools: nodePools}
 
 	if err := failFastWhenUnknownKeysFound([]unknownKeyValidation{
 		{c, ""},
@@ -112,6 +112,12 @@ func ConfigFromBytesWithEncryptService(data []byte, encryptService controlplane.
 		return nil, err
 	}
 	c.ProvidedEncryptService = encryptService
+
+	// Uses the same encrypt service for node pools for consistency
+	for _, p := range c.NodePools {
+		p.ProvidedEncryptService = encryptService
+	}
+
 	return c, nil
 }
 

--- a/core/root/render/credentials.go
+++ b/core/root/render/credentials.go
@@ -12,7 +12,8 @@ import (
 )
 
 type CredentialsRenderer interface {
-	RenderFiles(config.CredentialsOptions) error
+	RenderTLSCerts(config.CredentialsOptions) error
+	RenderAuthTokenFile() error
 }
 
 type credentialsRendererImpl struct {
@@ -25,9 +26,9 @@ func NewCredentialsRenderer(c *config.Cluster) CredentialsRenderer {
 	}
 }
 
-func (r credentialsRendererImpl) RenderFiles(renderCredentialsOpts config.CredentialsOptions) error {
+func (r credentialsRendererImpl) RenderTLSCerts(renderCredentialsOpts config.CredentialsOptions) error {
 	cluster := r.c
-	fmt.Printf("Generating TLS credentials...\n")
+	fmt.Println("Generating TLS credentials...")
 	var caKey *rsa.PrivateKey
 	var caCert *x509.Certificate
 	if renderCredentialsOpts.GenerateCA {
@@ -60,17 +61,22 @@ func (r credentialsRendererImpl) RenderFiles(renderCredentialsOpts config.Creden
 		return err
 	}
 
-	fmt.Printf("-> Generating new TLS assets\n")
+	fmt.Println("-> Generating new TLS assets")
 	_, err := cluster.NewTLSAssetsOnDisk(dir, renderCredentialsOpts, caKey, caCert)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("-> Generating auth token file\n")
-	_, err = config.NewAuthTokensOnDisk(dir)
-	if err != nil {
+	return nil
+}
+
+func (r credentialsRendererImpl) RenderAuthTokenFile() error {
+	cluster := r.c
+	dir := defaults.AssetsDir
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
 
-	return nil
+	fmt.Println("Generating auth token file...")
+	return cluster.CreateRawAuthTokens(dir)
 }

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -44,11 +44,11 @@ func WithDummyCredentials(fn func(dir string)) {
 		defer os.Remove(keyFile)
 	}
 
-	tokensFile := fmt.Sprintf("%s/tokens.csv", dir)
-	if err := ioutil.WriteFile(tokensFile, []byte(""), 0664); err != nil {
+	authTokenFile := fmt.Sprintf("%s/tokens.csv", dir)
+	if err := ioutil.WriteFile(authTokenFile, []byte(""), 0644); err != nil {
 		panic(err)
 	}
-	defer os.Remove(tokensFile)
+	defer os.Remove(authTokenFile)
 
 	fn(dir)
 }

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -97,7 +97,7 @@ func TestMainClusterConfig(t *testing.T) {
 			ClusterAutoscalerSupport: controlplane_config.ClusterAutoscalerSupport{
 				Enabled: false,
 			},
-			ClusterTLSBootstrap: controlplane_config.ClusterTLSBootstrap{
+			TLSBootstrap: controlplane_config.TLSBootstrap{
 				Enabled: false,
 			},
 			EphemeralImageStorage: controlplane_config.EphemeralImageStorage{
@@ -898,7 +898,7 @@ experimental:
     enabled: true
   clusterAutoscalerSupport:
     enabled: true
-  clusterTLSBootstrap:
+  tlsBootstrap:
     enabled: true
   ephemeralImageStorage:
     enabled: true
@@ -965,7 +965,7 @@ worker:
 						ClusterAutoscalerSupport: controlplane_config.ClusterAutoscalerSupport{
 							Enabled: true,
 						},
-						ClusterTLSBootstrap: controlplane_config.ClusterTLSBootstrap{
+						TLSBootstrap: controlplane_config.TLSBootstrap{
 							Enabled: true,
 						},
 						EphemeralImageStorage: controlplane_config.EphemeralImageStorage{
@@ -1039,7 +1039,7 @@ worker:
       enabled: true
     clusterAutoscalerSupport:
       enabled: true
-    clusterTLSBootstrap:
+    tlsBootstrap:
       enabled: true # Must be ignored, value is synced with the one from control plane
     ephemeralImageStorage:
       enabled: true
@@ -1083,7 +1083,7 @@ worker:
 						ClusterAutoscalerSupport: controlplane_config.ClusterAutoscalerSupport{
 							Enabled: true,
 						},
-						ClusterTLSBootstrap: controlplane_config.ClusterTLSBootstrap{
+						TLSBootstrap: controlplane_config.TLSBootstrap{
 							Enabled: false,
 						},
 						EphemeralImageStorage: controlplane_config.EphemeralImageStorage{
@@ -2576,7 +2576,7 @@ etcdDataVolumeIOPS: 104
 				stackTemplateOptions.ControlPlaneStackTemplateTmplFile = "../../core/controlplane/config/templates/stack-template.json"
 
 				// Creates auth token file with bootstrap token if this setting is enabled
-				if providedConfig.Experimental.ClusterTLSBootstrap.Enabled {
+				if providedConfig.Experimental.TLSBootstrap.Enabled {
 					tokensFile := fmt.Sprintf("%s/tokens.csv", dummyAssetsDir)
 					if err := ioutil.WriteFile(tokensFile, []byte("dummytoken,kubelet-bootstrap,10001,system:kubelet-bootstrap"), 0664); err != nil {
 						panic(err)

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -2,16 +2,18 @@ package integration
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
 	"github.com/kubernetes-incubator/kube-aws/cfnstack"
 	controlplane_config "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	"github.com/kubernetes-incubator/kube-aws/core/root"
 	"github.com/kubernetes-incubator/kube-aws/core/root/config"
 	"github.com/kubernetes-incubator/kube-aws/model"
 	"github.com/kubernetes-incubator/kube-aws/test/helper"
-	"os"
-	"reflect"
-	"strings"
-	"testing"
 )
 
 type ConfigTester func(c *config.Config, t *testing.T)
@@ -93,6 +95,9 @@ func TestMainClusterConfig(t *testing.T) {
 				Enabled: false,
 			},
 			ClusterAutoscalerSupport: controlplane_config.ClusterAutoscalerSupport{
+				Enabled: false,
+			},
+			ClusterTLSBootstrap: controlplane_config.ClusterTLSBootstrap{
 				Enabled: false,
 			},
 			EphemeralImageStorage: controlplane_config.EphemeralImageStorage{
@@ -893,6 +898,8 @@ experimental:
     enabled: true
   clusterAutoscalerSupport:
     enabled: true
+  clusterTLSBootstrap:
+    enabled: true
   ephemeralImageStorage:
     enabled: true
   kube2IamSupport:
@@ -956,6 +963,9 @@ worker:
 							Enabled: true,
 						},
 						ClusterAutoscalerSupport: controlplane_config.ClusterAutoscalerSupport{
+							Enabled: true,
+						},
+						ClusterTLSBootstrap: controlplane_config.ClusterTLSBootstrap{
 							Enabled: true,
 						},
 						EphemeralImageStorage: controlplane_config.EphemeralImageStorage{
@@ -1029,6 +1039,8 @@ worker:
       enabled: true
     clusterAutoscalerSupport:
       enabled: true
+    clusterTLSBootstrap:
+      enabled: true # Must be ignored, value is synced with the one from control plane
     ephemeralImageStorage:
       enabled: true
     kube2IamSupport:
@@ -1070,6 +1082,9 @@ worker:
 						},
 						ClusterAutoscalerSupport: controlplane_config.ClusterAutoscalerSupport{
 							Enabled: true,
+						},
+						ClusterTLSBootstrap: controlplane_config.ClusterTLSBootstrap{
+							Enabled: false,
 						},
 						EphemeralImageStorage: controlplane_config.EphemeralImageStorage{
 							Enabled:    true,
@@ -2559,6 +2574,14 @@ etcdDataVolumeIOPS: 104
 				stackTemplateOptions.RootStackTemplateTmplFile = "../../core/root/config/templates/stack-template.json"
 				stackTemplateOptions.NodePoolStackTemplateTmplFile = "../../core/nodepool/config/templates/stack-template.json"
 				stackTemplateOptions.ControlPlaneStackTemplateTmplFile = "../../core/controlplane/config/templates/stack-template.json"
+
+				// Creates auth token file with bootstrap token if this setting is enabled
+				if providedConfig.Experimental.ClusterTLSBootstrap.Enabled {
+					tokensFile := fmt.Sprintf("%s/tokens.csv", dummyAssetsDir)
+					if err := ioutil.WriteFile(tokensFile, []byte("dummytoken,kubelet-bootstrap,10001,system:kubelet-bootstrap"), 0664); err != nil {
+						panic(err)
+					}
+				}
 
 				cluster, err := root.ClusterFromConfig(providedConfig, stackTemplateOptions, false)
 				if err != nil {


### PR DESCRIPTION
This PR introduces an experimental feature for provisioning TLS certificates for worker nodes via the alpha [certificate signing requests](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/) workflow.

If RBAC is enabled in `cluster.yaml`, I also made sure to set up the appropriate cluster role bindings so that the token used for sending the certificate signing requests can only make requests related to certificate provisioning, as instructed by the official documentation.

Checklist:

- [x] Add a `kube-aws render token-file` that creates a token auth file with a cluster TLS bootstrap (if the feature is turned on in `cluster.yaml`, or an empty file otherwise)
- [x] Check whether the auth token file has a proper bootstrap token when the TLS bootstrap feature is turned on; if not, return a self-explaining message so the user knows what to do in order to fix the problem
- [x] Read the bootstrap token from the auth token file and generate an encrypted version of it
- [x] Send the encrypted bootstrap token in worker userdata
- [x] Replace the decrypted token in the kubeconfig used for the TLS bootstrapping workflow
- [x] Fix / add more tests wherever possible
- [x] Manual tests
  - [x] Create clusters with TLS bootstrapping enabled and disabled
  - [x] Make sure it plays well with other experimental features (i.e. self-hosted Calico, AWS node labels, node draining)
  - [x] Try to add worker nodes (and stop/start the kubelet on an existing node) to see if they can join the cluster without the need to manually approve every new certificate signing request
  - [x] Test token rollout methods (**Edit:** `kube-aws update` works as expected, since the generated certificates remain valid even though the token used to request it has changed)

Closes #406.