### PR TITLE
Dex integration.

### DIFF
--- a/contrib/dex/README.md
+++ b/contrib/dex/README.md
@@ -1,4 +1,4 @@
-# Exposing DEX service
+## Exposing DEX service
 After the cluster is up, you have to manually expose dex service using a ELB or Ingress.
 Faster is to use the `expose-service.sh` script or you can manually configure the services using the examples from `contrib/dex` directory.
 
@@ -17,3 +17,49 @@ You pay only for the AWS resources you create to run your application. This is t
 After deploying the Ingress you have to configure the workers security group to allow access on port 443 and optionally on port 80.
 Please note that if you plan to restrict access of these ports to your IP, you also have to allow access from controller nodes, as the API server will access the dex endpoint.
 
+##Configure `kubectl` for token authentication
+
+* `kubectl` config using command line example:
+
+
+    kubectl config set-credentials admin@example.com  \
+    --auth-provider=oidc \   
+    --auth-provider-arg=idp-issuer-url=https://dex.example.com \
+    --auth-provider-arg=client-id=example-app \
+    --auth-provider-arg=client-secret=ZXhhbXBsZS1hcHAtc2VjcmV0 \   
+    --auth-provider-arg=refresh-token=refresh_token \   
+    --auth-provider-arg=idp-certificate-authority=/etc/kubernetes/ssl/ca.pem \   
+    --auth-provider-arg=id-token=id_token \
+    --auth-provider-arg=extra-scopes=groups
+
+* `kubectl` config file example:
+
+
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority-data: ca.pem_base64_encoded
+        server: https://kubeapi.example.com
+      name: your_cluster_name
+    contexts:
+    - context:
+        cluster: your_cluster_name
+        user: admin@example.com
+      name: your_cluster_name
+    current-context: your_cluster_name
+    kind: Config
+    preferences: {}
+    users:
+    - name: admin@example.com
+      user:
+        auth-provider:
+          config:
+            access-token: id_token
+            client-id: example-app 
+            client-secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+            extra-scopes: groups
+            id-token: id_token
+            idp-issuer-url: https://dex.example.com
+            refresh-token: refresh_token
+          name: oidc
+          

--- a/contrib/dex/README.md
+++ b/contrib/dex/README.md
@@ -1,0 +1,19 @@
+# Exposing DEX service
+After the cluster is up, you have to manually expose dex service using a ELB or Ingress.
+Faster is to use the `expose-service.sh` script or you can manually configure the services using the examples from `contrib/dex` directory.
+
+1. ELB
+
+First option is to use a Public or Internal ELB.
+
+In this case you have to edit one of the files from `contrib/dex/elb` directory and set your certificate `arn` and `domainName`.
+
+Note: 
+* SSL/TLS certificates provisioned through AWS Certificate Manager are free. 
+You pay only for the AWS resources you create to run your application. This is the recommended method.
+
+2. Ingress
+
+After deploying the Ingress you have to configure the workers security group to allow access on port 443 and optionally on port 80.
+Please note that if you plan to restrict access of these ports to your IP, you also have to allow access from controller nodes, as the API server will access the dex endpoint.
+

--- a/contrib/dex/cleanup.sh
+++ b/contrib/dex/cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+kubectl delete -f ingress/
+kubectl delete -f elb
+kubectl delete secret dex-tls-secret -n kube-system

--- a/contrib/dex/elb/external-elb.yaml
+++ b/contrib/dex/elb/external-elb.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:xx-xxxx-x:xxxxxxxxx:xxxxxxx/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxx #replace this value
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    domainName: "dex.example.com" #replace this value
+  name: dex
+  namespace: kube-system
+  labels:
+    app: dex
+    component: identity
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 443
+    targetPort: 5556
+    protocol: TCP
+  selector:
+    app: dex

--- a/contrib/dex/elb/internal-elb.yaml
+++ b/contrib/dex/elb/internal-elb.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dex
+  namespace: kube-system
   labels:
     run: dex
   annotations:

--- a/contrib/dex/elb/internal-elb.yaml
+++ b/contrib/dex/elb/internal-elb.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  labels:
+    run: dex
+  annotations:
+     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:xx-xxxx-x:xxxxxxxxx:xxxxxxx/xxxxx-xxxx-xxxx-xxxx-xxxxxxxxx #replace this value
+     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+     service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+     domainName: "dex.example.com" #replace this value
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 443
+    targetPort: 5556
+    protocol: TCP
+  selector:
+    app: dex

