### PR TITLE
Don't mount /var/lib/rkt into kubelet

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -154,14 +154,16 @@ coreos:
         --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
         --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
         --mount volume=dns,target=/etc/resolv.conf \
+        {{ if eq .ContainerRuntime "rkt" -}}
         --volume rkt,kind=host,source=/opt/bin/host-rkt \
         --mount volume=rkt,target=/usr/bin/rkt \
         --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
         --mount volume=var-lib-rkt,target=/var/lib/rkt \
-        --volume var-lib-cni,kind=host,source=/var/lib/cni \
-        --mount volume=var-lib-cni,target=/var/lib/cni \
         --volume stage,kind=host,source=/tmp \
         --mount volume=stage,target=/tmp \
+        {{ end -}}
+        --volume var-lib-cni,kind=host,source=/var/lib/cni \
+        --mount volume=var-lib-cni,target=/var/lib/cni \
         --volume var-log,kind=host,source=/var/log \
         --mount volume=var-log,target=/var/log{{ if .UseCalico }} \
         --volume cni-bin,kind=host,source=/opt/cni/bin \

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -150,14 +150,16 @@ coreos:
         --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
         --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
         --mount volume=dns,target=/etc/resolv.conf \
+        {{ if eq .ContainerRuntime "rkt" -}}
         --volume rkt,kind=host,source=/opt/bin/host-rkt \
         --mount volume=rkt,target=/usr/bin/rkt \
         --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
         --mount volume=var-lib-rkt,target=/var/lib/rkt \
-        --volume var-lib-cni,kind=host,source=/var/lib/cni \
-        --mount volume=var-lib-cni,target=/var/lib/cni \
         --volume stage,kind=host,source=/tmp \
         --mount volume=stage,target=/tmp \
+        {{ end -}}
+        --volume var-lib-cni,kind=host,source=/var/lib/cni \
+        --mount volume=var-lib-cni,target=/var/lib/cni \
         --volume var-log,kind=host,source=/var/log \
         --mount volume=var-log,target=/var/log{{ if .UseCalico }} \
         --volume cni-bin,kind=host,source=/opt/cni/bin \


### PR DESCRIPTION
Due to https://github.com/rkt/rkt/issues/3465 no rkt containers can be GCed on
a node once kubelet is up and running.

Symptoms are that if you run following command, container can't be GCed:

```
rkt run  --insecure-options=image docker://busybox --exec date; rkt gc --grace-period=0;
```

So if any service periodically runs rkt containers, then node will eventually fill
up with many mounts and slow down operation.

As an extra-cleanup, also removing mounts of /tmp and rkt binary as they are
not used by kubelet