### PR TITLE
Fix etcd snapshots locations in S3

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1036,8 +1036,7 @@ func (c Cluster) StackConfig(opts StackTemplateOptions) (*StackConfig, error) {
 
 	stackConfig.StackTemplateOptions = opts
 
-	baseS3URI := strings.TrimSuffix(opts.S3URI, "/")
-	stackConfig.S3URI = fmt.Sprintf("%s/kube-aws/clusters/%s/exported/stacks", baseS3URI, c.ClusterName)
+	stackConfig.S3URI = strings.TrimSuffix(opts.S3URI, "/")
 
 	if opts.SkipWait {
 		enabled := false

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -374,7 +374,7 @@
                   "Resource": "arn:{{.Region.Partition}}:s3:::{{$.EtcdSnapshotsS3Bucket}}",
                   "Condition": {
                     "StringLike": {
-                      "s3:prefix": "{{$.EtcdSnapshotsS3Prefix}}/*"
+                      "s3:prefix": { "Fn::Join" : [ "", [{{$.EtcdSnapshotsS3PrefixRef}}, "/*" ]]}
                     }
                   }
                 },
@@ -384,7 +384,7 @@
                   "Action": [
                     "s3:*"
                   ],
-                  "Resource": "arn:{{.Region.Partition}}:s3:::{{$.EtcdSnapshotsS3Path}}/*"
+                  "Resource": { "Fn::Join" : [ "", ["arn:{{.Region.Partition}}:s3:::", {{$.EtcdSnapshotsS3PathRef}}, "/*" ]]}
                 },
                 {{/* Required for `etcdadm reconfigure` to determine the number of active etcd nodes */}}
                 {
@@ -614,7 +614,7 @@
                     "etcd-member",
                   "'\n",
                   "ETCDADM_CLUSTER_SNAPSHOTS_S3_URI='",
-                    "s3://{{$.EtcdSnapshotsS3Path}}",
+                    { "Fn::Join" : [ "", ["s3://", {{$.EtcdSnapshotsS3PathRef}} ]] },
                   "'\n",
                   "ETCDADM_STATE_FILES_DIR='",
                     "/var/run/coreos/etcdadm",

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -117,9 +117,9 @@ func (c ProvidedConfig) StackConfig(opts StackTemplateOptions) (*StackConfig, er
 
 	stackConfig.StackTemplateOptions = opts
 
-	baseS3URI := strings.TrimSuffix(opts.S3URI, "/")
-	stackConfig.S3URI = fmt.Sprintf("%s/kube-aws/clusters/%s/exported/stacks", baseS3URI, c.ClusterName)
-	stackConfig.KubeResourcesAutosave.S3Path = fmt.Sprintf("%s/kube-aws/clusters/%s/backup", strings.TrimPrefix(baseS3URI, "s3://"), c.ClusterName)
+	s3Folders := model.NewS3Folders(opts.S3URI, c.ClusterName)
+	stackConfig.S3URI = s3Folders.ClusterExportedStacks().URI()
+	stackConfig.KubeResourcesAutosave.S3Path = s3Folders.ClusterBackups().Path()
 
 	if opts.SkipWait {
 		enabled := false

--- a/e2e/run
+++ b/e2e/run
@@ -235,6 +235,8 @@ controller:
   count: $CONTROLLER_COUNT
 waitSignal:
   enabled: true
+kubeResourcesAutosave:
+  enabled: true
 experimental:
   awsNodeLabels:
     enabled: true

--- a/model/s3_folders.go
+++ b/model/s3_folders.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+type S3Folders struct {
+	clusterName string
+	s3URI       string
+}
+
+func NewS3Folders(s3URI string, clusterName string) S3Folders {
+	return S3Folders{
+		s3URI:       s3URI,
+		clusterName: clusterName,
+	}
+}
+
+func (n S3Folders) root() S3Folder {
+	return newS3Folder(n.s3URI)
+}
+
+func (n S3Folders) Cluster() S3Folder {
+	return n.root().subFolder(fmt.Sprintf("kube-aws/clusters/%s", n.clusterName))
+}
+
+func (n S3Folders) ClusterBackups() S3Folder {
+	return n.Cluster().subFolder("backup")
+}
+
+func (n S3Folders) ClusterExportedStacks() S3Folder {
+	return n.Cluster().subFolder("exported/stacks")
+}
+
+type S3Folder struct {
+	s3URI string
+}
+
+func newS3Folder(uri string) S3Folder {
+	return S3Folder{
+		s3URI: strings.TrimSuffix(uri, "/"),
+	}
+}
+
+func (f S3Folder) Path() string {
+	uri := strings.TrimSuffix(f.s3URI, "/")
+	return strings.TrimPrefix(uri, "s3://")
+}
+
+func (f S3Folder) URI() string {
+	return f.s3URI
+}
+
+func (f S3Folder) subFolder(name string) S3Folder {
+	return newS3Folder(fmt.Sprintf("%s/%s", f.s3URI, name))
+}


### PR DESCRIPTION
Etcd snapshots are now persisted with a s3 prefix `kube-aws/clusters/<cluster name>/instances/<roo stack id/etcd-snapshots` rather than the former `kube-aws/clusters/<cluster name>/exported/stacks/etcd-snapshots`
Closes #562