--- a/contrib/dex/expose-service.sh
+++ b/contrib/dex/expose-service.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+ORANGE='\033[0;33m'
+BLUE='\033[0;34m'
+
+PS3='Please select the method to expose the service for dex:'
+options=("PublicELB" "PrivateELB" "Ingress" "Quit")
+select opt in "${options[@]}"
+do
+    case $opt in
+        "PublicELB")
+            echo "Creating Public LaodBalancer"
+            echo -e ${BLUE}
+            read -r -p "Please replace the default values for the 'domain' and 'arn' in 'elb/external-elb.yaml'.Done? [y/N]" response
+            tput sgr0
+            if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
+            then
+                kubectl apply -f ./elb/external-elb.yaml
+            fi
+            #get ELB hostname
+            while
+            ELB=$(kubectl get svc dex -o jsonpath='{.status.loadBalancer.ingress[*].hostname}' -n kube-system);
+            :; grep -v elb.amazonaws.com <<<$ELB; do echo "Waiting for the ELB to become available"; sleep 5; done
+            DOMAIN=$(kubectl get svc dex -o jsonpath='{.metadata.annotations.domainName}' -n kube-system)
+            echo -e "Done. Please create a CNAME record or ALIAS with this value:"
+            echo -e "${BLUE}$DOMAIN > $ELB"
+
+            tput sgr0
+            break
+            ;;
+
+        "PrivateELB")
+            echo "Creating Public LaodBalancer"
+            echo -e ${BLUE}
+            read -r -p "Please replace the default values for the 'domain' and 'arn' in 'elb/external-elb.yaml'.Done? [y/N]" response
+            tput sgr0
+            if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
+            then
+                kubectl apply -f ./elb/internal-elb.yaml
+            fi
+            #get ELB hostname
+            while
+            ELB=$(kubectl get svc dex -o jsonpath='{.status.loadBalancer.ingress[*].hostname}' -n kube-system);
+            :; grep -v elb.amazonaws.com <<<$ELB; do echo "Waiting for the ELB to become available"; sleep 5; done
+            DOMAIN=$(kubectl get svc dex -o jsonpath='{.metadata.annotations.domainName}' -n kube-system)
+            echo -e "Please create a CNAME record or ALIAS with this value:"
+            echo -e "${BLUE}$DOMAIN > $ELB"
+            tput sgr0
+            break
+            ;;
+
+        "Ingress")
+            echo "Creating Ingress"
+            prompt="Please insert the path for your 'credentials' directory:"
+            while IFS= read -p "$prompt" -r -s -n 1 char
+            do
+                   if [[ $char == $'\0' ]]
+                   then
+                        break
+                   fi
+            prompt=$char
+            credentials_path+="$char"
+            done
+            echo
+
+            prompt="Please set the enpoint for dex:"
+            while IFS= read -p "$prompt" -r -s -n 1 char
+            do
+                   if [[ $char == $'\0' ]]
+                   then
+                        break
+                   fi
+            prompt=$char
+            endpoint+="$char"
+            done
+            echo
+
+            sed -i -e 's/dex.example.com/'"$endpoint"'/g' ingress/dex.ingress.yaml
+
+            echo "Creating TLS secret"
+            kubectl create secret tls dex-tls-secret --cert=$credentials_path/dex.pem --key=$credentials_path/dex-key.pem -n kube-system
+
+            echo " Creating Ingress"
+            kubectl apply -f ./ingress;
+
+            echo -e ${RED}"Waiting 10 seconds for the Ingress Controller to become available."
+            tput sgr0
+
+            sleep 10
+
+            echo " Please create a DNS record for Ingress"
+
+            echo
+            kubectl get ing -o wide -n kube-system
+
+            break
+            ;;
+        "Quit")
+            break
+            ;;
+        *) echo invalid option;;
+    esac
+done
+
+

--- a/contrib/dex/ingress/dex.ingress.yaml
+++ b/contrib/dex/ingress/dex.ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: dex-ingress
+  namespace: kube-system
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "true"
+    ingress.kubernetes.io/use-port-in-redirects: "true"
+spec:
+  tls:
+    - secretName: dex-tls-secret
+      hosts:
+        - dex.example.com
+  rules:
+    - host: dex.example.com
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: dex
+            servicePort: 5556

--- a/contrib/dex/ingress/dex.svc.yaml
+++ b/contrib/dex/ingress/dex.svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: kube-system
+  labels:
+    app: dex
+    component: identity
+spec:
+  selector:
+    app: dex
+    component: identity
+  ports:
+  - name: http
+    protocol: TCP
+    port: 5556

--- a/contrib/dex/ingress/nginx-ingress-lb.yaml
+++ b/contrib/dex/ingress/nginx-ingress-lb.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  namespace: kube-system
+  labels:
+    k8s-app: default-http-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    k8s-app: default-http-backend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: default-http-backend
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: default-http-backend
+  template:
+    metadata:
+      labels:
+        k8s-app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        image: gcr.io/google_containers/defaultbackend:1.3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+  namespace: kube-system
+  labels:
+    k8s-app: nginx-ingress-lb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: nginx-ingress-lb
+  template:
+    metadata:
+      labels:
+        k8s-app: nginx-ingress-lb
+        name: nginx-ingress-lb
+    spec:
+      terminationGracePeriodSeconds: 60
+      hostNetwork: true
+      containers:
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.3
+        name: nginx-ingress-lb
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        # use downward API
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 443
+        - containerPort: 8080
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -94,7 +94,7 @@ func NewDefaultCluster() *Cluster {
 			ClientId:        "example-app",
 			Username:        "email",
 			Groups:          "groups",
-			CaFile:          "/etc/kubernetes/ssl/openid-ca.pem",
+			CaFile:          "/etc/kubernetes/ssl/ca.pem",
 			Connectors:      []model.Connector{},
 			StaticClients:   []model.StaticClient{},
 			StaticPasswords: []model.StaticPassword{},

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -751,9 +751,9 @@ type Dex struct {
 	Url             string           `yaml:"url"`
 	ClientId        string           `yaml:"clientId"`
 	Username        string           `yaml:"username"`
-	Groups          string           `yaml:"groups",omitempty`
-	CaFile          string           `yaml:"caFile",omitempty`
-	Connectors      []Connector      `yaml:"connectors",omitempty`
+	Groups          string           `yaml:"groups,omitempty"`
+	CaFile          string           `yaml:"caFile,omitempty"`
+	Connectors      []Connector      `yaml:"connectors,omitempty"`
 	StaticClients   []StaticClient   `yaml:"staticClients"`
 	StaticPasswords []StaticPassword `yaml:"staticPasswords"`
 }

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -89,6 +89,17 @@ func NewDefaultCluster() *Cluster {
 		},
 
 		Taints: model.Taints{},
+		Dex: model.Dex{
+			Enabled:         false,
+			Url:             "https://dex.example.com",
+			ClientId:        "example-app",
+			Username:        "email",
+			Groups:          "groups",
+			CaFile:          "/etc/kubernetes/ssl/ca.pem",
+			Connectors:      []model.Connector{},
+			StaticClients:   []model.StaticClient{},
+			StaticPasswords: []model.StaticPassword{},
+		},
 	}
 
 	return &Cluster{

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -88,6 +88,17 @@ func NewDefaultCluster() *Cluster {
 			},
 		},
 		Taints: []Taint{},
