### PR TITLE
Make the validation error message when KMS failed more friendly

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -974,6 +974,9 @@ func (c Cluster) StackConfig(opts StackTemplateOptions) (*StackConfig, error) {
 				KMSKeyARN:      c.KMSKeyARN,
 				EncryptService: c.ProvidedEncryptService,
 			})
+			if err != nil {
+				return nil, err
+			}
 
 			stackConfig.Config.TLSConfig = compactAssets
 		} else {

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -79,11 +79,14 @@ func (c ProvidedConfig) StackConfig(opts StackTemplateOptions) (*StackConfig, er
 
 	if stackConfig.ManageCertificates {
 		if stackConfig.ComputedConfig.AssetsEncryptionEnabled() {
-			compactAssets, _ := cfg.ReadOrCreateCompactTLSAssets(opts.AssetsDir, cfg.KMSConfig{
+			compactAssets, err := cfg.ReadOrCreateCompactTLSAssets(opts.AssetsDir, cfg.KMSConfig{
 				Region:         stackConfig.ComputedConfig.Region,
 				KMSKeyARN:      c.KMSKeyARN,
 				EncryptService: c.ProvidedEncryptService,
 			})
+			if err != nil {
+				return nil, err
+			}
 			stackConfig.ComputedConfig.TLSConfig = compactAssets
 		} else {
 			rawAssets, _ := cfg.ReadOrCreateUnencryptedCompactTLSAssets(opts.AssetsDir)


### PR DESCRIPTION
Now, when e.g. AWS_ACCESS_KEY_ID is missing, the error looks like:
```
$ kube-aws validate --s3-uri ...
*snip*
Error: Failed to initialize cluster driver: failed to read/create TLS assets: UnrecognizedClientException: The security token included in the request is invalid.
```

Resolves #490