### PR TITLE
New options: customFiles and customSystemdUnits

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -9,6 +9,20 @@ coreos:
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
 
   units:
+{{- range $u := .Controller.CustomSystemdUnits}}
+    - name: {{$u.Name}}
+      command: {{ $u.Command }}
+      {{- if $u.Enable }}
+      enable: {{ $u.Enable }}
+      {{- end }}
+      {{- if $u.Runtime }}
+      runtime: {{ $u.Runtime }}
+      {{- end }}
+      content: |
+        {{- range $l := $u.ContentArray}}
+        {{ $l }}
+        {{- end }}
+{{- end}}
     - name: cfn-etcd-environment.service
       enable: true
       command: start
@@ -394,6 +408,16 @@ ssh_authorized_keys:
         WantedBy=install-kube-system.service
 {{end}}
 write_files:
+{{- if .Controller.CustomFiles}}
+  {{- range $w := .Controller.CustomFiles}}
+  - path: {{$w.Path}}
+    permissions: {{$w.PermissionsString}}
+    content: |
+      {{- range $l := $w.ContentArray}}
+      {{$l}}
+      {{- end}}
+  {{- end }}
+{{- end }}
 {{if .Experimental.DisableSecurityGroupIngress}}
   - path: /etc/kubernetes/additional-configs/cloud.config
     owner: root:root

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -412,10 +412,8 @@ write_files:
   {{- range $w := .Controller.CustomFiles}}
   - path: {{$w.Path}}
     permissions: {{$w.PermissionsString}}
-    content: |
-      {{- range $l := $w.ContentArray}}
-      {{$l}}
-      {{- end}}
+    encoding: gzip+base64
+    content: {{$w.GzippedBase64Content}}
   {{- end }}
 {{- end }}
 {{if .Experimental.DisableSecurityGroupIngress}}

--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -287,10 +287,8 @@ write_files:
   {{- range $w := .Etcd.CustomFiles}}
   - path: {{$w.Path}}
     permissions: {{$w.PermissionsString}}
-    content: |
-      {{- range $l := $w.ContentArray}}
-      {{$l}}
-      {{- end}}
+    encoding: gzip+base64
+    content: {{$w.GzippedBase64Content}}
   {{- end }}
 {{- end }}
   - path: /opt/bin/cfn-init-etcd-server

--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -3,6 +3,20 @@ coreos:
   update:
     reboot-strategy: "off"
   units:
+{{- range $u := .Etcd.CustomSystemdUnits}}
+    - name: {{$u.Name}}
+      command: {{ $u.Command }}
+      {{- if $u.Enable }}
+      enable: {{ $u.Enable }}
+      {{- end }}
+      {{- if $u.Runtime }}
+      runtime: {{ $u.Runtime }}
+      {{- end }}
+      content: |
+        {{- range $l := $u.ContentArray}}
+        {{ $l }}
+        {{- end }}
+{{- end}}
     - name: cfn-etcd-environment.service
       enable: true
       command: start
@@ -269,7 +283,16 @@ ssh_authorized_keys:
 {{end}}
 
 write_files:
-
+{{- if .Etcd.CustomFiles}}
+  {{- range $w := .Etcd.CustomFiles}}
+  - path: {{$w.Path}}
+    permissions: {{$w.PermissionsString}}
+    content: |
+      {{- range $l := $w.ContentArray}}
+      {{$l}}
+      {{- end}}
+  {{- end }}
+{{- end }}
   - path: /opt/bin/cfn-init-etcd-server
     owner: root:root
     permissions: 0700

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -494,10 +494,8 @@ write_files:
   {{- range $w := .CustomFiles}}
   - path: {{$w.Path}}
     permissions: {{$w.PermissionsString}}
-    content: |
-      {{- range $l := $w.ContentArray}}
-      {{$l}}
-      {{- end}}
+    encoding: gzip+base64
+    content: {{$w.GzippedBase64Content}}
   {{- end }}
 {{- end }}
 {{if .AwsEnvironment.Enabled}}

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -9,6 +9,20 @@ coreos:
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
 
   units:
+{{- range $u := .CustomSystemdUnits}}
+    - name: {{$u.Name}}
+      command: {{ $u.Command }}
+      {{- if $u.Enable }}
+      enable: {{$u.Enable}}
+      {{- end }}
+      {{- if $u.Runtime }}
+      runtime: {{$u.Runtime}}
+      {{- end }}
+      content: |
+        {{- range $l := $u.ContentArray}}
+        {{ $l }}
+        {{- end }}
+{{- end}}
 {{range $volumeMountSpecIndex, $volumeMountSpec := .VolumeMounts}}
     - name: format-{{$volumeMountSpec.SystemdMountName}}.service
       command: start