+		Dex: Dex{
+			Enabled:         false,
+			Url:             "https://dex.example.com",
+			ClientId:        "example-app",
+			Username:        "email",
+			Groups:          "groups",
+			CaFile:          "",
+			Connectors:      []Connector{},
+			StaticClients:   []StaticClient{},
+			StaticPasswords: []StaticPassword{},
+		},
 	}
 
 	return &Cluster{
@@ -119,6 +130,7 @@ func NewDefaultCluster() *Cluster {
 			CalicoCtlImage:              model.Image{Repo: "calico/ctl", Tag: "v1.1.0", RktPullDocker: false},
 			PauseImage:                  model.Image{Repo: "gcr.io/google_containers/pause-amd64", Tag: "3.0", RktPullDocker: false},
 			FlannelImage:                model.Image{Repo: "quay.io/coreos/flannel", Tag: "v0.6.2", RktPullDocker: false},
+			DexImage:                    model.Image{Repo: "quay.io/coreos/dex", Tag: "v2.4.0", RktPullDocker: false},
 		},
 		KubeClusterSettings: KubeClusterSettings{
 			DNSServiceIP: "10.3.0.10",
@@ -493,6 +505,7 @@ type DeploymentSettings struct {
 	KubeDashboardImage          model.Image `yaml:"kubeDashboardImage,omitempty"`
 	PauseImage                  model.Image `yaml:"pauseImage,omitempty"`
 	FlannelImage                model.Image `yaml:"flannelImage,omitempty"`
+	DexImage                    model.Image `yaml:"dexImage,omitempty"`
 }
 
 // Part of configuration which is specific to worker nodes
@@ -666,6 +679,7 @@ type Experimental struct {
 	NodeDrainer                 NodeDrainer              `yaml:"nodeDrainer"`
 	NodeLabels                  NodeLabels               `yaml:"nodeLabels"`
 	Plugins                     Plugins                  `yaml:"plugins"`
+	Dex                         Dex                      `yaml:"dex"`
 	DisableSecurityGroupIngress bool                     `yaml:"disableSecurityGroupIngress"`
 	NodeMonitorGracePeriod      string                   `yaml:"nodeMonitorGracePeriod"`
 	Taints                      []Taint                  `yaml:"taints"`
@@ -730,6 +744,39 @@ type KubeResourcesAutosave struct {
 
 type NodeDrainer struct {
 	Enabled bool `yaml:"enabled"`
+}
+
+type Dex struct {
+	Enabled         bool             `yaml:"enabled"`
+	Url             string           `yaml:"url"`
+	ClientId        string           `yaml:"clientId"`
+	Username        string           `yaml:"username"`
+	Groups          string           `yaml:"groups",omitempty`
+	CaFile          string           `yaml:"caFile",omitempty`
+	Connectors      []Connector      `yaml:"connectors",omitempty`
+	StaticClients   []StaticClient   `yaml:"staticClients"`
+	StaticPasswords []StaticPassword `yaml:"staticPasswords"`
+}
+
+type Connector struct {
+	Type   string            `yaml:"type"`
+	Id     string            `yaml:"id"`
+	Name   string            `yaml:"name"`
+	Config map[string]string `yaml:"config"`
+}
+
+type StaticClient struct {
+	Id           string `yaml:"id"`
+	RedirectURIs string `yaml:"redirectURIs"`
+	Name         string `yaml:"name"`
+	Secret       string `yaml:"secret"`
+}
+
+type StaticPassword struct {
+	Email    string `yaml:"email"`
+	Hash     string `yaml:"hash"`
+	Username string `yaml:"username"`
+	UserId   string `yaml:"userID"`
 }
 
 type NodeLabels map[string]string

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -95,7 +95,7 @@ func NewDefaultCluster() *Cluster {
 			ClientId:        "example-app",
 			Username:        "email",
 			Groups:          "groups",
-			CaFile:          "/etc/kubernetes/ssl/ca.pem",
+			SelfSignedCa:    true,
 			Connectors:      []model.Connector{},
 			StaticClients:   []model.StaticClient{},
 			StaticPasswords: []model.StaticPassword{},

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -88,16 +88,16 @@ func NewDefaultCluster() *Cluster {
 			},
 		},
 		Taints: []Taint{},
-		Dex: Dex{
+		Dex: model.Dex{
 			Enabled:         false,
 			Url:             "https://dex.example.com",
 			ClientId:        "example-app",
 			Username:        "email",
 			Groups:          "groups",
-			CaFile:          "",
-			Connectors:      []Connector{},
-			StaticClients:   []StaticClient{},
-			StaticPasswords: []StaticPassword{},
+			CaFile:          "/etc/kubernetes/ssl/openid-ca.pem",
+			Connectors:      []model.Connector{},
+			StaticClients:   []model.StaticClient{},
+			StaticPasswords: []model.StaticPassword{},
 		},
 	}
 
@@ -679,7 +679,7 @@ type Experimental struct {
 	NodeDrainer                 NodeDrainer              `yaml:"nodeDrainer"`
 	NodeLabels                  NodeLabels               `yaml:"nodeLabels"`
 	Plugins                     Plugins                  `yaml:"plugins"`
-	Dex                         Dex                      `yaml:"dex"`
+	Dex                         model.Dex                `yaml:"dex"`
 	DisableSecurityGroupIngress bool                     `yaml:"disableSecurityGroupIngress"`
 	NodeMonitorGracePeriod      string                   `yaml:"nodeMonitorGracePeriod"`
 	Taints                      []Taint                  `yaml:"taints"`
@@ -744,39 +744,6 @@ type KubeResourcesAutosave struct {
 
 type NodeDrainer struct {
 	Enabled bool `yaml:"enabled"`
-}
-
-type Dex struct {
-	Enabled         bool             `yaml:"enabled"`
-	Url             string           `yaml:"url"`
-	ClientId        string           `yaml:"clientId"`
-	Username        string           `yaml:"username"`
-	Groups          string           `yaml:"groups,omitempty"`
-	CaFile          string           `yaml:"caFile,omitempty"`
-	Connectors      []Connector      `yaml:"connectors,omitempty"`
-	StaticClients   []StaticClient   `yaml:"staticClients"`
-	StaticPasswords []StaticPassword `yaml:"staticPasswords"`
-}
-
-type Connector struct {
-	Type   string            `yaml:"type"`
-	Id     string            `yaml:"id"`
-	Name   string            `yaml:"name"`
-	Config map[string]string `yaml:"config"`
-}
-
-type StaticClient struct {
-	Id           string `yaml:"id"`
-	RedirectURIs string `yaml:"redirectURIs"`
-	Name         string `yaml:"name"`
-	Secret       string `yaml:"secret"`
-}
-
-type StaticPassword struct {
-	Email    string `yaml:"email"`
-	Hash     string `yaml:"hash"`
-	Username string `yaml:"username"`
-	UserId   string `yaml:"userID"`
 }
 
 type NodeLabels map[string]string

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -621,6 +621,16 @@ write_files:
       {{ end }}
       {{ end }}
 
+      {{ if .Experimental.Dex.Enabled }}
+      if kubectl get cm dex -n kube-system;
+        then echo "Configmap for dex already exists and could have been customized. Skipping."; 
+      else 
+        mfdir=/srv/kubernetes/manifests
+        kubectl apply -f "${mfdir}/dex-cm.yaml"
+        kubectl apply -f "${mfdir}/dex-deployment.yaml";
+      fi
+      {{ end }}
+
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |
       DOCKER_OPT_BIP=""
@@ -1263,6 +1273,19 @@ write_files:
           - --advertise-address=$private_ipv4
           - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }},ResourceQuota
           - --anonymous-auth=false
+          {{if .Experimental.Dex.Enabled}}
+          - --oidc-issuer-url={{.Experimental.Dex.Url}}
+          - --oidc-client-id={{.Experimental.Dex.ClientId}}
+          {{if .Experimental.Dex.Username}}
+          - --oidc-username-claim={{.Experimental.Dex.Username}}
+          {{ end -}}
+          {{if .Experimental.Dex.Groups}}
+          - --oidc-groups-claim={{.Experimental.Dex.Groups}}
+          {{ end -}}
+          {{if .Experimental.Dex.CaFile}}
+          - --oidc-ca-file={{.Experimental.Dex.CaFile}}
+          {{ end -}}
+          {{ end -}}
           - --cert-dir=/etc/kubernetes/ssl
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
@@ -1917,3 +1940,111 @@ write_files:
            echo "Finished Loading EFS Persistent Volume"'
 
 {{ end }}
+{{if .Experimental.Dex.Enabled}}
+  - path: /srv/kubernetes/manifests/dex-deployment.yaml
+    content: |
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+      metadata:
+        name: dex
+        namespace: kube-system
+        labels:
+          app: dex
+          component: identity
+        annotations:
+          scheduler.alpha.kubernetes.io/critical-pod: ''
+      spec:
+        replicas: 1
+        minReadySeconds: 30
+        strategy:
+          rollingUpdate:
+            maxUnavailable: 0
+        template:
+          metadata:
+            name: dex
+            labels:
+              app: dex
+              component: identity
+          spec:
+            volumes:
+            - name: config
+              configMap:
+                name: dex
+                items:
+                - key: config.yaml
+                  path: config.yaml
+            containers:
+            - name: dex
+              imagePullPolicy: IfNotPresent
+              image: {{.DexImage.RepoWithTag}}
+              command: ["/usr/local/bin/dex", "serve", "/etc/dex/config.yaml"]
+              volumeMounts:
+              - name: config
+                mountPath: /etc/dex
+              ports:
+              - containerPort: 5556
+                protocol: TCP
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 5556
+                initialDelaySeconds: 5
+                timeoutSeconds: 1
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 50Mi
+                limits:
+                  cpu: 100m
+                  memory: 50Mi
+
+  - path: /srv/kubernetes/manifests/dex-cm.yaml
+    content: |
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: dex
+        namespace: kube-system
+      data:
+        config.yaml: |
+          issuer: {{.Experimental.Dex.Url}}
+          storage:
+            type: kubernetes
+            config:
+              inCluster: true
+          web:
+            http: 0.0.0.0:5556
+          frontend:
+            theme: 'coreos'
+            issuer: 'KubeAWS Identity'
+          {{ if .Experimental.Dex.Connectors -}}
+          connectors:
+            {{- range $connector := .Experimental.Dex.Connectors }}
+            - type: {{ $connector.Type }}
+              id: {{ $connector.Id }}
+              name: {{ $connector.Name }}
+              config:
+                {{ range $key, $value := $connector.Config -}}
+                {{ $key }}: {{ $value }}
+                {{ end -}}
+            {{ end -}}
+          {{- end }}
+          oauth2:
+            skipApprovalScreen: true
+          staticClients:
+          {{- range $staticClient := .Experimental.Dex.StaticClients }}
+          - id: '{{ $staticClient.Id }}'
+            redirectURIs:
+            - '{{ $staticClient.RedirectURIs }}'
+            name: '{{ $staticClient.Name }}'
+            secret: '{{ $staticClient.Secret }}'
+          {{- end }}
+          enablePasswordDB: true
+          {{- range $staticPassword := .Experimental.Dex.StaticPasswords }}
+          staticPasswords:
+          - email: '{{ $staticPassword.Email }}'
+            hash: '{{ $staticPassword.Hash }}'
+            username: '{{ $staticPassword.Username }}'
+            userID: '{{ $staticPassword.UserId }}'
+         {{ end -}}
+  {{ end }}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1872,6 +1872,15 @@ write_files:
   - path: /etc/kubernetes/ssl/etcd-client-key.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.TLSConfig.EtcdClientKey}}
+
+  - path: /etc/kubernetes/ssl/dex.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+    encoding: gzip+base64
+    content: {{.TLSConfig.DexCert}}
+
+  - path: /etc/kubernetes/ssl/dex-key.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+    encoding: gzip+base64
+    content: {{.TLSConfig.DexKey}}
+
 {{ end }}
 
 

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2039,12 +2039,14 @@ write_files:
             name: '{{ $staticClient.Name }}'
             secret: '{{ $staticClient.Secret }}'
           {{- end }}
+          {{if .Experimental.Dex.StaticPasswords -}}
           enablePasswordDB: true
+          {{ end -}}
           {{- range $staticPassword := .Experimental.Dex.StaticPasswords }}
           staticPasswords:
-          - email: '{{ $staticPassword.Email }}'
-            hash: '{{ $staticPassword.Hash }}'
-            username: '{{ $staticPassword.Username }}'
-            userID: '{{ $staticPassword.UserId }}'
+          - email: "{{ $staticPassword.Email }}"
+            hash: "{{ $staticPassword.Hash }}"
+            username: "{{ $staticPassword.Username }}"
+            userID: "{{ $staticPassword.UserId }}"
          {{ end -}}
   {{ end }}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1841,6 +1841,7 @@ write_files:
     encoding: gzip+base64
     content: {{.TLSConfig.EtcdClientKey}}
 
+{{ if .Experimental.Dex.Enabled }}
   - path: /etc/kubernetes/ssl/dex.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.TLSConfig.DexCert}}
