### PR TITLE
Bugfix: Add missing '/' when constructing the Autosave S3 put path

### DIFF
--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -116,7 +116,7 @@ func (c *ClusterRef) validateExistingVPCState(ec2Svc ec2Service) error {
 
 func NewCluster(cfg *config.Cluster, opts config.StackTemplateOptions, awsDebug bool) (*Cluster, error) {
 	cluster := NewClusterRef(cfg, awsDebug)
-	cluster.KubeResourcesAutosave.S3Path = fmt.Sprintf("%skube-aws/clusters/%s/backup", strings.TrimPrefix(opts.S3URI, "s3://"), cfg.ClusterName)
+	cluster.KubeResourcesAutosave.S3Path = fmt.Sprintf("%s/kube-aws/clusters/%s/backup", strings.TrimPrefix(opts.S3URI, "s3://"), cfg.ClusterName)
 	stackConfig, err := cluster.StackConfig(opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This issue prevented the autosave to push to s3 since it was pushing to the wrong path.