@@ -476,6 +490,16 @@ ssh_authorized_keys:
         WantedBy=kubelet.service
 {{end}}
 write_files:
+{{- if .CustomFiles}}
+  {{- range $w := .CustomFiles}}
+  - path: {{$w.Path}}
+    permissions: {{$w.PermissionsString}}
+    content: |
+      {{- range $l := $w.ContentArray}}
+      {{$l}}
+      {{- end}}
+  {{- end }}
+{{- end }}
 {{if .AwsEnvironment.Enabled}}
   - path: /opt/bin/set-aws-environment
     owner: root:root

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -168,6 +168,24 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    # If you like specific private subnets to be used by the internal ELB:
 #    # subnets:
 #    #   - name: ManagedPrivateSubnet0
+#  
+#  # User defined files that will be added to the Controller cluster cloud-init configuration in the "write_files:" section.
+#  customFiles:
+#    - path: "/etc/rkt/auth.d/docker.json"
+#      permissions: 0600
+#      content: |
+#        { "rktKind": "dockerAuth", "rktVersion": "v1", ... }
+#
+#  # User defined systemd units that will be added to the Controller cluster cloud-init configuration in the "units:" section.
+#  customSystemdUnits:
+#    - name: monitoring.service
+#      command: start
+#      enable: true
+#      content: |
+#        [Unit]
+#        Description=Example Custom Service
+#        [Service]
+#        ExecStart=/bin/rkt run --set-env TAGS=Controller ...
 
 # CAUTION: Deprecated and will be removed in v0.9.7. Please use controller.createTimeout instead
 #controllerCreateTimeout: PT15M
@@ -428,6 +446,24 @@ worker:
 #      customSettings:
 #        key1: [ 1, 2, 3 ]
 
+#      # User defined files that will be added to the NodePool cloud-init configuration in the "write_files:" section.
+#      customFiles:
+#        - path: "/etc/rkt/auth.d/docker.json"
+#          permissions: 0600
+#          content: |
+#            { "rktKind": "dockerAuth", "rktVersion": "v1", ... }
+#
+#      # User defined systemd units that will be added to the NodePool cluster cloud-init configuration in the "units:" section.
+#      customSystemdUnits:
+#        - name: monitoring.service
+#          command: start
+#          enable: true
+#          content: |
+#            [Unit]
+#            Description=Example Custom Service
+#            [Service]
+#            ExecStart=/bin/rkt run --set-env TAGS=Controller ...
+
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M
 
@@ -567,6 +603,24 @@ worker:
 #  # ARN of the KMS key used to encrypt the etcd data volume. The account default key will be used if `etcdDataVolumeEncrypted`
 #  # is enable and `etcd.kmsKeyArn` is omitted.
 #  kmsKeyArn: ""
+#
+#  # User defined files that will be added to the Etcd cluster cloud-init configuration in the "write_files:" section.
+#  customFiles:
+#    - path: "/etc/rkt/auth.d/docker.json"
+#      permissions: 0600
+#      content: |
+#        { "rktKind": "dockerAuth", "rktVersion": "v1", ... }
+#   
+#  # User defined systemd units that will be added to the Etcd cluster cloud-init configuration in the "units:" section.
+#  customSystemdUnits:
+#    - name: monitoring.service
+#      command: start
+#      enable: true
+#      content: |
+#        [Unit]
+#        Description=Example Custom Service
+#        [Service]
+#        ExecStart=/bin/rkt run --set-env TAGS=Controller ...
 
 # CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.instanceType instead
 # etcdInstanceType: t2.medium

--- a/model/controller.go
+++ b/model/controller.go
@@ -7,9 +7,11 @@ type Controller struct {
 	AutoScalingGroup   AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
 	ClusterAutoscaler  ClusterAutoscaler `yaml:"clusterAutoscaler,omitempty"`
 	EC2Instance        `yaml:",inline"`
-	LoadBalancer       ControllerElb `yaml:"loadBalancer,omitempty"`
-	ManagedIamRoleName string        `yaml:"managedIamRoleName,omitempty"`
-	Subnets            []Subnet      `yaml:"subnets,omitempty"`
+	LoadBalancer       ControllerElb       `yaml:"loadBalancer,omitempty"`
+	ManagedIamRoleName string              `yaml:"managedIamRoleName,omitempty"`
+	Subnets            []Subnet            `yaml:"subnets,omitempty"`
+	CustomFiles        []CustomFile        `yaml:"customFiles,omitempty"`
+	CustomSystemdUnits []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
 	UnknownKeys        `yaml:",inline"`
 }
 