@@ -1848,7 +1849,7 @@ write_files:
   - path: /etc/kubernetes/ssl/dex-key.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.TLSConfig.DexKey}}
-
+{{ end }}
 {{ end }}
 
   - path: /etc/kubernetes/controller-kubeconfig.yaml

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1249,8 +1249,8 @@ write_files:
           {{if .Experimental.Dex.Groups}}
           - --oidc-groups-claim={{.Experimental.Dex.Groups}}
           {{ end -}}
-          {{if .Experimental.Dex.CaFile}}
-          - --oidc-ca-file={{.Experimental.Dex.CaFile}}
+          {{if .Experimental.Dex.SelfSignedCa}}
+          - --oidc-ca-file=/etc/kubernetes/ssl/ca.pem
           {{ end -}}
           {{ end -}}
           - --cert-dir=/etc/kubernetes/ssl

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -589,6 +589,7 @@ write_files:
     encoding: gzip+base64
     content: {{.TLSConfig.CACert}}
 
+{{ if .Experimental.Dex.Enabled }}
   - path: /etc/kubernetes/ssl/dex.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.TLSConfig.DexCert}}
@@ -596,7 +597,7 @@ write_files:
   - path: /etc/kubernetes/ssl/dex-key.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64
     content: {{.TLSConfig.DexKey}}
