### PR TITLE
Set --storage-backend to etcd2 if not using etcd3

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1243,6 +1243,8 @@ write_files:
           - --secure-port=443
           {{if .Etcd.Version.Is3}}
           - --storage-backend=etcd3
+          {{else}}
+          - --storage-backend=etcd2
           {{end}}
           - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
           {{ if .AuthTokensConfig.HasTokens }}


### PR DESCRIPTION
Since Kubernetes 1.6, the default storage backend is etcd3 if
not specified. If etcd version is set to '2' in cluster config,
we need to set --storage-backend=etcd2.