### PR TITLE
Allow customizing network ranges from which SSH accesses to nodes are allowed

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -145,11 +145,12 @@ func NewDefaultCluster() *Cluster {
 		// for kube-apiserver
 		ServiceCIDR: "10.3.0.0/24",
 		// for base cloudformation stack
-		TLSCADurationDays:   365 * 10,
-		TLSCertDurationDays: 365,
-		CreateRecordSet:     false,
-		RecordSetTTL:        300,
-		CustomSettings:      make(map[string]interface{}),
+		TLSCADurationDays:           365 * 10,
+		TLSCertDurationDays:         365,
+		CreateRecordSet:             false,
+		RecordSetTTL:                300,
+		SSHAccessAllowedSourceCIDRs: model.DefaultCIDRRanges(),
+		CustomSettings:              make(map[string]interface{}),
 		KubeResourcesAutosave: KubeResourcesAutosave{
 			Enabled: false,
 		},
@@ -647,8 +648,10 @@ type Cluster struct {
 	TLSCertDurationDays    int    `yaml:"tlsCertDurationDays,omitempty"`
 	HostedZoneID           string `yaml:"hostedZoneId,omitempty"`
 	ProvidedEncryptService EncryptService
-	CustomSettings         map[string]interface{} `yaml:"customSettings,omitempty"`
-	KubeResourcesAutosave  `yaml:"kubeResourcesAutosave,omitempty"`
+	// SSHAccessAllowedSourceCIDRs is network ranges of sources you'd like SSH accesses to be allowed from, in CIDR notation
+	SSHAccessAllowedSourceCIDRs model.CIDRRanges       `yaml:"sshAccessAllowedSourceCIDRs,omitempty"`
+	CustomSettings              map[string]interface{} `yaml:"customSettings,omitempty"`
+	KubeResourcesAutosave       `yaml:"kubeResourcesAutosave,omitempty"`
 }
 
 type Experimental struct {

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -34,6 +34,12 @@ externalDNSName: {{.ExternalDNSName}}
 # Either specify hostedZoneId or hostedZone, but not both
 #hostedZoneId: ""
 
+# Network ranges of sources you'd like SSH accesses to be allowed from, in CIDR notation. Defaults to ["0.0.0.0/0"] which allows any sources.
+# Explicitly set to an empty array to completely disable it.
+# If you do that, probably you would like to set securityGroupIds to provide this worker node pool an existing SG with a SSH access allowed from specific ranges.
+#sshAccessAllowedSourceCIDRs:
+#- 0.0.0.0/0
+
 # The name of one of API endpoints defined in `apiEndpoints` below to be written in kubeconfig and then used by admins
 # to access k8s API from their laptops, CI servers, or etc.
 # Required if there are 2 or more API endpoints defined in `apiEndpoints`
@@ -138,6 +144,13 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    type: gp2
 #    # Number of I/O operations per second (IOPS) that the controller node disk supports. Leave blank if controllerRootVolumeType is not io1
 #    iops: 0
+#
+#  # Existing security groups attached to controller nodes which are typically used to
+#  # (1) allow access from controller nodes to services running on an existing infrastructure
+#  # (2) allow ssh accesses from bastions when `sshAccessAllowedSourceCIDRs` are explicitly set to an empty array
+#  securityGroupIds:
+#    - sg-1234abcd
+#    - sg-5678efab
 #
 #  # Auto Scaling Group definition for controllers. If only `controllerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
 #  autoScalingGroup:
@@ -551,6 +564,12 @@ worker:
 #    # References subnets defined under the top-level `subnets` key by their names
 #    - name: ManagedPrivateSubnet1
 #    - name: ManagedPrivateSubnet2
+#
+#  # Existing security groups attached to etcd nodes which are typically used to
+#  # allow ssh accesses from bastions when `sshAccessAllowedSourceCIDRs` are explicitly set to an empty array
+#  securityGroupIds:
+#    - sg-1234abcd
+#    - sg-5678efab
 #
 #  # The version of etcd to be used. Set to e.g. "3.1.3" to use etcd3
 #  version: 2

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -439,12 +439,13 @@
     {{if $etcdInstance.NetworkInterfaceManaged}}
     "{{$etcdInstance.NetworkInterfaceLogicalName}}": {
       "Properties": {
-          "SubnetId": {{$etcdInstance.SubnetRef}},
-          "GroupSet": [
-            {
-              "Ref": "SecurityGroupEtcd"
-            }
-          ]
+        "SubnetId": {{$etcdInstance.SubnetRef}},
+        "GroupSet": [
+          {{range $sgIndex, $sgRef := $.Etcd.SecurityGroupRefs}}
+          {{if gt $sgIndex 0}},{{end}}
+          {{$sgRef}}
+          {{end}}
+        ]
       },
       "Type": "AWS::EC2::NetworkInterface"
     },
@@ -672,9 +673,10 @@
         "InstanceType": "{{$.Etcd.InstanceType}}",
         {{if $.KeyName}}"KeyName": "{{$.KeyName}}",{{end}}
         "SecurityGroups": [
-          {
-            "Ref": "SecurityGroupEtcd"
-          }
+          {{range $sgIndex, $sgRef := $.Etcd.SecurityGroupRefs}}
+          {{if gt $sgIndex 0}},{{end}}
+          {{$sgRef}}
+          {{end}}
         ],
         "PlacementTenancy": "{{$.Etcd.Tenancy}}",
         "UserData": { "Fn::Base64": { "Fn::Join" : ["\n", [
@@ -720,9 +722,10 @@
         "InstanceType": "{{.Controller.InstanceType}}",
         {{if .KeyName}}"KeyName": "{{.KeyName}}",{{end}}
         "SecurityGroups": [
-          {
-            "Ref": "SecurityGroupController"
-          }
+          {{range $sgIndex, $sgRef := $.Controller.SecurityGroupRefs}}
+          {{if gt $sgIndex 0}},{{end}}
+          {{$sgRef}}
+          {{end}}
         ],
         "PlacementTenancy": "{{ .Controller.Tenancy }}",
         "UserData": { "Fn::Base64": { "Fn::Join" : ["\n", [
@@ -880,12 +883,14 @@
             "IpProtocol": "icmp",
             "ToPort": -1
           },
+          {{ range $_, $r := $.SSHAccessAllowedSourceCIDRs -}}
           {
-            "CidrIp": "0.0.0.0/0",
+            "CidrIp": "{{$r}}",
             "FromPort": 22,
             "IpProtocol": "tcp",
             "ToPort": 22
           },
+          {{end -}}
           {
             "SourceSecurityGroupId" : { "Ref" : "SecurityGroupElbAPIServer" },
             "FromPort": 443,
@@ -986,17 +991,19 @@
           }
         ],
         "SecurityGroupIngress": [
+          {{ range $_, $r := $.SSHAccessAllowedSourceCIDRs -}}
+          {
+            "CidrIp": "{{$r}}",
+            "FromPort": 22,
+            "IpProtocol": "tcp",
+            "ToPort": 22
+          },
+          {{end -}}
           {
             "CidrIp": "0.0.0.0/0",
             "FromPort": -1,
             "IpProtocol": "icmp",
             "ToPort": -1
-          },
-          {
-            "CidrIp": "0.0.0.0/0",
-            "FromPort": 22,
-            "IpProtocol": "tcp",
-            "ToPort": 22
           }
         ],
         "Tags": [
@@ -1159,17 +1166,19 @@
           }
         ],
         "SecurityGroupIngress": [
+          {{ range $_, $r := $.SSHAccessAllowedSourceCIDRs -}}
+          {
+            "CidrIp": "{{$r}}",
+            "FromPort": 22,
+            "IpProtocol": "tcp",
+            "ToPort": 22
+          },
+          {{end -}}
           {
             "CidrIp": "0.0.0.0/0",
             "FromPort": 3,
             "IpProtocol": "icmp",
             "ToPort": -1
-          },
-          {
-            "CidrIp": "0.0.0.0/0",
-            "FromPort": 22,
-            "IpProtocol": "tcp",
-            "ToPort": 22
           }
         ],
         "Tags": [

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -85,3 +85,5 @@ The test cluster created by the `e2e/run` script can be customized via various e
 `ETCD_INTERNAL_DOMAIN_NAME=internal.example.com`: Used only when `ETCD_MEMBER_IDENTITY_PROVIDER` is set to "eni". See comments in `cluster.yaml` for more details.
 
 `KUBE_AWS_CLUSTER_NAME=mycluster`: The name of a kube-aws main cluster i.e. a cloudformation stack for the main cluster. Must be unique in your AWS account.
+
+`LIMIT_SSH_ACCESS`: When set to a non-empty value, limit ssh access to all the nodes to be allowed from only your public IP.

--- a/e2e/run
+++ b/e2e/run
@@ -141,6 +141,11 @@ customize_cluster_yaml() {
     echo -e "workerSecurityGroupIds:\n- $(testinfra_glue_sg)" >> cluster.yaml
   fi
 
+  if [ "${LIMIT_SSH_ACCESS}" != "" ]; then
+    ip=$(curl -s https://api.ipify.org)
+    echo -e "sshAccessAllowedSourceCIDRs:\n- $ip/32" >> cluster.yaml
+  fi
+
   echo -e "
 worker:
   nodePools:

--- a/model/cidr_range.go
+++ b/model/cidr_range.go
@@ -1,0 +1,42 @@
+package model
+
+import (
+	"fmt"
+	"net"
+)
+
+// CIDRRanges represents IP network ranges in CIDR notation
+type CIDRRanges []CIDRRange
+
+// CIDRRange represents an IP network range in CIDR notation
+// See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html#cfn-ec2-security-group-ingress-cidrip
+type CIDRRange struct {
+	str string
+}
+
+func DefaultCIDRRanges() CIDRRanges {
+	return CIDRRanges{
+		{"0.0.0.0/0"},
+	}
+}
+
+func (c *CIDRRange) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var cidr string
+	if err := unmarshal(&cidr); err != nil {
+		return fmt.Errorf("failed to parse CIDR range: %v", err)
+	}
+
+	_, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return fmt.Errorf("failed to parse CIDR range: %v", err)
+	}
+
+	*c = CIDRRange{str: cidr}
+
+	return nil
+}
+
+// String returns the string representation of this CIDR range
+func (c CIDRRange) String() string {
+	return c.str
+}

--- a/model/cidr_range_test.go
+++ b/model/cidr_range_test.go
@@ -1,0 +1,74 @@
+package model
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+func TestCIDRRangesExtractFromYAML(t *testing.T) {
+	t.Run("WhenOverrodeWithNonEmpty", func(t *testing.T) {
+		rs := struct {
+			CIDRRanges `yaml:"rs"`
+		}{DefaultCIDRRanges()}
+		err := yaml.Unmarshal([]byte("rs:\n- \"1.2.3.255/32\"\n"), &rs)
+		if err != nil {
+			t.Errorf("failed ot extract CIDR ranges from yaml: %v", err)
+			t.FailNow()
+		}
+		expected := "1.2.3.255/32"
+		actual := rs.CIDRRanges[0].str
+		if actual != expected {
+			t.Errorf("unexpected cidr range extracted. expected = %s, actual = %s", expected, actual)
+		}
+	})
+	t.Run("WhenOverrodeWithEmpty", func(t *testing.T) {
+		rs := struct {
+			CIDRRanges `yaml:"rs"`
+		}{DefaultCIDRRanges()}
+		err := yaml.Unmarshal([]byte("rs:\n"), &rs)
+		if err != nil {
+			t.Errorf("failed ot extract CIDR ranges from yaml: %v", err)
+			t.FailNow()
+		}
+		if len(rs.CIDRRanges) != 0 {
+			t.Errorf("unexpected cidr ranges to be empty, but was: %+v(len=%d)", rs.CIDRRanges, len(rs.CIDRRanges))
+		}
+	})
+	t.Run("WhenOmitted", func(t *testing.T) {
+		rs := struct {
+			CIDRRanges `yaml:"rs"`
+		}{DefaultCIDRRanges()}
+		err := yaml.Unmarshal([]byte(""), &rs)
+		if err != nil {
+			t.Errorf("failed ot extract CIDR ranges from yaml: %v", err)
+			t.FailNow()
+		}
+		expected := "0.0.0.0/0"
+		actual := rs.CIDRRanges[0].str
+		if actual != expected {
+			t.Errorf("unexpected cidr range extracted. expected = %s, actual = %s", expected, actual)
+		}
+	})
+}
+
+func TestCIDRRangeExtractFromYAML(t *testing.T) {
+	r := CIDRRange{}
+	err := yaml.Unmarshal([]byte("\"0.0.0.0/0\""), &r)
+	if err != nil {
+		t.Errorf("failed to extract CIDR range from yaml: %v", err)
+	}
+	expected := "0.0.0.0/0"
+	if r.str != expected {
+		t.Errorf("unexpected cidr range extracted. expected = %s, actual = %s", expected, r.str)
+	}
+}
+
+func TestCIDRRangeString(t *testing.T) {
+	r := CIDRRange{str: "0.0.0.0/0"}
+	expected := "0.0.0.0/0"
+	actual := fmt.Sprintf("%s", r)
+	if actual != expected {
+		t.Errorf("unexpected string rendered. expected = %s, actual = %s", expected, actual)
+	}
+}

--- a/model/controller.go
+++ b/model/controller.go
@@ -1,6 +1,8 @@
 package model
 
-import "errors"
+import (
+	"errors"
+)
 
 // TODO Merge this with NodePoolConfig
 type Controller struct {
@@ -9,6 +11,7 @@ type Controller struct {
 	EC2Instance        `yaml:",inline"`
 	LoadBalancer       ControllerElb       `yaml:"loadBalancer,omitempty"`
 	ManagedIamRoleName string              `yaml:"managedIamRoleName,omitempty"`
+	SecurityGroupIds   []string            `yaml:"securityGroupIds"`
 	Subnets            []Subnet            `yaml:"subnets,omitempty"`
 	CustomFiles        []CustomFile        `yaml:"customFiles,omitempty"`
 	CustomSystemdUnits []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
@@ -35,6 +38,21 @@ func NewDefaultController() Controller {
 
 func (c Controller) LogicalName() string {
 	return "Controllers"
+}
+
+func (c Controller) SecurityGroupRefs() []string {
+	refs := []string{}
+
+	for _, id := range c.SecurityGroupIds {
+		refs = append(refs, id)
+	}
+
+	refs = append(
+		refs,
+		`{"Ref":"SecurityGroupController"}`,
+	)
+
+	return refs
 }
 
 func (c Controller) Validate() error {

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -12,6 +12,7 @@ type Etcd struct {
 	Snapshot           EtcdSnapshot         `yaml:"snapshot,omitempty"`
 	EC2Instance        `yaml:",inline"`
 	Nodes              []EtcdNode          `yaml:"nodes,omitempty"`
+	SecurityGroupIds   []string            `yaml:"securityGroupIds"`
 	Subnets            []Subnet            `yaml:"subnets,omitempty"`
 	CustomFiles        []CustomFile        `yaml:"customFiles,omitempty"`
 	CustomSystemdUnits []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
@@ -121,6 +122,21 @@ func (e Etcd) HostedZoneLogicalName() (string, error) {
 
 func (e Etcd) KMSKeyARN() string {
 	return e.Cluster.KMSKeyARN
+}
+
+func (e Etcd) SecurityGroupRefs() []string {
+	refs := []string{}
+
+	for _, id := range e.SecurityGroupIds {
+		refs = append(refs, id)
+	}
+
+	refs = append(
+		refs,
+		`{"Ref":"SecurityGroupEtcd"}`,
+	)
+
+	return refs
 }
 
 func (e Etcd) SystemdUnitName() string {

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -2927,6 +2927,60 @@ etcdDataVolumeEncrypted: true
 				},
 			},
 		},
+		{
+			context: "WithSSHAccessAllowedSourceCIDRsSpecified",
+			configYaml: minimalValidConfigYaml + `
+sshAccessAllowedSourceCIDRs:
+- 1.2.3.255/32
+`,
+			assertConfig: []ConfigTester{
+				func(c *config.Config, t *testing.T) {
+					l := len(c.SSHAccessAllowedSourceCIDRs)
+					if l != 1 {
+						t.Errorf("unexpected size of sshAccessAllowedSouceCIDRs: %d", l)
+						t.FailNow()
+					}
+					actual := c.SSHAccessAllowedSourceCIDRs[0].String()
+					expected := "1.2.3.255/32"
+					if actual != expected {
+						t.Errorf("unexpected cidr in sshAccessAllowedSourecCIDRs[0]. expected = %s, actual = %s", expected, actual)
+					}
+				},
+			},
+		},
+		{
+			context:    "WithSSHAccessAllowedSourceCIDRsOmitted",
+			configYaml: minimalValidConfigYaml,
+			assertConfig: []ConfigTester{
+				func(c *config.Config, t *testing.T) {
+					l := len(c.SSHAccessAllowedSourceCIDRs)
+					if l != 1 {
+						t.Errorf("unexpected size of sshAccessAllowedSouceCIDRs: %d", l)
+						t.FailNow()
+					}
+					actual := c.SSHAccessAllowedSourceCIDRs[0].String()
+					expected := "0.0.0.0/0"
+					if actual != expected {
+						t.Errorf("unexpected cidr in sshAccessAllowedSourecCIDRs[0]. expected = %s, actual = %s", expected, actual)
+					}
+				},
+			},
+		},
+		{
+			context: "WithSSHAccessAllowedSourceCIDRsEmptied",
+			configYaml: minimalValidConfigYaml + `
+sshAccessAllowedSourceCIDRs:
+`,
+			assertConfig: []ConfigTester{
+				func(c *config.Config, t *testing.T) {
+					l := len(c.SSHAccessAllowedSourceCIDRs)
+					if l != 0 {
+						t.Errorf("unexpected size of sshAccessAllowedSouceCIDRs: %d", l)
+						t.FailNow()
+					}
+				},
+			},
+		},
 	}
 
 	for _, validCase := range validCases {


### PR DESCRIPTION
It has been hard-coded to `0.0.0.0/0` which isn't desirable for security.
From now on, you can use `sshAccessAllowedSourceCIDRs` to override the list of ranges allowed.
Explicitly setting it to an empty array would result in nodes unable to be SSHed. However, doing so while configuring `worker.securityGroupIds`, `controller.securityGroupIds` and `etcd.securityGroupIds` would allow you to fully customize how SSH accesses are allowed - including not only ranges but ports to be allowed.

Closes #338

cc @c-knowles @swestcott 
