### PR TITLE
Follow-up for the multi API endpoints support

### DIFF
--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -164,7 +164,7 @@ coreos:
         ExecStartPre=/usr/bin/docker run --rm -e SLEEP=false -v /opt/cni/bin:/host/opt/cni/bin {{ .CalicoCniImage.RepoWithTag }} /install-cni.sh
         {{end -}}
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
-        --api-servers={{.APIServerEndpoint}} \
+        --api-servers={{.APIEndpointURL}} \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
         {{/* Work-around until https://github.com/kubernetes/kubernetes/issues/43967 is fixed via https://github.com/kubernetes/kubernetes/pull/43995 */ -}}
         --cni-bin-dir=/opt/cni/bin \
@@ -245,7 +245,7 @@ coreos:
         --net=host \
         {{.HyperkubeImage.RepoWithTag}} \
           --exec=/kubectl -- \
-          --server=https://{{.APIEndpoint.DNSName}}:443 \
+          --server={{.APIEndpointURL}}:443 \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \
           --ignore-daemonsets \
@@ -408,7 +408,7 @@ coreos:
           -e LAUNCHCONFIGURATION=${LAUNCHCONFIGURATION} \
           {{.HyperkubeImage.RepoWithTag}} /bin/bash \
             -ec 'echo "placing labels and annotations with additional AWS parameters."; \
-             kctl="/kubectl --server=https://{{.APIEndpoint.DNSName}}:443 --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml"; \
+             kctl="/kubectl --server={{.APIEndpointURL}}:443 --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml"; \
              kctl_label="$kctl label --overwrite nodes/$(hostname)"; \
              kctl_annotate="$kctl annotate --overwrite nodes/$(hostname)"; \
              $kctl_label kube-aws.coreos.com/autoscalinggroup=${AUTOSCALINGGROUP}; \
@@ -710,7 +710,7 @@ write_files:
           'echo "tainting this node."
            hostname="'${hostname}'"
            taints=({{range $i, $taint := .Experimental.Taints}}"{{$taint.String}}" {{end}})
-           kubectl="/kubectl --server=https://{{.APIEndpoint.DNSName}}:443 --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml"
+           kubectl="/kubectl --server={{.APIEndpointURL}}:443 --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml"
            taint="$kubectl taint node --overwrite"
            for t in ${taints[@]}; do
              $taint "$hostname" "$t"
@@ -737,7 +737,7 @@ write_files:
             command:
             - /hyperkube
             - proxy
-            - --master={{.APIServerEndpoint}}
+            - --master={{.APIEndpointURL}}
             - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
             securityContext:
               privileged: true
