### PR TITLE
Fix mount directory for containerized-build-release-binaries script

### DIFF
--- a/containerized-build-release-binaries
+++ b/containerized-build-release-binaries
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 COREOS_KUBERNETES_ROOT=$(git rev-parse --show-toplevel)
-KUBERNETES_MOUNT_DIR="/go/src/github.com/coreos/kube-aws"
+KUBERNETES_MOUNT_DIR="/go/src/github.com/kubernetes-incubator/kube-aws"
 
 docker run --rm -i \
     -v "${COREOS_KUBERNETES_ROOT}:${KUBERNETES_MOUNT_DIR}:z" -w ${KUBERNETES_MOUNT_DIR} \


### PR DESCRIPTION
The containerized-build-release-binaries script file needs to be updated to reflect the new mount directory. (This is a consequence of the move kubernetes-incubator).

 Otherwise the script fails:

```
main.go:6:2: cannot find package "github.com/kubernetes-incubator/kube-aws/cmd" in any of:
        /go/src/github.com/coreos/kube-aws/vendor/github.com/kubernetes-incubator/kube-aws/cmd (vendor tree)
        /usr/local/go/src/github.com/kubernetes-incubator/kube-aws/cmd (from $GOROOT)
        /go/src/github.com/kubernetes-incubator/kube-aws/cmd (from $GOPATH)
```