### PR TITLE
Add reclaim policy

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -105,7 +105,8 @@
                   "    storage: 500Gi\n",
                   "  nfs:\n",
                   "    path: /\n",
-                  "    server: ", {"Ref": "FileSystemCustom"}, ".efs.{{ $.Region }}.amazonaws.com", "\n"
+                  "    server: ", {"Ref": "FileSystemCustom"}, ".efs.{{ $.Region }}.amazonaws.com", "\n",
+                  "  persistentVolumeReclaimPolicy: Recycle\n"
                 ]]}
               }
             }


### PR DESCRIPTION
A small amendment to the Persistent Volume created as EFS.

We found that the default policy for the pv is Reclaim. When you delete the VolumeClaim and try to recreate it, it enters a pending state unless the volume itself is deleted and recreated.

Using Recycle as a reclaim policy allows reruns of the volume claim without having to recreate the volume