### PR TITLE
Setup sysctl net.netfilter.nf_conntrack_max 

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -24,6 +24,14 @@ coreos:
         ExecStartPre=/opt/bin/cfn-etcd-environment
         ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
 
+{{if .UseCalico }}
+    # https://github.com/coreos/docs/blob/5d7b1cccb8286185275b07db1495828be9fdb0ea/os/other-settings.md#tuning-sysctl-parameters
+    - name: systemd-modules-load.service
+      command: restart
+    - name: systemd-sysctl.service
+      command: restart
+{{ end }}
+
 {{if .Experimental.AwsEnvironment.Enabled}}
     - name: set-aws-environment.service
       enable: true
@@ -1504,6 +1512,17 @@ write_files:
                 "isDefaultGateway": true
             }
         }
+
+{{ else }}
+
+  # http://docs.projectcalico.org/v2.0/usage/configuration/
+  - path: /etc/modules-load.d/nf.conf
+    content: |
+      nf_conntrack
+  - path: /etc/sysctl.d/nf.conf
+    content: |
+      net.netfilter.nf_conntrack_max=1000000
+
 {{ end }}
 
 {{if .Experimental.Authentication.Webhook.Enabled}}

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -238,6 +238,14 @@ coreos:
         WantedBy=multi-user.target
 {{ end }}
 
+{{if .UseCalico }}
+    # https://github.com/coreos/docs/blob/5d7b1cccb8286185275b07db1495828be9fdb0ea/os/other-settings.md#tuning-sysctl-parameters
+    - name: systemd-modules-load.service
+      command: restart
+    - name: systemd-sysctl.service
+      command: restart
+{{ end }}
+
 {{if .AwsEnvironment.Enabled}}
     - name: set-aws-environment.service
       enable: true
@@ -761,4 +769,15 @@ write_files:
                 "isDefaultGateway": true
             }
         }
+
+{{ else }}
+
+  # http://docs.projectcalico.org/v2.0/usage/configuration/
+  - path: /etc/modules-load.d/nf.conf
+    content: |
+      nf_conntrack
+  - path: /etc/sysctl.d/nf.conf
+    content: |
+      net.netfilter.nf_conntrack_max=1000000
+
 {{ end }}


### PR DESCRIPTION
This sysctl fix the nf_conntrack table 

**Logs**

```[2833841.216211] nf_conntrack: nf_conntrack: table full, dropping packet
[2833874.822698] nf_conntrack: nf_conntrack: table full, dropping packet
[2834097.097883] nf_conntrack: nf_conntrack: table full, dropping packet
[2834232.639992] nf_conntrack: nf_conntrack: table full, dropping packet 
``` 

This values are suggested in the docs of [project calico](http://docs.projectcalico.org/v2.0/usage/configuration/)