-
+{{ end }}
 {{ end }}
 
 {{ if .AssetsEncryptionEnabled }}

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -610,6 +610,14 @@ write_files:
     encoding: gzip+base64
     content: {{.TLSConfig.CACert}}
 
+  - path: /etc/kubernetes/ssl/dex.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+    encoding: gzip+base64
+    content: {{.TLSConfig.DexCert}}
+
+  - path: /etc/kubernetes/ssl/dex-key.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+    encoding: gzip+base64
+    content: {{.TLSConfig.DexKey}}
+
 {{ end }}
 
 {{ if .AssetsEncryptionEnabled }}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1090,7 +1090,7 @@ addons:
 #       id: github
 #       name: GitHub
 #       config:
-#         ClientId: "your_client_id"
+#         clientId: "your_client_id"
 #         clientSecret: "your_client_secret"
 #         redirectURI: https://dex.example.com/callback
 #         org: your_organization
@@ -1102,11 +1102,11 @@ addons:
 #       secret: 'ZXhhbXBsZS1hcHAtc2VjcmV0'
 #
 #     staticPasswords:
-#     - email: 'admin@example.com'
+#     - email: "admin@example.com"
 #       # bcrypt hash of the string "password". You can use bcrypt-tool from CoreOS to generate the passwords.
-#       hash: '$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W'
-#       username: 'admin'
-#       userID: '08a8684b-db88-4b73-90a9-3cd1661f5466'
+#       hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+#       username: "admin"
+#       userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 #
 #   # Kubernetes node labels to be added to controller nodes
 #   nodeLabels:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1113,15 +1113,14 @@ addons:
 #   # Enable dex  integration - https://github.com/coreos/dex
 #   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
 #   # Notice: always use "https" for the "url", otherwise the Kubernetes API server will not start correctly.
-#   # Please leave the "caFile" commented  if you use a certificate signed  by a trusted CA as in Case you plan to
-#   # expose the service using a LoadBalancer.
+#   # Please set selfSignedCa to false if you plan to expose dex service using a LoadBalancer or Ingress with certificates signed by a trusted CA.
 #   dex:
 #     enabled: true
 #     url: "https://dex.example.com"
 #     clientId: "example-app"
 #     username: "email"
 #     groups: "groups"
-#     caFile: "/etc/kubernetes/ssl/ca.pem"
+#     selfSignedCa: true
 #
 #   # Dex connectors configuration. You can add configuration for the desired connectors suported by dex or
 #   # skip this part if you don't plan to use any of them. Here is an example of GitHub connector.

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1111,9 +1111,10 @@ addons:
 #   nodeDrainer:
 #     enabled: true
 #   # Enable dex  integration - https://github.com/coreos/dex
-#   # Configure OpenID Connect token authenticator plugin in Kubernetes API server. Notice: always use "https" for the "url",
-#   # otherwise the Kubernetes API server will not start correctly. The "caFile" can be skipped if you use a certificate signed
-#   # by a trusted CA.
+#   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
+#   # Notice: always use "https" for the "url", otherwise the Kubernetes API server will not start correctly.
+#   # Please leave the "caFile" commented  if you use a certificate signed  by a trusted CA as in Case you plan to
+#   # expose the service using a LoadBalancer.
 #   dex:
 #     enabled: true
 #     url: "https://dex.example.com"

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1071,6 +1071,43 @@ addons:
 #   # When enabled, `kubectl drain` is run on the node going to shut-down
 #   nodeDrainer:
 #     enabled: true
