### PR TITLE
'Cluster-dump' feature to export Kubernetes Resources to S3

### DIFF
--- a/Documentation/kubernetes-on-aws-backup-restore.md
+++ b/Documentation/kubernetes-on-aws-backup-restore.md
@@ -1,0 +1,51 @@
+# Backup
+
+A feature to backup of Kubernetes resources can be enabled by specifying: 
+```
+kubeResourcesAutosave:
+    enabled: true
+``` 
+in cluster.yaml.
+
+When active, a kube-system Deployment schedules a single pod to take and upload snapshots of all Kubernetes resources to S3.
+- Backups are taken and exported when the pod (re)starts and then continues to backup in 24 hours intervals.
+- Each snapshot resides in a timestamped folder
+- The resources have several fields omitted such as status , uid, etc ... this is to allow the possibility of restoring resources inside a fresh cluster
+- Resources that reside within namespaces are grouped inside folders labeled with the namespace name
+- Resources outside namespaces are grouped at the same directory level as the namespace folders
+- The backups are exported to the S3 URI: ```s3://<your-bucket-name>/.../<your-cluster-name>/backup/*```
+
+### Example
+
+A Kubernetes environment has the namespaces:
+ - kube-system
+ - alpha
+ - beta
+ 
+A backup is created on 04/05/2017 at 13:48:33.
+
+The backup is exported to S3 to the path: 
+```
+s3://my-bucket-name/my-cluster-name/backup/17-05-04_13-48-33
+```
+Inside the ```17-05-04_13-48-33``` directory are be several .json files of the Kubernetes resources that reside outside namespaces, in addition to a number of folders with names matching the namespaces:
+```
+17-05-04_13-48-33/kube-system
+17-05-04_13-48-33/alpha
+17-05-04_13-48-33/beta
+17-05-04_13-48-33/persistentvolumes.json
+17-05-04_13-48-33/storageclasses.json
+...
+...
+...
+
+```
+Inside each namespace folder are be several .json files of the Kubernetes resources that reside inside the respective namespace
+```
+17-05-04_13-48-33/kube-system/deployments.json
+17-05-04_13-48-33/kube-system/statefulsets.json
+...
+...
+...
+
+```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Check out our getting started tutorial on launching your first Kubernetes cluste
   * Configure various Kubernetes add-ons
 * [Step 7: Destroy](/Documentation/kubernetes-on-aws-destroy.md)
   * Destroy the cluster
+* **Optional Features**
+  * [Backup Kubernetes resources](/Documentation/kubernetes-on-aws-backup-restore.md)
 
 ## Examples
 

