### PR TITLE
New settings: nodeMonitorGracePeriod, disableSecurityGroupIngress for controller-manager, nodeStatusUpdateFrequency for worker kubelet

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -13,9 +13,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"regexp"
-	"sort"
-
 	"github.com/coreos/go-semver/semver"
 	"github.com/kubernetes-incubator/kube-aws/cfnresource"
 	"github.com/kubernetes-incubator/kube-aws/coreos/amiregistry"
@@ -662,7 +659,6 @@ type Experimental struct {
 	Plugins                     Plugins                  `yaml:"plugins"`
 	DisableSecurityGroupIngress bool                     `yaml:"disableSecurityGroupIngress"`
 	NodeMonitorGracePeriod      string                   `yaml:"nodeMonitorGracePeriod"`
-	NodeStatusUpdateFrequency   string                   `yaml:"nodeStatusUpdateFrequency"`
 	Taints                      []Taint                  `yaml:"taints"`
 	model.UnknownKeys           `yaml:",inline"`
 }

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -662,6 +662,7 @@ type Experimental struct {
 	Plugins                     Plugins                  `yaml:"plugins"`
 	DisableSecurityGroupIngress bool                     `yaml:"disableSecurityGroupIngress"`
 	NodeMonitorGracePeriod      string                   `yaml:"nodeMonitorGracePeriod"`
+	NodeStatusUpdateFrequency   string                   `yaml:"nodeStatusUpdateFrequency"`
 	Taints                      []Taint                  `yaml:"taints"`
 	model.UnknownKeys           `yaml:",inline"`
 }

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -13,6 +13,9 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"regexp"
+	"sort"
+
 	"github.com/coreos/go-semver/semver"
 	"github.com/kubernetes-incubator/kube-aws/cfnresource"
 	"github.com/kubernetes-incubator/kube-aws/coreos/amiregistry"
