### PR TITLE
Deprecate externalDNSName/createRecordSet/hostedZoneId

### DIFF
--- a/Documentation/kubernetes-on-aws-render.md
+++ b/Documentation/kubernetes-on-aws-render.md
@@ -251,14 +251,28 @@ useCalico: true
 
 `kube-aws` can optionally create an ALIAS record for the controller's ELB in an existing Route53 hosted zone.
 
-Edit the `cluster.yaml` file:
+Just run `kube-aws init` with the flag `--hosted-zone-id` to specify the id of the hosted zone in which the record is created.
+
+If you've run `kube-aws init` without the flag, edit the `cluster.yaml` file to add `loadBalancer.hostedZone.id` under the first item of `apiEndpoints`:
 
 ```yaml
-externalDNSName: kubernetes.staging.example.com
-createRecordSet: true
-hostedZoneId: A12B3CDE4FG5HI
+apiEndpoints:
+- name: default
+  dNSName: kubernetes.staging.example.com
+  loadBalancer:
+    hostedZone:
+      id: A12B3CDE4FG5HI
+
 # DEPRECATED: use hostedZoneId instead
 #hostedZone: staging.example.com
+
+# DEPRECATED: use loadBalancer.hostedZone.id instead
+#hostedZoneId: A12B3CDE4FG5HI
+
+# DEPRECATED: use loadBalancer.createRecordSet instead
+# This is even implied to be true when loadBalancer.hostedZone.id is specified
+#createRecordSet: true
+
 ```
 
 If `createRecordSet` is not set to true, the deployer will be responsible for making externalDNSName routable to the the ELB managing the controller nodes after the cluster is created.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -24,6 +24,7 @@ func init() {
 	RootCmd.AddCommand(cmdInit)
 	cmdInit.Flags().StringVar(&initOpts.ClusterName, "cluster-name", "", "The name of this cluster. This will be the name of the cloudformation stack")
 	cmdInit.Flags().StringVar(&initOpts.ExternalDNSName, "external-dns-name", "", "The hostname that will route to the api server")
+	cmdInit.Flags().StringVar(&initOpts.HostedZoneID, "hosted-zone-id", "", "The hosted zone in which a Route53 record set for a k8s API endpoint is created")
 	cmdInit.Flags().StringVar(&initOpts.Region.Name, "region", "", "The AWS region to deploy to")
 	cmdInit.Flags().StringVar(&initOpts.AvailabilityZone, "availability-zone", "", "The AWS availability-zone to deploy to")
 	cmdInit.Flags().StringVar(&initOpts.KeyName, "key-name", "", "The AWS key-pair for ssh access to nodes")

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1371,7 +1371,8 @@ func (c DeploymentSettings) Valid() (*DeploymentValidationResult, error) {
 		}
 
 		for i, a := range instanceCIDRs {
-			for j, b := range instanceCIDRs[i+1:] {
+			for j := i + 1; j < len(instanceCIDRs); j++ {
+				b := instanceCIDRs[j]
 				if netutil.CidrOverlap(a, b) {
 					return nil, fmt.Errorf("CIDR of subnet %d (%s) overlaps with CIDR of subnet %d (%s)", i, a, j, b)
 				}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -3,12 +3,8 @@
 # name must not conflict with an existing cluster.
 clusterName: {{.ClusterName}}
 
-# DNS name routable to the Kubernetes controller nodes
-# from worker nodes and external clients. Configure the options
-# below if you'd like kube-aws to create a Route53 record sets/hosted zones
-# for you.  Otherwise the deployer is responsible for making this name routable
-# If you'd like to have 2 or more DNS names, please omit this and use `apiEndpoints` instead
-externalDNSName: {{.ExternalDNSName}}
+# CAUTION: Deprecated and will be removed in v0.9.7. Please use apiEndpoints[].dnsName instead
+#externalDNSName:
 
 # CoreOS release channel to use. Currently supported options: alpha, beta, stable
 # See coreos.com/releases for more information
@@ -18,17 +14,14 @@ externalDNSName: {{.ExternalDNSName}}
 # If omitted, the latest AMI for the releaseChannel is used.
 #amiId: ""
 
-# Set to true if you want kube-aws to create a Route53 Alias Record pointing to the controller ELB for you.
-#createRecordSet: false
+# CAUTION: Deprecated and will be removed in v0.9.7. Please use apiEndpoints[].loadBalancer.createRecordSet instead
+#createRecordSet:
 
-# TTL in seconds for the Route53 RecordSet created if createRecordSet is set to true.
-#recordSetTTL: 300
+# CAUTION: Deprecated and will be removed in v0.9.7. Please use apiEndpoints[].loadBalancer.recordSetTTL instead
+#recordSetTTL:
 
-# DEPRECATED: use hostedZoneId instead
-# The name of the hosted zone to add the externalDNSName to,
-# E.g: "google.com".  This needs to already exist, kube-aws will not create
-# it for you.
-#hostedZone: ""
+# CAUTION: Deprecated and will be removed in v0.9.7. Please use apiEndpoints[].loadBalancer.hostedZone.id instead
+#hostedZoneId:
 
 # The ID of hosted zone to add the externalDNSName to.
 # Either specify hostedZoneId or hostedZone, but not both
@@ -47,43 +40,58 @@ externalDNSName: {{.ExternalDNSName}}
 
 # Kubernetes API endpoints with each one has a DNS name and is with/without a managed/unmanaged ELB, Route 53 record set
 # CAUTION: `externalDNSName` must be omitted when there are one or more items under `apiEndpoints`
-#apiEndpoints:
-#  # The unique name of this API endpoint used to identify it inside CloudFormation stacks or
-#  # to be referenced from other parts of cluster.yaml
-#- name: template
-#
-#  # DNS name for this endpoint, added to the kube-apiserver TLS cert
-#  dnsName: dns-name.tld
-#
-#  loadBalancer:
-#    # Specifies an existing load-balancer used for load-balancing controller nodes and serving this endpoint
-#    # Setting id requires all the other settings excluding `name` to be omitted because reusing an ELB implies that configuring other resources
-#    # like a Route 53 record set for the endpoint is now your responsibility!
-#    # Also, don't forget to add controller.securityGroupIds to include a glue SG to allow your existing ELB to access controller nodes created by kube-aws
-#    id: existing-elb
-#
-#    # Set to false when you want to disable creation of the record set for this api load balancer
-#    # Must be omitted when `id` is specified
-#    createRecordSet: true
-#
-#    # All the subnets assigned to this load-balancer. Specified only when this load balancer is not reused but managed one
-#    # Must be omitted when `id` is specified
-#    subnets:
-#    - name: managedPublic1
-#
-#    # Set to true so that the managed ELB becomes an `internal` one rather than `internet-facing` one
-#    # When set to true while subnets are omitted, one or more private subnets in the top-level `subnets` must exist
-#    # Must be omitted when `id` is specified
-#    private: true
-#
-#    # TTL in seconds for the Route53 RecordSet created if createRecordSet is set to true.
-#    recordSetTTL: 300
-#
-#    # The Route 53 hosted zone is where the resulting Alias record is created for this endpoint
-#    # Must be omitted when `id` is specified
-#    hostedZone:
-#      id: hostedzone-abc
-#
+apiEndpoints:
+- # The unique name of this API endpoint used to identify it inside CloudFormation stacks or
+  # to be referenced from other parts of cluster.yaml
+  name: default
+
+  # DNS name for this endpoint, added to the kube-apiserver TLS cert
+  # It must be somehow routable to the Kubernetes controller nodes
+  # from worker nodes and external clients. Configure the options
+  # below if you'd like kube-aws to create a Route53 record sets/hosted zones
+  # for you.  Otherwise the deployer is responsible for making this name routable
+  dnsName: {{.ExternalDNSName}}
+
+  # Configuration for an ELB serving this endpoint
+  # Omit all the settings when you want kube-aws not to provision an ELB for you
+  loadBalancer:
+    # Specifies an existing load-balancer used for load-balancing controller nodes and serving this endpoint
+    # Setting id requires all the other settings excluding `name` to be omitted because reusing an ELB implies that configuring other resources
+    # like a Route 53 record set for the endpoint is now your responsibility!
+    # Also, don't forget to add controller.securityGroupIds to include a glue SG to allow your existing ELB to access controller nodes created by kube-aws
+    #id: existing-elb
+
+    # Set to true when you want kube-aws to create a Route53 ALIAS record set for this API load balancer for you
+    # Must be omitted when `id` is specified
+    {{if .HostedZoneID -}}
+    createRecordSet: true
+    {{else -}}
+    createRecordSet: false
+    {{- end}}
+    # All the subnets assigned to this load-balancer. Specified only when this load balancer is not reused but managed one
+    # Must be omitted when `id` is specified
+    #subnets:
+    #- name: managedPublic1
+
+    # Set to true so that the managed ELB becomes an `internal` one rather than `internet-facing` one
+    # When set to true while subnets are omitted, one or more private subnets in the top-level `subnets` must exist
+    # Must be omitted when `id` is specified
+    #private: false
+
+    # TTL in seconds for the Route53 RecordSet created if createRecordSet is set to true.
+    #recordSetTTL: 300
+
+    # The Route 53 hosted zone is where the resulting Alias record is created for this endpoint
+    # Must be omitted when `id` is specified
+    {{if .HostedZoneID -}}
+    hostedZone:
+      # The ID of hosted zone to add the dnsName to.
+      id: {{.HostedZoneID}}
+    {{else -}}
+    #hostedZone:
+    #  # The ID of hosted zone to add the dnsName to.
+    #  id: ""
+    {{- end}}
 #    # Network ranges of sources you'd like Kubernetes API accesses to be allowed from, in CIDR notation. Defaults to ["0.0.0.0/0"] which allows any sources.
 #    # Explicitly set to an empty array to completely disable it.
 #    # If you do that, probably you would like to set securityGroupIds to provide this load balancer an existing SG with a Kubernetes API access allowed from specific ranges.

--- a/e2e/run
+++ b/e2e/run
@@ -95,10 +95,8 @@ init() {
     --region ${KUBE_AWS_REGION} \
     --availability-zone ${KUBE_AWS_AVAILABILITY_ZONE} \
     --key-name ${KUBE_AWS_KEY_NAME} \
-    --kms-key-arn ${KUBE_AWS_KMS_KEY_ARN}
-
-  echo "hostedZoneId: ${KUBE_AWS_HOSTED_ZONE_ID}" >> cluster.yaml
-  echo 'createRecordSet: true' >> cluster.yaml
+    --kms-key-arn ${KUBE_AWS_KMS_KEY_ARN} \
+    --hosted-zone-id ${KUBE_AWS_HOSTED_ZONE_ID}
 
   if [ "${KUBE_AWS_USE_CALICO}" != "" ]; then
     echo 'useCalico: true' >> cluster.yaml

--- a/model/api_endpoints.go
+++ b/model/api_endpoints.go
@@ -6,7 +6,7 @@ import (
 
 type APIEndpoints []APIEndpoint
 
-// DefaultAPIEndpointName returns the default endpoint name used when you've omitted the `name` key in each item of the `apiEndpintsp[]` array
+// DefaultAPIEndpointName is the default endpoint name used when you've omitted `apiEndpoints` but not `externalDNSName`
 const DefaultAPIEndpointName = "Default"
 
 // NewDefaultAPIEndpoints creates the slice of API endpoints containing only the default one which is with arbitrary DNS name and an ELB

--- a/model/derived/api_endpoints.go
+++ b/model/derived/api_endpoints.go
@@ -114,5 +114,13 @@ func (e APIEndpoints) ManagedELBLogicalNames() []string {
 // GetDefault returns the default API endpoint identified by its name.
 // The name is defined as DefaultAPIEndpointName
 func (e APIEndpoints) GetDefault() APIEndpoint {
-	return e[model.DefaultAPIEndpointName]
+	if len(e) != 1 {
+		panic(fmt.Sprintf("[bug] GetDefault invoked with an unexpected number of API endpoints: %d", len(e)))
+	}
+	var name string
+	for n, _ := range e {
+		name = n
+		break
+	}
+	return e[name]
 }


### PR DESCRIPTION
In favor of recently added `apiEndpoints[]`.

Also adds the new flag `--hosted-zone-id` to the `kube-aws up` command to pre-populate `apiEndpoints[].loadBalancer.hostedZone.id`. It is useful if you'd been scripting like `echo "hostedZoneId: ${FOO}" >> cluster.yaml` to automatically enabling record set creation - your former method won't work anymore due to the fact that the new setting is deeply nested.

Closes #545