### PR TITLE
Fix hyperlink to restore script in Readme.md.

### DIFF
--- a/contrib/cluster-backup/README.md
+++ b/contrib/cluster-backup/README.md
@@ -1,5 +1,5 @@
 # Restore
-Restoring a Kubernetes environment (from a previous backup) may be executed through the use of the bash script: [kubernetes-on-aws-restore.sh](/Documentation/scripts/kubernetes-on-aws-backup.sh)    
+Restoring a Kubernetes environment (from a previous backup) may be executed through the use of the bash script: [kubernetes-on-aws-restore.sh](/contrib/cluster-backup/restore.sh)    
 
 The script was designed to be used by the cluster provisioner and assumes that their local machine has:
 - 'kubectl' installed locally

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1011,8 +1011,8 @@ worker:
 #  enabled: true
 #   maxBatchSize: 1
 
-# Exports all Kubernetes resources (in .json format) to a bucket 's3://S3URI/clusterBackup/*'.
-# The export process executes on start-up and repeats every 24 hours.
+# Autosaves all Kubernetes resources (in .json format) to a bucket 's3:.../<your-cluster-name>/backup/*'.
+# The autosave process executes on start-up and repeats every 24 hours.
 #kubeResourcesAutosave:
 #  enabled: false
 


### PR DESCRIPTION
Minor fixes:
- Fix hyperlink to restore script in Readme.md.
- Reference 'autosave' rather than 'export' in comments of cluster.yaml.