@@ -830,7 +830,7 @@ write_files:
           "log_level": "info",
           "policy": {
             "type": "k8s",
-            "k8s_api_root": "https://{{.APIEndpoint.DNSName}}/api/v1/",
+            "k8s_api_root": "{{.APIEndpointURL}}/api/v1/",
             "k8s_client_key": "/etc/kubernetes/ssl/worker-key.pem",
             "k8s_client_certificate": "/etc/kubernetes/ssl/worker.pem",
             "k8s_certificate_authority": "/etc/kubernetes/ssl/ca.pem"

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -34,6 +34,11 @@ externalDNSName: {{.ExternalDNSName}}
 # Either specify hostedZoneId or hostedZone, but not both
 #hostedZoneId: ""
 
+# The name of one of API endpoints defined in `apiEndpoints` below to be written in kubeconfig and then used by admins
+# to access k8s API from their laptops, CI servers, or etc.
+# Required if there are 2 or more API endpoints defined in `apiEndpoints`
+#adminAPIEndpointName: versionedPublic
+
 # Kubernetes API endpoints with each one has a DNS name and is with/without a managed/unmanaged ELB, Route 53 record set
 # CAUTION: `externalDNSName` must be omitted when there are one or more items under `apiEndpoints`
 #apiEndpoints:

--- a/core/controlplane/config/templates/kubeconfig.tmpl
+++ b/core/controlplane/config/templates/kubeconfig.tmpl
@@ -3,7 +3,7 @@ kind: Config
 clusters:
 - cluster:
     certificate-authority: credentials/ca.pem
-    server: {{ .APIServerEndpoint }}
+    server: {{ .AdminAPIEndpointURL }}
   name: kube-aws-{{ .ClusterName }}-cluster
 contexts:
 - context:

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -272,6 +272,12 @@ func ClusterFromBytesWithEncryptService(data []byte, main *cfg.Config, encryptSe
 	return cluster, nil
 }
 
+// APIEndpointURL is the url of the API endpoint which is written in cloud-config-worker and used by kubelets in worker nodes
+// to access the apiserver
+func (c ProvidedConfig) APIEndpointURL() string {
+	return fmt.Sprintf("https://%s", c.APIEndpoint.DNSName)
+}
+
 func (c ProvidedConfig) Config() (*ComputedConfig, error) {
 	config := ComputedConfig{ProvidedConfig: c}
 

--- a/e2e/run
+++ b/e2e/run
@@ -13,7 +13,7 @@ ETCD_VERSION=${ETCD_VERSION:-}
 
 export KUBECONFIG
 
-USAGE_EXAMPLE="KUBE_AWS_CLUSTER_NAME=kubeawstest1 KUBE_AWS_KEY_NAME=name/of/ec2/key KUBE_AWS_KMS_KEY_ARN=arn:aws:kms:us-west-1:<account id>:key/your-key KUBE_AWS_REGION=us-west-1 KUBE_AWS_AVAILABILITY_ZONE=us-west-1b ./$0 [prepare|configure|start|all]"
+USAGE_EXAMPLE="KUBE_AWS_CLUSTER_NAME=kubeawstest1 KUBE_AWS_KEY_NAME=name/of/ec2/key KUBE_AWS_KMS_KEY_ARN=arn:aws:kms:us-west-1:<account id>:key/your-key KUBE_AWS_REGION=us-west-1 KUBE_AWS_AVAILABILITY_ZONE=us-west-1b ./$0 [init|configure|start|all]"
 
 if [ "${KUBE_AWS_CLUSTER_NAME}" == "" ]; then
   echo KUBE_AWS_CLUSTER_NAME is not set. Run this command like $USAGE_EXAMPLE 1>&2
@@ -69,7 +69,9 @@ main_all() {
   status=$(aws cloudformation describe-stacks --stack-name $(main_stack_name) --output json | jq -rc '.Stacks[0].StackStatus')
   if [ "$status" = "" ]; then
     if [ ! -e "${WORK_DIR}/cluster.yaml" ]; then
-      prepare
+      init
+    fi
+    if ! [ -d "${WORK_DIR}/credentials" -a -d "${WORK_DIR}/userdata" -a -e "${WORK_DIR}/kubeconfig" -a -d "${WORK_DIR}/stack-templates" ]; then
       configure
     fi
     if [ "$(main_status)" = "" ]; then
@@ -81,12 +83,10 @@ main_all() {
   fi
 }
 
-prepare() {
+init() {
   echo Creating or ensuring existence of the kube-aws assets directory ${WORK_DIR}
   mkdir -p ${WORK_DIR}
-}
 
-configure() {
   cd ${WORK_DIR}
 
   ${KUBE_AWS_CMD} init \
@@ -105,6 +105,12 @@ configure() {
   fi
 
   customize_cluster_yaml
+}
+
+configure() {
+  cd ${WORK_DIR}
+
+  rm -rf ./kubeconfig ./credentials ./userdata ./stack-templates ./exported
 
   ${KUBE_AWS_CMD} render
 

--- a/model/derived/api_endpoints.go
+++ b/model/derived/api_endpoints.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/kubernetes-incubator/kube-aws/model"
 	"sort"
+	"strings"
 )
 
 // APIEndpoints is a set of API endpoints associated to a Kubernetes cluster
@@ -78,7 +79,13 @@ func (e APIEndpoints) FindByName(name string) (*APIEndpoint, error) {
 	if exists {
 		return &endpoint, nil
 	}
-	return nil, fmt.Errorf("no API endpoint named \"%s\" defined under the `apiEndpoints[]`", name)
+
+	apiEndpointNames := []string{}
+	for _, endpoint := range e {
+		apiEndpointNames = append(apiEndpointNames, endpoint.Name)
+	}
+
+	return nil, fmt.Errorf("no API endpoint named \"%s\" defined under the `apiEndpoints[]`. The name must be one of: %s", name, strings.Join(apiEndpointNames, ", "))
 }
 
 // ELBRefs returns the names of all the ELBs to which controller nodes should be associated

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1401,6 +1401,8 @@ worker:
   # btw apiEndpointName can be defaulted to a private/public managed(hence unstable/possibly versioned but not stable/unversioned)
   # elb/round-robin if and only if there is only one. However we dont do the complex defaulting like that for now.
 
+adminAPIEndpointName: versionedPublic
+
 apiEndpoints:
 - name: unversionedPublic
   dnsName: api.example.com
@@ -3121,6 +3123,8 @@ worker:
   # no api endpoint named like that exists!
   apiEndpointName: unknownEndpoint
 
+adminAPIEndpointName: versionedPublic
+
 apiEndpoints:
 - name: unversionedPublic
   dnsName: api.example.com
@@ -3156,6 +3160,8 @@ worker:
   - name: pool1
     # this one is ng; no api endpoint named this exists!
     apiEndpointName: unknownEndpoint
+
+adminAPIEndpointName: versionedPublic
 
 apiEndpoints:
 - name: unversionedPublic
@@ -3208,6 +3214,8 @@ worker:
     apiEndpointName: unknownEndpoint
   - name: pool1
     # this one is ng; missing apiEndpointName
+
+adminAPIEndpointName: versionedPublic
 
 apiEndpoints:
 - name: unversionedPublic


### PR DESCRIPTION
This fixes the issue which prevented a k8s cluster from being properly configured when multiple API endpoints are defined in cluster.yaml.

It was due to empty API endpoint URLs embedded across userdata and kubeconfig.
AdminAPIEndpointURL and APIEndpointURL are implemented and injected to kubeconfig and cloud-config-worker respectively to fix the empty URLs issue.

In order to implement AdminAPIEndpointURL, `adminAPIEndpointName` in cluster.yaml is added and now required in addition to `apiEndpoints` and `worker.apiEndpointName`

Resolves #527

cc @c-knowles 