### PR TITLE
Quote security group refs for etcd, controller, and apiendpoints

### DIFF
--- a/model/controller.go
+++ b/model/controller.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"fmt"
 )
 
 // TODO Merge this with NodePoolConfig
@@ -44,7 +45,7 @@ func (c Controller) SecurityGroupRefs() []string {
 	refs := []string{}
 
 	for _, id := range c.SecurityGroupIds {
-		refs = append(refs, id)
+		refs = append(refs, fmt.Sprintf(`"%s"`, id))
 	}
 
 	refs = append(

--- a/model/derived/api_endpoint_lb.go
+++ b/model/derived/api_endpoint_lb.go
@@ -59,7 +59,7 @@ func (b APIEndpointLB) SecurityGroupRefs() []string {
 	refs := []string{}
 
 	for _, id := range b.SecurityGroupIds {
-		refs = append(refs, id)
+		refs = append(refs, fmt.Sprintf(`"%s"`, id))
 	}
 
 	if b.ManageSecurityGroup() {

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -128,7 +129,7 @@ func (e Etcd) SecurityGroupRefs() []string {
 	refs := []string{}
 
 	for _, id := range e.SecurityGroupIds {
-		refs = append(refs, id)
+		refs = append(refs, fmt.Sprintf(`"%s"`, id))
 	}
 
 	refs = append(


### PR DESCRIPTION
I noticed that the recent work to extend glue security groups to etcd/controllers/apiendpoints were missing the double quotes when being rendered into the stack json. I think I addressed all instances of this case.

I was getting the following error when enabling security groups for the controllers:
```
Error while rendering template : Error while rendering stack template : invalid character 's' looking for beginning of value:
json syntax error (offset=17339), in this region:
-------
,
        "SecurityGroups": [
          
          
          sg-af3da9d6
          
          ,
          {"Ref":"SecurityGroupController"}

-------

```