+#   # Enable dex  integration - https://github.com/coreos/dex
+#   # Configure OpenID Connect token authenticator plugin in Kubernetes API server. Notice: always use "https" for the "url",
+#   # otherwise the Kubernetes API server will not start correctly. The "caFile" can be skipped if you use a certificate signed
+#   # by a trusted CA.
+#   dex:
+#     enabled: true
+#     url: "https://dex.example.com"
+#     clientId: "example-app"
+#     username: "email"
+#     groups: "groups"
+#     caFile: "/etc/kubernetes/ssl/openid-ca.pem"
+#
+#   # Dex connectors configuration. You can add configuration for the desired connectors suported by dex or
+#   # skip this part if you don't plan to use any of them. Here is an example of GitHub connector.
+#     connectors:
+#     - type: github
+#       id: github
+#       name: GitHub
+#       config:
+#         ClientId: "your_client_id"
+#         clientSecret: "your_client_secret"
+#         redirectURI: https://dex.example.com/callback
+#         org: your_organization
+#   # Configure static clients and users
+#     staticClients:
+#     - id: 'example-app'
+#       redirectURIs: 'http://127.0.0.1:5555/callback'
+#       name: 'Example App'
+#       secret: 'ZXhhbXBsZS1hcHAtc2VjcmV0'
+#
+#     staticPasswords:
+#     - email: 'admin@example.com'
+#       # bcrypt hash of the string "password". You can use bcrypt-tool from CoreOS to generate the passwords.
+#       hash: '$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W'
+#       username: 'admin'
+#       userID: '08a8684b-db88-4b73-90a9-3cd1661f5466'
+#
 #   # Kubernetes node labels to be added to controller nodes
 #   nodeLabels:
 #     kube-aws.coreos.com/role: worker

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1081,7 +1081,7 @@ addons:
 #     clientId: "example-app"
 #     username: "email"
 #     groups: "groups"
-#     caFile: "/etc/kubernetes/ssl/openid-ca.pem"
+#     caFile: "/etc/kubernetes/ssl/ca.pem"
 #
 #   # Dex connectors configuration. You can add configuration for the desired connectors suported by dex or
 #   # skip this part if you don't plan to use any of them. Here is an example of GitHub connector.

--- a/core/controlplane/config/tls_config_test.go
+++ b/core/controlplane/config/tls_config_test.go
@@ -68,6 +68,11 @@ func TestTLSGeneration(t *testing.T) {
 			KeyBytes:  assets.EtcdKey,
 			CertBytes: assets.EtcdCert,
 		},
+		{
+			Name:      "dex",
+			KeyBytes:  assets.DexKey,
+			CertBytes: assets.DexCert,
+		},
 	}
 
 	var err error