@@ -643,22 +646,24 @@ type Cluster struct {
 }
 
 type Experimental struct {
-	Admission                Admission                `yaml:"admission"`
-	AuditLog                 AuditLog                 `yaml:"auditLog"`
-	Authentication           Authentication           `yaml:"authentication"`
-	AwsEnvironment           AwsEnvironment           `yaml:"awsEnvironment"`
-	AwsNodeLabels            AwsNodeLabels            `yaml:"awsNodeLabels"`
-	ClusterAutoscalerSupport ClusterAutoscalerSupport `yaml:"clusterAutoscalerSupport"`
-	TLSBootstrap             TLSBootstrap             `yaml:"tlsBootstrap"`
-	EphemeralImageStorage    EphemeralImageStorage    `yaml:"ephemeralImageStorage"`
-	Kube2IamSupport          Kube2IamSupport          `yaml:"kube2IamSupport,omitempty"`
-	LoadBalancer             LoadBalancer             `yaml:"loadBalancer"`
-	TargetGroup              TargetGroup              `yaml:"targetGroup"`
-	NodeDrainer              NodeDrainer              `yaml:"nodeDrainer"`
-	NodeLabels               NodeLabels               `yaml:"nodeLabels"`
-	Plugins                  Plugins                  `yaml:"plugins"`
-	Taints                   []Taint                  `yaml:"taints"`
-	model.UnknownKeys        `yaml:",inline"`
+	Admission                   Admission                `yaml:"admission"`
+	AuditLog                    AuditLog                 `yaml:"auditLog"`
+	Authentication              Authentication           `yaml:"authentication"`
+	AwsEnvironment              AwsEnvironment           `yaml:"awsEnvironment"`
+	AwsNodeLabels               AwsNodeLabels            `yaml:"awsNodeLabels"`
+	ClusterAutoscalerSupport    ClusterAutoscalerSupport `yaml:"clusterAutoscalerSupport"`
+	TLSBootstrap                TLSBootstrap             `yaml:"tlsBootstrap"`
+	EphemeralImageStorage       EphemeralImageStorage    `yaml:"ephemeralImageStorage"`
+	Kube2IamSupport             Kube2IamSupport          `yaml:"kube2IamSupport,omitempty"`
+	LoadBalancer                LoadBalancer             `yaml:"loadBalancer"`
+	TargetGroup                 TargetGroup              `yaml:"targetGroup"`
+	NodeDrainer                 NodeDrainer              `yaml:"nodeDrainer"`
+	NodeLabels                  NodeLabels               `yaml:"nodeLabels"`
+	Plugins                     Plugins                  `yaml:"plugins"`
+	DisableSecurityGroupIngress bool                     `yaml:"disableSecurityGroupIngress"`
+	NodeMonitorGracePeriod      string                   `yaml:"nodeMonitorGracePeriod"`
+	Taints                      []Taint                  `yaml:"taints"`
+	model.UnknownKeys           `yaml:",inline"`
 }
 
 type Admission struct {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -383,6 +383,14 @@ ssh_authorized_keys:
         WantedBy=install-kube-system.service
 {{end}}
 write_files:
+{{if .Experimental.DisableSecurityGroupIngress}}
+  - path: /etc/kubernetes/additional-configs/cloud.config
+    owner: root:root
+    permissions: 0644
+    content: |
+      [global]
+      DisableSecurityGroupIngress = true
+{{end}}
 {{if .Experimental.AwsEnvironment.Enabled}}
   - path: /opt/bin/set-aws-environment
     owner: root:root
@@ -1153,6 +1161,12 @@ write_files:
           {{ end }}
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
+          {{if .Experimental.NodeMonitorGracePeriod}}
+          - --node-monitor-grace-period {{ .Experimental.NodeMonitorGracePeriod }}
+          {{end}}
+          {{if .Experimental.DisableSecurityGroupIngress}}
+          - --cloud-config=/etc/kubernetes/additional-configs/cloud.config
+          {{end}}
           resources:
             requests:
               cpu: 200m
@@ -1164,6 +1178,11 @@ write_files:
             initialDelaySeconds: 15
             timeoutSeconds: 15
           volumeMounts:
+          {{if .Experimental.DisableSecurityGroupIngress}}
+          - mountPath: /etc/kubernetes/additional-configs
+            name: additional-configs
+            readOnly: true
+          {{end}}
           - mountPath: /etc/kubernetes/ssl
             name: ssl-certs-kubernetes
             readOnly: true
@@ -1172,6 +1191,11 @@ write_files:
             readOnly: true
         hostNetwork: true
         volumes:
+        {{if .Experimental.DisableSecurityGroupIngress}}
+        - hostPath: 
+            path: /etc/kubernetes/additional-configs
+          name: additional-configs
+        {{end}}
         - hostPath:
             path: /etc/kubernetes/ssl
           name: ssl-certs-kubernetes

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1162,7 +1162,7 @@ write_files:
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
           {{if .Experimental.NodeMonitorGracePeriod}}
-          - --node-monitor-grace-period {{ .Experimental.NodeMonitorGracePeriod }}
+          - --node-monitor-grace-period={{ .Experimental.NodeMonitorGracePeriod }}
           {{end}}
           {{if .Experimental.DisableSecurityGroupIngress}}
           - --cloud-config=/etc/kubernetes/additional-configs/cloud.config

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -165,7 +165,7 @@ coreos:
         {{end}}--register-node=true \
         {{if .Experimental.Taints}}--register-schedulable=false \
         {{end}}--allow-privileged=true \
-        {{if .NodeStatusUpdateFrequency}}--node-status-update-frequency={{.NodeStatusUpdateFrequency}}
+        {{if .NodeStatusUpdateFrequency}}--node-status-update-frequency={{.NodeStatusUpdateFrequency}} \
         {{end}}--pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns={{.DNSServiceIP}} \
         --cluster_domain=cluster.local \

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -165,7 +165,7 @@ coreos:
         {{end}}--register-node=true \
         {{if .Experimental.Taints}}--register-schedulable=false \
         {{end}}--allow-privileged=true \
-        {{if .Experimental.NodeStatusUpdateFrequency}}--node-status-update-frequency={{.Experimental.NodeStatusUpdateFrequency}}
+        {{if .NodeStatusUpdateFrequency}}--node-status-update-frequency={{.NodeStatusUpdateFrequency}}
         {{end}}--pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns={{.DNSServiceIP}} \
         --cluster_domain=cluster.local \

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -165,7 +165,8 @@ coreos:
         {{end}}--register-node=true \
         {{if .Experimental.Taints}}--register-schedulable=false \
         {{end}}--allow-privileged=true \
-        --pod-manifest-path=/etc/kubernetes/manifests \
+        {{if .Experimental.NodeStatusUpdateFrequency}}--node-status-update-frequency={{.Experimental.NodeStatusUpdateFrequency}}
+        {{end}}--pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns={{.DNSServiceIP}} \
         --cluster_domain=cluster.local \
         --cloud-provider=aws \

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -989,6 +989,10 @@ addons:
 #   # This is the amount of time which we allow running Node to be unresponsive before marking it unhealthy. 
 #   # Must be N times more than kubelet's nodeStatusUpdateFrequency (default 10s).
 #   nodeMonitorGracePeriod: "40s"
+#   
+#   # Command line flag passed to kubelet. (default 10s)
+#   # Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller.
+#   nodeStatusUpdateFrequency: "10s"
 
 # AWS Tags for cloudformation stack resources
 #stackTags:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -237,6 +237,9 @@ worker:
 #        # Follow the aws convention of '/dev/xvd*' where '*' is a single letter from 'f' to 'z'
 #        device: "/dev/xvdf"
 #        path: "/ebs"
+#   
+#      # Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller.
+#      # nodeStatusUpdateFrequency: "10s"
 #
 #      #
 #      # Settings only for ASG-based node pools
@@ -989,10 +992,6 @@ addons:
 #   # This is the amount of time which we allow running Node to be unresponsive before marking it unhealthy. 
 #   # Must be N times more than kubelet's nodeStatusUpdateFrequency (default 10s).
 #   nodeMonitorGracePeriod: "40s"
-#   
-#   # Command line flag passed to kubelet. (default 10s)
-#   # Specifies how often kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller.
-#   nodeStatusUpdateFrequency: "10s"
 
 # AWS Tags for cloudformation stack resources
 #stackTags:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -979,7 +979,15 @@ addons:
 #     # See https://github.com/kubernetes-incubator/kube-aws/issues/230 for more information.
 #     rbac:
 #       enabled: true
-#
+#   # This flag disables automatic security group rule management for ELBs.  
+#   # It requires that the user has setup a rule that allows inbound traffic on kubelet ports 
+#   # from the local VPC subnet so that load balancers can access it.
+#   # Disable setting a new security group rule for every ELB.
+#   disableSecurityGroupIngress: false
+#   # Set NodeMonitorGracePeriod <duration>.  Option on controller-manager (default 40s)
+#   # This is the amount of time which we allow running Node to be unresponsive before marking it unhealthy. 
+#   # Must be N times more than kubelet's nodeStatusUpdateFrequency.
+#   nodeMonitorGracePeriod: "40s"
 
 # AWS Tags for cloudformation stack resources
 #stackTags:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -979,14 +979,15 @@ addons:
 #     # See https://github.com/kubernetes-incubator/kube-aws/issues/230 for more information.
 #     rbac:
 #       enabled: true
-#   # This flag disables automatic security group rule management for ELBs.  
+#
+#   # When set to true this configures the k8s aws provider so that it doesn't modify every node's security group to include an additional ingress rule per an ELB created for a k8s service whose type is "LoadBalancer"
 #   # It requires that the user has setup a rule that allows inbound traffic on kubelet ports 
-#   # from the local VPC subnet so that load balancers can access it.
-#   # Disable setting a new security group rule for every ELB.
+#   # from the local VPC subnet so that load balancers can access it.  Ref: https://github.com/kubernetes/kubernetes/issues/26670
 #   disableSecurityGroupIngress: false
-#   # Set NodeMonitorGracePeriod <duration>.  Option on controller-manager (default 40s)
+#   
+#   # Command line flag passed to the controller-manager. (default 40s)
 #   # This is the amount of time which we allow running Node to be unresponsive before marking it unhealthy. 
-#   # Must be N times more than kubelet's nodeStatusUpdateFrequency.
+#   # Must be N times more than kubelet's nodeStatusUpdateFrequency (default 10s).
 #   nodeMonitorGracePeriod: "40s"
 
 # AWS Tags for cloudformation stack resources

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -5,17 +5,18 @@ import (
 )
 
 type NodePoolConfig struct {
-	AutoScalingGroup     AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
-	ClusterAutoscaler    ClusterAutoscaler `yaml:"clusterAutoscaler"`
-	SpotFleet            SpotFleet         `yaml:"spotFleet,omitempty"`
-	EC2Instance          `yaml:",inline"`
-	ManagedIamRoleName   string `yaml:"managedIamRoleName,omitempty"`
-	DeprecatedRootVolume `yaml:",inline"`
-	SpotPrice            string                 `yaml:"spotPrice,omitempty"`
-	SecurityGroupIds     []string               `yaml:"securityGroupIds,omitempty"`
-	CustomSettings       map[string]interface{} `yaml:"customSettings,omitempty"`
-	VolumeMounts         []VolumeMount          `yaml:"volumeMounts,omitempty"`
-	UnknownKeys          `yaml:",inline"`
+	AutoScalingGroup          AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
+	ClusterAutoscaler         ClusterAutoscaler `yaml:"clusterAutoscaler"`
+	SpotFleet                 SpotFleet         `yaml:"spotFleet,omitempty"`
+	EC2Instance               `yaml:",inline"`
+	ManagedIamRoleName        string `yaml:"managedIamRoleName,omitempty"`
+	DeprecatedRootVolume      `yaml:",inline"`
+	SpotPrice                 string                 `yaml:"spotPrice,omitempty"`
+	SecurityGroupIds          []string               `yaml:"securityGroupIds,omitempty"`
+	CustomSettings            map[string]interface{} `yaml:"customSettings,omitempty"`
+	VolumeMounts              []VolumeMount          `yaml:"volumeMounts,omitempty"`
+	UnknownKeys               `yaml:",inline"`
+	NodeStatusUpdateFrequency string `yaml:"nodeStatusUpdateFrequency"`
 }
 
 type ClusterAutoscaler struct {


### PR DESCRIPTION
## disableSecurityGroupIngress

This flag disables automatic security group rule management for ELBs.  
It requires that the user has setup a rule that allows inbound traffic on kubelet ports 
 from the local VPC subnet so that load balancers can access it.
Disable setting a new security group rule for every ELB.

## nodeMonitorGracePeriod

Set NodeMonitorGracePeriod <duration>.  Option on controller-manager (default 40s)
This is the amount of time which we allow running Node to be unresponsive before marking it unhealthy. 
Must be N times more than kubelet's nodeStatusUpdateFrequency.
