### PR TITLE
Perform docker post-start check

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -57,6 +57,12 @@ coreos:
             After=var-lib-docker.mount
             Wants=var-lib-docker.mount
 {{end}}
+        - name: 10-post-start-check.conf
+          content: |
+            [Service]
+            RestartSec=10
+            ExecStartPost=/usr/bin/docker pull {{.PauseImage.RepoWithTag}}
+
         - name: 40-flannel.conf
           content: |
             [Unit]

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -59,6 +59,12 @@ coreos:
             After=var-lib-docker.mount
             Wants=var-lib-docker.mount
 {{end}}
+        - name: 10-post-start-check.conf
+          content: |
+            [Service]
+            RestartSec=10
+            ExecStartPost=/usr/bin/docker pull {{.PauseImage.RepoWithTag}}
+
         - name: 40-flannel.conf
           content: |
             [Unit]


### PR DESCRIPTION
Very rarely we see that docker can't pull any image with
errors like

```
Get https://gcr.io/v1/_ping: x509: certificate signed by unknown authority
```

produced in it's logfile. Basically nothing can be pulled and
docker acts as if CA bundle is not installed on a system. Simple
restart fixes the problem.

This is a poor attempt to automatically recover from this
situation. Unfortunately reloading daemon doesn't make it
to re-read /etc/ssl/certs/ca-certificates.crt

We've tried to run "update-ca-certificates" which regenerates
'/etc/ssl/certs/ca-certificates.crt' file in `ExecStartPre` for
few weeks, but today we triggered this strange edge condition
nevertheless, hence this PR