@@ -151,7 +156,7 @@ func TestReadOrCreateCompactTLSAssets(t *testing.T) {
 
 			files := []string{
 				"ca", "admin", "admin-key", "worker", "worker-key", "apiserver", "apiserver-key",
-				"etcd", "etcd-key", "etcd-client", "etcd-client-key",
+				"etcd", "etcd-key", "etcd-client", "etcd-client-key", "dex", "dex-key",
 			}
 
 			for _, f := range files {

--- a/model/dex.go
+++ b/model/dex.go
@@ -10,7 +10,7 @@ type Dex struct {
 	ClientId        string           `yaml:"clientId"`
 	Username        string           `yaml:"username"`
 	Groups          string           `yaml:"groups,omitempty"`
-	CaFile          string           `yaml:"caFile,omitempty"`
+	SelfSignedCa    bool             `yaml:"selfSignedCa"`
 	Connectors      []Connector      `yaml:"connectors,omitempty"`
 	StaticClients   []StaticClient   `yaml:"staticClients,omitempty"`
 	StaticPasswords []StaticPassword `yaml:"staticPasswords,omitempty"`

--- a/model/dex.go
+++ b/model/dex.go
@@ -1,0 +1,34 @@
+package model
+
+type Dex struct {
+	Enabled         bool             `yaml:"enabled"`
+	Url             string           `yaml:"url"`
+	ClientId        string           `yaml:"clientId"`
+	Username        string           `yaml:"username"`
+	Groups          string           `yaml:"groups,omitempty"`
+	CaFile          string           `yaml:"caFile,omitempty"`
+	Connectors      []Connector      `yaml:"connectors,omitempty"`
+	StaticClients   []StaticClient   `yaml:"staticClients,omitempty"`
+	StaticPasswords []StaticPassword `yaml:"staticPasswords,omitempty"`
+}
+
+type Connector struct {
+	Type   string            `yaml:"type"`
+	Id     string            `yaml:"id"`
+	Name   string            `yaml:"name"`
+	Config map[string]string `yaml:"config"`
+}
+
+type StaticClient struct {
+	Id           string `yaml:"id"`
+	RedirectURIs string `yaml:"redirectURIs"`
+	Name         string `yaml:"name"`
+	Secret       string `yaml:"secret"`
+}
+
+type StaticPassword struct {
+	Email    string `yaml:"email"`
+	Hash     string `yaml:"hash"`
+	Username string `yaml:"username"`
+	UserId   string `yaml:"userID"`
+}

--- a/model/dex.go
+++ b/model/dex.go
@@ -1,5 +1,9 @@
 package model
 
+import (
+	"net/url"
+)
+
 type Dex struct {
 	Enabled         bool             `yaml:"enabled"`
 	Url             string           `yaml:"url"`
@@ -31,4 +35,9 @@ type StaticPassword struct {
 	Hash     string `yaml:"hash"`
 	Username string `yaml:"username"`
 	UserId   string `yaml:"userID"`
+}
+
+func (c Dex) DexDNSNames() string {
+	u, _ := url.Parse(c.Url)
+	return u.Host
 }

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -30,7 +30,7 @@ func WithDummyCredentials(fn func(dir string)) {
 	// config/temp, nodepool/config/temp, test/integration/temp
 	defer os.RemoveAll(dir)
 
-	for _, pairName := range []string{"ca", "apiserver", "worker", "admin", "etcd", "etcd-client"} {
+	for _, pairName := range []string{"ca", "apiserver", "worker", "admin", "etcd", "etcd-client", "dex"} {
 		certFile := fmt.Sprintf("%s/%s.pem", dir, pairName)
 		if err := ioutil.WriteFile(certFile, []byte("dummycert"), 0644); err != nil {
 			panic(err)

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -116,16 +116,16 @@ func TestMainClusterConfig(t *testing.T) {
 			LoadBalancer: controlplane_config.LoadBalancer{
 				Enabled: false,
 			},
-			Dex: controlplane_config.Dex{
+			Dex: model.Dex{
 				Enabled:         false,
 				Url:             "https://dex.example.com",
 				ClientId:        "example-app",
 				Username:        "email",
 				Groups:          "groups",
-				CaFile:          "",
-				Connectors:      []controlplane_config.Connector{},
-				StaticClients:   []controlplane_config.StaticClient{},
-				StaticPasswords: []controlplane_config.StaticPassword{},
+				CaFile:          "/etc/kubernetes/ssl/openid-ca.pem",
+				Connectors:      []model.Connector{},
+				StaticClients:   []model.StaticClient{},
+				StaticPasswords: []model.StaticPassword{},
 			},
 			NodeDrainer: controlplane_config.NodeDrainer{
 				Enabled: false,
@@ -1007,7 +1007,7 @@ experimental:
       id: github
       name: GitHub
       config:
-        ClientId: "your_client_id"
+        clientId: "your_client_id"
         clientSecret: "your_client_secret"
         redirectURI: https://dex.example.com/callback
         org: your_organization
@@ -1091,20 +1091,20 @@ worker:
 							Arns:             []string{"arn:aws:elasticloadbalancing:eu-west-1:xxxxxxxxxxxx:targetgroup/manuallymanagedetg/xxxxxxxxxxxxxxxx"},
 							SecurityGroupIds: []string{"sg-12345678"},
 						},
-						Dex: controlplane_config.Dex{
+						Dex: model.Dex{
 							Enabled:  true,
 							Url:      "https://dex.example.com",
 							ClientId: "example-app",
 							Username: "email",
 							Groups:   "groups",
 							CaFile:   "/etc/kubernetes/ssl/openid-ca.pem",
-							Connectors: []controlplane_config.Connector{
-								{Type: "github", Id: "github", Name: "GitHub", Config: map[string]string{"ClientId": "your_client_id", "clientSecret": "your_client_secret", "redirectURI": "https://dex.example.com/callback", "org": "your_organization"}},
+							Connectors: []model.Connector{
+								{Type: "github", Id: "github", Name: "GitHub", Config: map[string]string{"clientId": "your_client_id", "clientSecret": "your_client_secret", "redirectURI": "https://dex.example.com/callback", "org": "your_organization"}},
 							},
-							StaticClients: []controlplane_config.StaticClient{
+							StaticClients: []model.StaticClient{
 								{Id: "example-app", RedirectURIs: "http://127.0.0.1:5555/callback", Name: "Example App", Secret: "ZXhhbXBsZS1hcHAtc2VjcmV0"},
 							},
-							StaticPasswords: []controlplane_config.StaticPassword{
+							StaticPasswords: []model.StaticPassword{
 								{Email: "admin@example.com", Hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W", Username: "admin", UserId: "08a8684b-db88-4b73-90a9-3cd1661f5466"},
 							},
 						},

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -122,7 +122,7 @@ func TestMainClusterConfig(t *testing.T) {
 				ClientId:        "example-app",
 				Username:        "email",
 				Groups:          "groups",
-				CaFile:          "/etc/kubernetes/ssl/openid-ca.pem",
+				CaFile:          "/etc/kubernetes/ssl/ca.pem",
 				Connectors:      []model.Connector{},
 				StaticClients:   []model.StaticClient{},
 				StaticPasswords: []model.StaticPassword{},
@@ -1001,7 +1001,7 @@ experimental:
     clientId: "example-app"
     username: "email"
     groups: "groups"
-    caFile: "/etc/kubernetes/ssl/openid-ca.pem"
+    caFile: "/etc/kubernetes/ssl/ca.pem"
     connectors:
     - type: github
       id: github
@@ -1097,7 +1097,7 @@ worker:
 							ClientId: "example-app",
 							Username: "email",
 							Groups:   "groups",
-							CaFile:   "/etc/kubernetes/ssl/openid-ca.pem",
+							CaFile:   "/etc/kubernetes/ssl/ca.pem",
 							Connectors: []model.Connector{
 								{Type: "github", Id: "github", Name: "GitHub", Config: map[string]string{"clientId": "your_client_id", "clientSecret": "your_client_secret", "redirectURI": "https://dex.example.com/callback", "org": "your_organization"}},
 							},

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -122,7 +122,7 @@ func TestMainClusterConfig(t *testing.T) {
 				ClientId:        "example-app",
 				Username:        "email",
 				Groups:          "groups",
-				CaFile:          "/etc/kubernetes/ssl/ca.pem",
+				SelfSignedCa:    true,
 				Connectors:      []model.Connector{},
 				StaticClients:   []model.StaticClient{},
 				StaticPasswords: []model.StaticPassword{},
@@ -1078,7 +1078,7 @@ experimental:
     clientId: "example-app"
     username: "email"
     groups: "groups"
-    caFile: "/etc/kubernetes/ssl/ca.pem"
+    SelfSignedCa: true
     connectors:
     - type: github
       id: github
@@ -1169,12 +1169,12 @@ worker:
 							SecurityGroupIds: []string{"sg-12345678"},
 						},
 						Dex: model.Dex{
-							Enabled:  true,
-							Url:      "https://dex.example.com",
-							ClientId: "example-app",
-							Username: "email",
-							Groups:   "groups",
-							CaFile:   "/etc/kubernetes/ssl/ca.pem",
+							Enabled:      true,
+							Url:          "https://dex.example.com",
+							ClientId:     "example-app",
+							Username:     "email",
+							Groups:       "groups",
+							SelfSignedCa: true,
 							Connectors: []model.Connector{
 								{Type: "github", Id: "github", Name: "GitHub", Config: map[string]string{"clientId": "your_client_id", "clientSecret": "your_client_secret", "redirectURI": "https://dex.example.com/callback", "org": "your_organization"}},
 							},

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -116,6 +116,17 @@ func TestMainClusterConfig(t *testing.T) {
 			LoadBalancer: controlplane_config.LoadBalancer{
 				Enabled: false,
 			},
+			Dex: controlplane_config.Dex{
+				Enabled:         false,
+				Url:             "https://dex.example.com",
+				ClientId:        "example-app",
+				Username:        "email",
+				Groups:          "groups",
+				CaFile:          "",
+				Connectors:      []controlplane_config.Connector{},
+				StaticClients:   []controlplane_config.StaticClient{},
+				StaticPasswords: []controlplane_config.StaticPassword{},
+			},
 			NodeDrainer: controlplane_config.NodeDrainer{
 				Enabled: false,
 			},
@@ -984,6 +995,32 @@ experimental:
       - arn:aws:elasticloadbalancing:eu-west-1:xxxxxxxxxxxx:targetgroup/manuallymanagedetg/xxxxxxxxxxxxxxxx
     securityGroupIds:
       - sg-12345678
+  dex:
+    enabled: true
+    url: "https://dex.example.com"
+    clientId: "example-app"
+    username: "email"
+    groups: "groups"
+    caFile: "/etc/kubernetes/ssl/openid-ca.pem"
+    connectors:
+    - type: github
+      id: github
+      name: GitHub
+      config:
+        ClientId: "your_client_id"
+        clientSecret: "your_client_secret"
+        redirectURI: https://dex.example.com/callback
+        org: your_organization
+    staticClients:
+    - id: 'example-app'
+      redirectURIs: 'http://127.0.0.1:5555/callback'
+      name: 'Example App'
+      secret: 'ZXhhbXBsZS1hcHAtc2VjcmV0'
+    staticPasswords:
+    - email: 'admin@example.com'
+      hash: '$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W'
+      username: 'admin'
+      userID: '08a8684b-db88-4b73-90a9-3cd1661f5466'
   nodeDrainer:
     enabled: true
   nodeLabels:
@@ -1053,6 +1090,23 @@ worker:
 							Enabled:          true,
 							Arns:             []string{"arn:aws:elasticloadbalancing:eu-west-1:xxxxxxxxxxxx:targetgroup/manuallymanagedetg/xxxxxxxxxxxxxxxx"},
 							SecurityGroupIds: []string{"sg-12345678"},
+						},
+						Dex: controlplane_config.Dex{
+							Enabled:  true,
+							Url:      "https://dex.example.com",
+							ClientId: "example-app",
+							Username: "email",
+							Groups:   "groups",
+							CaFile:   "/etc/kubernetes/ssl/openid-ca.pem",
+							Connectors: []controlplane_config.Connector{
+								{Type: "github", Id: "github", Name: "GitHub", Config: map[string]string{"ClientId": "your_client_id", "clientSecret": "your_client_secret", "redirectURI": "https://dex.example.com/callback", "org": "your_organization"}},
+							},
+							StaticClients: []controlplane_config.StaticClient{
+								{Id: "example-app", RedirectURIs: "http://127.0.0.1:5555/callback", Name: "Example App", Secret: "ZXhhbXBsZS1hcHAtc2VjcmV0"},
+							},
+							StaticPasswords: []controlplane_config.StaticPassword{
+								{Email: "admin@example.com", Hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W", Username: "admin", UserId: "08a8684b-db88-4b73-90a9-3cd1661f5466"},
+							},
 						},
 						NodeDrainer: controlplane_config.NodeDrainer{
 							Enabled: true,


### PR DESCRIPTION
Hi @mumoshu I don't know if this is the best approach to integrate `dex` into `kube-aws` 
as I'm trying to make it as simple as possible but in the same time customisable and my skills with Go are limited. 

The current setup: 
* a Kubernetes "Deployment" + a minimal config in a "ConfigMap"
* all the parameters are set inside the "ConfigMap" which is generated from `cluster.yaml`
* after the cluster is up, the user can customize `dex` "ConfigMap" and "Deployment"
* upgrading/scaling the masters will not modify the "ConfigMap" or the "Deployment"
*`dex` is running on http on port 5556
* the user decide how to expose the service using a internal/public LoadBalancer, a Ingress Controller or a NodePort
* the required SSL certificates are managed by the user. In our case we prefer using a LoadBalancer with AWS Certificate Manager that will also remove the need to configure the `--oidc-ca-file` parameter 

Issues:
* some steps are still manual, like creating the service and configuring the Loadbalancer or Ingress but these are  pretty easy to configure and we can provide examples 
* advanced configurations require modifying the "ConfigMap"/"Deployment". For example, if you plan to use the LDAP connector. Adding the desired configuration in `cluster.yaml` is not parsed well in this case. It's fine for the other connectors.
* `--oidc-ca-file` parameter is working but there is no method yet to load the CA certificate on masters

Possible improvements I'm thinking at:
* generate self signed certificates using `kube-aws`
* find a method to put sensitive data (for example the credentials for the connectors) in secrets (this can be done now manually after the cluster is up)
* configure a Ingress/LoadBalancer/NodePort automatically (in this case Tectonic is using a ingress that terminates the TLS for all the services, including `dex`, and put a TCP LoadBalancer in front)

I'm open for suggestions on how we can improve this.
Related to #506

Thanks!

