### PR TITLE
Allow customizing network ranges from which Kubernetes API accesses are allowed

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -59,6 +59,7 @@ externalDNSName: {{.ExternalDNSName}}
 #    # Specifies an existing load-balancer used for load-balancing controller nodes and serving this endpoint
 #    # Setting id requires all the other settings excluding `name` to be omitted because reusing an ELB implies that configuring other resources
 #    # like a Route 53 record set for the endpoint is now your responsibility!
+#    # Also, don't forget to add controller.securityGroupIds to include a glue SG to allow your existing ELB to access controller nodes created by kube-aws
 #    id: existing-elb
 #
 #    # Set to false when you want to disable creation of the record set for this api load balancer
@@ -82,6 +83,17 @@ externalDNSName: {{.ExternalDNSName}}
 #    # Must be omitted when `id` is specified
 #    hostedZone:
 #      id: hostedzone-abc
+#
+#    # Network ranges of sources you'd like Kubernetes API accesses to be allowed from, in CIDR notation. Defaults to ["0.0.0.0/0"] which allows any sources.
+#    # Explicitly set to an empty array to completely disable it.
+#    # If you do that, probably you would like to set securityGroupIds to provide this load balancer an existing SG with a Kubernetes API access allowed from specific ranges.
+#    apiAccessAllowedSourceCIDRs:
+#    #- 0.0.0.0/0
+#
+#    # Existing security groups attached to this load balancer which are typically used to
+#    # allow Kubernetes API accesses from admins and/or CD systems when `apiAccessAllowedSourceCIDRs` are explicitly set to an empty array
+#    securityGroupIds:
+#    - sg-1234567
 #
 #  #
 #  # Common configuration #1: Unversioned, internet-facing API endpoint

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -811,11 +811,46 @@
         {{else}}
         "Scheme": "internet-facing",
         {{end}}
-        "SecurityGroups" : [
-          { "Ref" : "SecurityGroupElbAPIServer" }
+        "SecurityGroups": [
+          {{range $sgIndex, $sgRef := .LoadBalancer.SecurityGroupRefs}}
+          {{if gt $sgIndex 0}},{{end}}
+          {{$sgRef}}
+          {{end}}
         ]
       }
     },
+    {{if .LoadBalancer.ManageSecurityGroup -}}
+    "{{.LoadBalancer.SecurityGroupLogicalName}}" : {
+      "Properties": {
+        "GroupDescription": {
+          "Ref": "AWS::StackName"
+        },
+        "SecurityGroupIngress": [
+          {{ range $j, $r := .LoadBalancer.APIAccessAllowedSourceCIDRs -}}
+          {{if gt $j 0}},{{end}}
+          {
+            "CidrIp": "{{$r}}",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443
+          }
+          {{end}}
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-sg-api-endpoint-{{$i}}"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
+    {{end -}}
     {{end -}}
     {{end -}}
     "SecurityGroupElbAPIServer" : {
@@ -824,12 +859,6 @@
           "Ref": "AWS::StackName"
         },
         "SecurityGroupIngress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443
-          },
           {
              "CidrIp": "0.0.0.0/0",
              "FromPort": -1,
@@ -844,10 +873,10 @@
           },
           {
             "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Value": "{{$.ClusterName}}"
           }
         ],
-        "VpcId": {{.VPCRef}}
+        "VpcId": {{$.VPCRef}}
       },
       "Type": "AWS::EC2::SecurityGroup"
     },

--- a/model/api_endpoints.go
+++ b/model/api_endpoints.go
@@ -16,7 +16,8 @@ func NewDefaultAPIEndpoints(dnsName string, subnets []SubnetReference, hostedZon
 			Name:    DefaultAPIEndpointName,
 			DNSName: dnsName,
 			LoadBalancer: APIEndpointLB{
-				SubnetReferences: subnets,
+				APIAccessAllowedSourceCIDRs: DefaultCIDRRanges(),
+				SubnetReferences:            subnets,
 				HostedZone: HostedZone{
 					Identifier: Identifier{
 						ID: hostedZoneId,

--- a/model/derived/api_endpoint_lb.go
+++ b/model/derived/api_endpoint_lb.go
@@ -49,3 +49,27 @@ func (b APIEndpointLB) Ref() string {
 		return b.LogicalName()
 	})
 }
+
+func (b APIEndpointLB) SecurityGroupLogicalName() string {
+	return fmt.Sprintf("APIEndpoint%sSG", strings.Title(b.Name))
+}
+
+// SecurityGroupRefs contains CloudFormation resource references for additional SGs associated to this LB
+func (b APIEndpointLB) SecurityGroupRefs() []string {
+	refs := []string{}
+
+	for _, id := range b.SecurityGroupIds {
+		refs = append(refs, id)
+	}
+
+	if b.ManageSecurityGroup() {
+		refs = append(refs, fmt.Sprintf(`{"Ref":"%s"}`, b.SecurityGroupLogicalName()))
+	}
+
+	refs = append(
+		refs,
+		`{"Ref":"SecurityGroupElbAPIServer"}`,
+	)
+
+	return refs
+}


### PR DESCRIPTION
It has been hard-coded to `0.0.0.0/0` which isn't desirable for security.

From now on, you can use `apiEndpoints[].loadBalancer.apiAccessAllowedSourceCIDRs` to override the list of ranges allowed.
Explicitly setting it to an empty array would result in a load balancer which is completely unable to be accessed. However, doing so while configuring `apiEndpoints[].loadBalancer.securityGroupIds` would allow you to fully customize how API accesses are allowed - including not only ranges but ports to be allowed.

Similar to/Depends on #551
Closes #544