### PR TITLE
Rescheduler to 0.3.0 which uses k8s 1.6

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -110,7 +110,7 @@ func NewDefaultCluster() *Cluster {
 			ClusterAutoscalerImage:      model.Image{Repo: "gcr.io/google_containers/cluster-proportional-autoscaler-amd64", Tag: "1.0.0", RktPullDocker: false},
 			KubeDnsImage:                model.Image{Repo: "gcr.io/google_containers/kubedns-amd64", Tag: "1.9", RktPullDocker: false},
 			KubeDnsMasqImage:            model.Image{Repo: "gcr.io/google_containers/kube-dnsmasq-amd64", Tag: "1.4", RktPullDocker: false},
-			KubeReschedulerImage:        model.Image{Repo: "gcr.io/google-containers/rescheduler", Tag: "v0.2.2", RktPullDocker: false},
+			KubeReschedulerImage:        model.Image{Repo: "gcr.io/google-containers/rescheduler", Tag: "v0.3.0", RktPullDocker: false},
 			DnsMasqMetricsImage:         model.Image{Repo: "gcr.io/google_containers/dnsmasq-metrics-amd64", Tag: "1.0", RktPullDocker: false},
 			ExecHealthzImage:            model.Image{Repo: "gcr.io/google_containers/exechealthz-amd64", Tag: "1.2", RktPullDocker: false},
 			HeapsterImage:               model.Image{Repo: "gcr.io/google_containers/heapster", Tag: "v1.3.0", RktPullDocker: false},

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -853,7 +853,7 @@ worker:
 # kube rescheduler image repository to use.
 #kubeReschedulerImage:
 #  repo: gcr.io/google-containers/rescheduler
-#  tag: v0.2.2
+#  tag: v0.3.0
 #  rktPullDocker: false
 
 # DNS Masq metrics image repository to use.


### PR DESCRIPTION
For https://github.com/kubernetes-incubator/kube-aws/issues/118.

The rescheduler has been updated for k8s 1.6+.

Here's some logs showing 0.3.0 working on latest master:
```
I0406 13:38:38.432791       1 rescheduler.go:140] Critical pod kube-system_heapster-v1.3.0-76786035-rw214 is unschedulable. Trying to find a spot for it.
W0406 13:38:38.441782       1 rescheduler.go:383] Skipping node ip-10-0-101-53.eu-west-1.compute.internal due to CriticalAddonsOnly taint with value: kube-system_heapster-v1.3.0-76786035-bsnx1
I0406 13:38:38.460355       1 rescheduler.go:159] Trying to place the pod on node ip-10-0-102-121.eu-west-1.compute.internal
I0406 13:38:38.474273       1 rescheduler.go:332] Pod default_nginx-test-2766461593-w7vlw will be deleted in order to schedule critical pod kube-system_heapster-v1.3.0-76786035-rw214.
I0406 13:38:38.474441       1 event.go:217] Event(v1.ObjectReference{Kind:"Pod", Namespace:"default", Name:"nginx-test-2766461593-w7vlw", UID:"ca7d76eb-1acc-11e7-96d4-066ad7a20777", APIVersion:"v1", ResourceVersion:"2846", FieldPath:""}): type: 'Normal' reason: 'DeletedByRescheduler' Deleted by rescheduler in order to schedule critical pod kube-system_heapster-v1.3.0-76786035-rw214.
I0406 13:38:38.480103       1 rescheduler.go:332] Pod default_nginx-test-2766461593-wc4qn will be deleted in order to schedule critical pod kube-system_heapster-v1.3.0-76786035-rw214.
I0406 13:38:38.480273       1 event.go:217] Event(v1.ObjectReference{Kind:"Pod", Namespace:"default", Name:"nginx-test-2766461593-wc4qn", UID:"ca7d8939-1acc-11e7-96d4-066ad7a20777", APIVersion:"v1", ResourceVersion:"2642", FieldPath:""}): type: 'Normal' reason: 'DeletedByRescheduler' Deleted by rescheduler in order to schedule critical pod kube-system_heapster-v1.3.0-76786035-rw214.
I0406 13:38:38.486228       1 rescheduler.go:332] Pod default_nginx-test-2766461593-zr3c8 will be deleted in order to schedule critical pod kube-system_heapster-v1.3.0-76786035-rw214.
I0406 13:38:38.486275       1 event.go:217] Event(v1.ObjectReference{Kind:"Pod", Namespace:"default", Name:"nginx-test-2766461593-zr3c8", UID:"ca7d4a9c-1acc-11e7-96d4-066ad7a20777", APIVersion:"v1", ResourceVersion:"2806", FieldPath:""}): type: 'Normal' reason: 'DeletedByRescheduler' Deleted by rescheduler in order to schedule critical pod kube-system_heapster-v1.3.0-76786035-rw214.
I0406 13:38:38.655555       1 rescheduler.go:178] Waiting for pod kube-system_heapster-v1.3.0-76786035-rw214 to be scheduled
I0406 13:39:34.659128       1 rescheduler.go:190] Pod kube-system_heapster-v1.3.0-76786035-rw214 was successfully scheduled.
```

Unfortunately as per my notes in https://github.com/kubernetes-incubator/kube-aws/issues/118#issuecomment-291182707, the logs are inside the container at `/tmp/rescheduler.INFO`. Even the [salt config](https://github.com/kubernetes/kubernetes/blob/master/cluster/saltbase/salt/rescheduler/rescheduler.manifest) does not function as expected.