### PR TITLE
Correct file references

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -502,7 +502,7 @@ write_files:
       done
 
       {{- if .Addons.Rescheduler.Enabled }}
-      kubectl apply -f "@$mfdir/kube-rescheduler-de.yaml"
+      kubectl apply -f "${mfdir}/kube-rescheduler-de.yaml"
       {{- end }}
 
       {{if .Experimental.Plugins.Rbac.Enabled}}
@@ -513,7 +513,7 @@ write_files:
       fi
 
       for manifest in {bootstrapped-node,}; do
-          kubectl apply -f "@${mfdir}/cluster-roles/$manifest.yaml"
+          kubectl apply -f "${mfdir}/cluster-roles/$manifest.yaml"
       done
 
       for manifest in {system-worker,kube-worker,kube-admin,bootstrapped-node}; do
@@ -521,8 +521,8 @@ write_files:
       done
 
       {{ if .Experimental.TLSBootstrap.Enabled }}
-      kubectl create -f "@${mfdir}/cluster-roles/kubelet-bootstrap.yaml" | echo 'Failed to create the cluster role named "kubelet-bootstrap". Skipping'
-      kubectl create -f "@${mfdir}/cluster-role-bindings/kubelet-bootstrap.yaml" |  | echo 'Failed to create the cluster role binding "kubelet-bootstrap". Skipping'
+      kubectl create -f "${mfdir}/cluster-roles/kubelet-bootstrap.yaml" | echo 'Failed to create the cluster role named "kubelet-bootstrap". Skipping'
+      kubectl create -f "${mfdir}/cluster-role-bindings/kubelet-bootstrap.yaml" |  | echo 'Failed to create the cluster role binding "kubelet-bootstrap". Skipping'
       {{ end }}
       {{ end }}
 


### PR DESCRIPTION
Behaviour before this change is that the rescheduler does not get
deployed, in fact the entire `.Addons.Rescheduler.Enabled` block will
be missing from the controller file even when it is enabled.

Introduced by https://github.com/kubernetes-incubator/kube-aws/pull/472.

Should also fix some the cluster roles and TLS bootstrap, not tested that part but pretty certain it's currently broken.