--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -116,6 +116,7 @@ func (c *ClusterRef) validateExistingVPCState(ec2Svc ec2Service) error {
 
 func NewCluster(cfg *config.Cluster, opts config.StackTemplateOptions, awsDebug bool) (*Cluster, error) {
 	cluster := NewClusterRef(cfg, awsDebug)
+	cluster.KubeResourcesAutosave.S3Path = fmt.Sprintf("%skube-aws/clusters/%s/backup", strings.TrimPrefix(opts.S3URI, "s3://"), cfg.ClusterName)
 	stackConfig, err := cluster.StackConfig(opts)
 	if err != nil {
 		return nil, err

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -150,6 +150,9 @@ func NewDefaultCluster() *Cluster {
 		CreateRecordSet:     false,
 		RecordSetTTL:        300,
 		CustomSettings:      make(map[string]interface{}),
+		KubeResourcesAutosave: KubeResourcesAutosave{
+			Enabled: false,
+		},
 	}
 }
 
@@ -643,6 +646,7 @@ type Cluster struct {
 	HostedZoneID           string `yaml:"hostedZoneId,omitempty"`
 	ProvidedEncryptService EncryptService
 	CustomSettings         map[string]interface{} `yaml:"customSettings,omitempty"`
+	KubeResourcesAutosave  `yaml:"kubeResourcesAutosave,omitempty"`
 }
 
 type Experimental struct {
@@ -715,6 +719,11 @@ type EphemeralImageStorage struct {
 
 type Kube2IamSupport struct {
 	Enabled bool `yaml:"enabled"`
+}
+
+type KubeResourcesAutosave struct {
+	Enabled bool `yaml:"enabled"`
+	S3Path  string
 }
 
 type NodeDrainer struct {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -497,7 +497,7 @@ write_files:
       {{ end }}
 
       # Deployments
-      for manifest in {kube-dns-de,kube-dns-autoscaler-de,heapster-de}.yaml; do
+      for manifest in {kube-dns-de,kube-dns-autoscaler-de,heapster-de{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}.yaml; do
           kubectl apply -f "${mfdir}/$manifest"
       done
 
@@ -790,6 +790,116 @@ write_files:
       sed -i -e "s#\$ETCDCERT#$etcd_cert#g" /srv/kubernetes/manifests/calico.yaml
       sed -i -e "s#\$ETCDKEY#$etcd_key#g" /srv/kubernetes/manifests/calico.yaml
 
+{{ end }}
+{{ if .KubeResourcesAutosave.Enabled }}
+  - path: /srv/kubernetes/manifests/kube-resources-autosave.yaml
+    content: |
+      ---
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: kube-resources-autosave
+        namespace: kube-system
+        labels:
+          k8s-app: kube-resources-autosave-policy
+      spec:
+        replicas: 1
+        template:
+          metadata:
+            name: kube-resources-autosave
+            namespace: kube-system
+            labels:
+              k8s-app: kube-resources-autosave-policy
+          spec:
+            containers:
+            - name: kube-resources-autosave-dumper
+              image: {{.HyperkubeImage.RepoWithTag}}
+              command: ["/bin/bash", "-c" ]
+              args:
+                - |
+                    set -x ;
+                    DUMP_DIR_COMPLETE=/kube-resources-autosave/complete ;
+                    mkdir -p ${DUMP_DIR_COMPLETE} ;
+                    while true; do
+                      TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+                      DUMP_DIR=/kube-resources-autosave/tmp/${TIMESTAMP} ;
+                      mkdir -p ${DUMP_DIR} ;
+                      RESOURCES_OUT_NAMESPACE=( namespaces persistentvolumes nodes storageclasses clusterrolebindings clusterroles ) ;
+                      for r in ${RESOURCES_OUT_NAMESPACE[@]};do
+                        echo " Searching for resources: ${r}" ;
+                        /kubectl get --export -o=json ${r} | \
+                        jq '.items[] |
+                            del(.status,
+                            .metadata.uid,
+                            .metadata.selfLink,
+                            .metadata.resourceVersion,
+                            .metadata.creationTimestamp,
+                            .metadata.generation,
+                            .spec.claimRef
+                          )' > ${DUMP_DIR}/${r}.json ;
+                      done ;
+                      RESOURCES_IN_NAMESPACE=( componentstatuses configmaps daemonsets deployments endpoints events horizontalpodautoscalers
+                      ingresses jobs limitranges networkpolicies  persistentvolumeclaims pods podsecuritypolicies podtemplates replicasets
+                      replicationcontrollers resourcequotas secrets serviceaccounts services statefulsets thirdpartyresources
+                      poddisruptionbudgets roles rolebindings) ;
+                      for ns in $(jq -r '.metadata.name' < ${DUMP_DIR}/namespaces.json);do
+                        echo "Searching in namespace: ${ns}" ;
+                        mkdir -p ${DUMP_DIR}/${ns} ;
+                        for r in ${RESOURCES_IN_NAMESPACE[@]};do
+                          echo " Searching for resources: ${r}" ;
+                          /kubectl --namespace=${ns} get --export -o=json ${r} | \
+                          jq '.items[] |
+                            select(.type!="kubernetes.io/service-account-token") |
+                            del(
+                              .spec.clusterIP,
+                              .metadata.uid,
+                              .metadata.selfLink,
+                              .metadata.resourceVersion,
+                              .metadata.creationTimestamp,
+                              .metadata.generation,
+                              .metadata.annotations."pv.kubernetes.io/bind-completed",
+                              .status
+                            )' > ${DUMP_DIR}/${ns}/${r}.json && touch /probe-token ;
+                        done ;
+                      done ;
+                    mv ${DUMP_DIR} ${DUMP_DIR_COMPLETE}/${TIMESTAMP} ;
+                    rm -r -f ${DUMP_DIR} ;
+                    sleep 24h ;
+                    done
+              livenessProbe:
+                exec:
+                  command: ["/bin/bash", "-c", "(( $(date +%s) - $(stat -c%Y /probe-token) < 25*60*60 ))" ]
+                initialDelaySeconds: 240
+                periodSeconds: 10
+              volumeMounts:
+              - name: dump-dir
+                mountPath: /kube-resources-autosave
+                readOnly: false
+            - name: kube-resources-autosave-pusher
+              image: {{.AWSCliImage.RepoWithTag}}
+              command: ["/bin/bash", "-c" ]
+              args:
+                - |
+                    set -x ;
+                    DUMP_DIR_COMPLETE=/kube-resources-autosave/complete ;
+                    while true; do
+                      for FILE in ${DUMP_DIR_COMPLETE}/* ; do
+                        aws s3 mv ${FILE} s3://{{ .KubeResourcesAutosave.S3Path }}/$(basename ${FILE}) --recursive && rm -r -f ${FILE} && touch /probe-token ;
+                      done ;
+                      sleep 1m ;
+                    done
+              livenessProbe:
+                exec:
+                  command: ["/bin/bash", "-c", "(( $(date +%s) - $(stat -c%Y /probe-token) < 25*60*60 ))" ]
+                initialDelaySeconds: 240
+                periodSeconds: 10
+              volumeMounts:
+              - name: dump-dir
+                mountPath: /kube-resources-autosave
+                readOnly: false
+            volumes:
+            - name: dump-dir
+              emptyDir: {}
 {{ end }}
 
 {{if .AssetsEncryptionEnabled }}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -933,6 +933,11 @@ worker:
 #  enabled: true
 #   maxBatchSize: 1
 
+# Exports all Kubernetes resources (in .json format) to a bucket 's3://S3URI/clusterBackup/*'.
+# The export process executes on start-up and repeats every 24 hours.
+#kubeResourcesAutosave:
+#  enabled: false
+
 # Addon features
 addons:
   # When enabled, Kubernetes rescheduler is deployed to the cluster controller(s)

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -50,7 +50,8 @@ type DeploymentSettings struct {
 }
 
 type MainClusterSettings struct {
-	EtcdNodes []derived.EtcdNode
+	EtcdNodes             []derived.EtcdNode
+	KubeResourcesAutosave cfg.KubeResourcesAutosave
 }
 
 type StackTemplateOptions struct {
@@ -115,6 +116,7 @@ func (c ProvidedConfig) StackConfig(opts StackTemplateOptions) (*StackConfig, er
 
 	baseS3URI := strings.TrimSuffix(opts.S3URI, "/")
 	stackConfig.S3URI = fmt.Sprintf("%s/kube-aws/clusters/%s/exported/stacks", baseS3URI, c.ClusterName)
+	stackConfig.KubeResourcesAutosave.S3Path = fmt.Sprintf("%s/kube-aws/clusters/%s/backup", strings.TrimPrefix(baseS3URI, "s3://"), c.ClusterName)
 
 	if opts.SkipWait {
 		enabled := false
@@ -234,6 +236,7 @@ define one or more public subnets in cluster.yaml or explicitly reference privat
 	}
 
 	c.EtcdNodes = main.EtcdNodes
+	c.KubeResourcesAutosave = main.KubeResourcesAutosave
 
 	var apiEndpoint derived.APIEndpoint
 	if c.APIEndpointName != "" {

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -327,6 +327,15 @@
                   ],
                   "Resource": "arn:{{.Region.Partition}}:s3:::{{$.UserDataWorkerS3Prefix}}*"
                 },
+                {{ if .KubeResourcesAutosave.Enabled }}
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:PutObject"
+                  ],
+                  "Resource": "arn:{{.Region.Partition}}:s3:::{{ .KubeResourcesAutosave.S3Path }}/*"
+                },
+                {{end}}
                 {{if .Kube2IamSupport.Enabled }}
                 {
                   "Action": "sts:AssumeRole",


### PR DESCRIPTION
A new kube-system Deployment has been created which takes and uploads snapshots of all Kubernetes resources within the cluster to S3.

There are two containers:

 **cluster-dump-dumper**:
 - Uses kubectl to snapshot all Kubernetes resources (interval of 24 hours).
 - Each snapshot resides in a timestamped folder
 - The resources have several fields omitted such as _status_ , _uid_, etc ... this is to allow the possibility of restoring resources inside a fresh cluster
 - Resources that reside within namespaces are grouped inside folders labeled with the namespace name
 - Resources outside namespaces are grouped at the same directory level as the namespace folders

 **cluster-dump-pusher**
 - Uses aws to upload snapshots to S3
 - The S3 path is constructed from the _S3URI_ passed into kube-aws binary; a string "/clusterDump/"; and the _timestamped folder_

Notes:
- We decided to use bash as arguments to the containers to avoid any additional docker image dependencies - it makes use of the *aws* and *hyperkube* images already defined in cluster.yaml. Also, as the Deployment definition resides on controller nodes but the pods themselves are on worker nodes, storing the bash as separate files did not fell appropriate.

 - We intend to create a 'restore' script that will deploy resources from snapshot folder into a new cluster. Use Case: We destroy a cluster and recreate it (maybe with new features) but also restore the Kubernetes resources we had originally.

- https://coreos.com/kubernetes/docs/latest/cluster-dump-restore.html