### PR TITLE
AWS CLI region default

### DIFF
--- a/e2e/run
+++ b/e2e/run
@@ -27,6 +27,8 @@ if [ "${KUBE_AWS_REGION}" == "" ]; then
   echo KUBE_AWS_REGION is not set. Run this command like $USAGE_EXAMPLE 1>&2
   exit 1
 fi
+# set the AWS CLI default region to the region we are deploying to, otherwise a mismatch with the user env will cause all `aws` commands to fail
+export AWS_DEFAULT_REGION=${KUBE_AWS_REGION}
 
 if [ "${KUBE_AWS_AVAILABILITY_ZONE}" == "" ]; then
   echo KUBE_AWS_REGION is not set. Run this command like $USAGE_EXAMPLE 1>&2


### PR DESCRIPTION
Set to same as kube-aws region

Otherwise if there we are deploying an e2e test cluster to a region different to the user's environment setup we get this:

```
+++ aws cloudformation --output json describe-stacks --stack-name kubeawstest1
+++ jq -r '.Stacks[].Outputs[] | select (.OutputKey == "ControlPlaneStackName").OutputValue'

An error occurred (ValidationError) when calling the DescribeStacks operation: Stack with id kubeawstest1 does not exist
++ aws cloudformation --output json describe-stack-resources --stack-name
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument --stack-name: expected one argument
+ group_id=
+ aws ec2 authorize-security-group-ingress --group-id --protocol tcp --port 4194 --source-group
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument --group-id: expected one argument
+ echo 'skipping authorization for 4194'
skipping authorization for 4194
+ aws ec2 authorize-security-group-ingress --group-id --protocol tcp --port 10250 --source-group
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument --group-id: expected one argument
```