### PR TITLE
Export worker stack names and worker IAM role ARNs

### DIFF
--- a/Documentation/kubernetes-on-aws-add-ons.md
+++ b/Documentation/kubernetes-on-aws-add-ons.md
@@ -52,6 +52,36 @@ worker:
 
 See [the relevant GitHub issue](https://github.com/kubernetes-incubator/kube-aws/issues/253) for more information.
 
+You can reference controller and worker IAM Roles in a separate CloudFormation stack that provides roles to assume:
+
+```yaml
+...
+Parameters:
+  KubeAWSStackName:
+    Type: String
+Resources:
+  IAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: ec2.amazonaws.com
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              AWS:
+                Fn::ImportValue: !Sub "${KubeAWSStackName}-ControllerIAMRoleArn"
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              AWS:
+                Fn::ImportValue: !Sub "${KubeAWSStackName}-NodePool<Node Pool Name>WorkerIAMRoleArn"
+      ...
+```
+
 When you are done with your cluster, [destroy your cluster][aws-step-7]
 
 [aws-step-1]: kubernetes-on-aws.md

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1488,6 +1488,11 @@
     "StackName": {
       "Description": "The name of this stack which is used by node pool stacks to import outputs from this stack",
       "Value": { "Ref": "AWS::StackName" }
+    },
+    "ControllerIAMRoleArn": {
+      "Description": "The ARN of the IAM role for this Node Pool",
+      "Value": { "Fn::GetAtt": ["IAMRoleController", "Arn"] },
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-ControllerIAMRoleArn" } }
     }
   }
 }

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -423,5 +423,16 @@
       },
       "Type": "AWS::IAM::Role"
     }
+  },
+  "Outputs": {
+    "WorkerIAMRoleArn": {
+      "Description": "The ARN of the IAM role for this Node Pool",
+      "Value": { "Fn::GetAtt": ["IAMRoleWorker", "Arn"] },
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-WorkerIAMRoleArn" } }
+    },
+    "StackName": {
+      "Description": "The name of this stack",
+      "Value": { "Ref": "AWS::StackName" }
+    }
   }
 }

--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -45,6 +45,21 @@
     "ControlPlaneStackName": {
       "Description": "The name of the control plane stack",
       "Value": {"Fn::GetAtt" : [ "{{$.ControlPlane.Name}}" , "Outputs.StackName" ]}
-    }
+    },
+    "ControllerIAMRoleArn": {
+      "Description": "The IAM Role ARN for controller nodes",
+      "Value": {"Fn::GetAtt" : [ "{{$.ControlPlane.Name}}" , "Outputs.ControllerIAMRoleArn" ]},
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-ControllerIAMRoleArn" } }
+    }{{range $_, $p := .NodePools}},
+    "NodePool{{ $p.Name }}StackName": {
+      "Description": "The name of the {{$p.Name}} node pool stack",
+      "Value": {"Fn::GetAtt" : [ "{{$p.Name}}", "Outputs.StackName" ]},
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-NodePool{{$p.Name}}StackName" } }
+    },
+    "NodePool{{ $p.Name }}WorkerIAMRoleArn": {
+      "Description": "The IAM Role ARN for workers in the {{$p.Name}} node pool stack",
+      "Value": {"Fn::GetAtt" : [ "{{$p.Name}}", "Outputs.WorkerIAMRoleArn" ]},
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-NodePool{{$p.Name}}WorkerIAMRoleArn" } }
+    }{{end}}
   }
 }


### PR DESCRIPTION
This allows node pool IAM roles to be referenced in external cloudformation
stacks that provide roles for kube2iam to use. The worker IAM role is required
to grant permissions to the worker instances in an AssumeRolePolicyDocument.