--- a/model/custom_file.go
+++ b/model/custom_file.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+type CustomFile struct {
+	Path        string `yaml:"path"`
+	Permissions uint   `yaml:"permissions"`
+	Content     string `yaml:"content"`
+	UnknownKeys `yaml:",inline"`
+}
+
+func (c CustomFile) ContentArray() []string {
+	// CustomFiles needs an array so that we can inline it.
+	return strings.Split(c.Content, "\n")
+}
+
+func (c CustomFile) PermissionsString() string {
+	// We also need to write out octal notation for permissions.
+	return fmt.Sprintf("0%o", c.Permissions)
+}

--- a/model/custom_file.go
+++ b/model/custom_file.go
@@ -2,7 +2,8 @@ package model
 
 import (
 	"fmt"
-	"strings"
+
+	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
 )
 
 type CustomFile struct {
@@ -12,12 +13,15 @@ type CustomFile struct {
 	UnknownKeys `yaml:",inline"`
 }
 
-func (c CustomFile) ContentArray() []string {
-	// CustomFiles needs an array so that we can inline it.
-	return strings.Split(c.Content, "\n")
-}
-
 func (c CustomFile) PermissionsString() string {
 	// We also need to write out octal notation for permissions.
 	return fmt.Sprintf("0%o", c.Permissions)
+}
+
+func (c CustomFile) GzippedBase64Content() string {
+	out, err := gzipcompressor.CompressString(c.Content)
+	if err != nil {
+		return ""
+	}
+	return out
 }

--- a/model/custom_systemd_unit.go
+++ b/model/custom_systemd_unit.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"strconv"
+	"strings"
+)
+
+type CustomSystemdUnit struct {
+	Name        string `yaml:"name"`
+	Command     string `yaml:"command"`
+	Content     string `yaml:"content"`
+	Enable      bool   `yaml:"enable,omitempty"`
+	Runtime     bool   `yaml:"runtime,omitempty"`
+	UnknownKeys `yaml:",inline"`
+}
+
+func (c CustomSystemdUnit) ContentArray() []string {
+	return strings.Split(c.Content, "\n")
+}
+
+func (c CustomSystemdUnit) EnableString() string {
+	return strconv.FormatBool(c.Enable)
+}
+
+func (c CustomSystemdUnit) RuntimeString() string {
+	return strconv.FormatBool(c.Runtime)
+}

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -6,14 +6,16 @@ import (
 )
 
 type Etcd struct {
-	Cluster          EtcdCluster          `yaml:",inline"`
-	DataVolume       DataVolume           `yaml:"dataVolume,omitempty"`
-	DisasterRecovery EtcdDisasterRecovery `yaml:"disasterRecovery,omitempty"`
-	Snapshot         EtcdSnapshot         `yaml:"snapshot,omitempty"`
-	EC2Instance      `yaml:",inline"`
-	Nodes            []EtcdNode `yaml:"nodes,omitempty"`
-	Subnets          []Subnet   `yaml:"subnets,omitempty"`
-	UnknownKeys      `yaml:",inline"`
+	Cluster            EtcdCluster          `yaml:",inline"`
+	DataVolume         DataVolume           `yaml:"dataVolume,omitempty"`
+	DisasterRecovery   EtcdDisasterRecovery `yaml:"disasterRecovery,omitempty"`
+	Snapshot           EtcdSnapshot         `yaml:"snapshot,omitempty"`
+	EC2Instance        `yaml:",inline"`
+	Nodes              []EtcdNode          `yaml:"nodes,omitempty"`
+	Subnets            []Subnet            `yaml:"subnets,omitempty"`
+	CustomFiles        []CustomFile        `yaml:"customFiles,omitempty"`
+	CustomSystemdUnits []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
+	UnknownKeys        `yaml:",inline"`
 }
 
 type EtcdVersion string
@@ -58,7 +60,6 @@ func NewDefaultEtcd() Etcd {
 		},
 	}
 }
-
 func (i Etcd) LogicalName() string {
 	return "Etcd"
 }

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -16,7 +16,9 @@ type NodePoolConfig struct {
 	CustomSettings            map[string]interface{} `yaml:"customSettings,omitempty"`
 	VolumeMounts              []VolumeMount          `yaml:"volumeMounts,omitempty"`
 	UnknownKeys               `yaml:",inline"`
-	NodeStatusUpdateFrequency string `yaml:"nodeStatusUpdateFrequency"`
+	NodeStatusUpdateFrequency string              `yaml:"nodeStatusUpdateFrequency"`
+	CustomFiles               []CustomFile        `yaml:"customFiles,omitempty"`
+	CustomSystemdUnits        []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
 }
 
 type ClusterAutoscaler struct {


### PR DESCRIPTION
This adds the capability to write user defined files and systemd units to the 3 main types of servers: Etcd, Controller, NodePool Worker as specified by the cluster.yaml configuration for the cluster.