### PR TITLE
Change API endpoint ELB health check to SSL:443

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -786,7 +786,7 @@
         "HealthCheck" : {
           "HealthyThreshold" : "3",
           "Interval" : "10",
-          "Target" : "TCP:443",
+          "Target" : "SSL:443",
           "Timeout" : "8",
           "UnhealthyThreshold" : "3"
         },


### PR DESCRIPTION
The API endpoint ELB health check is set to "TCP:443". This causes
"TLS handshake error" in apiserver logs. Changing it to "SSL:443" will
perform the proper SSL handshake and make the error disappear from the log.

```
I0427 03:57:55.059255       1 logs.go:41] http: TLS handshake error from 172.24.14.156:11370: EOF
I0427 03:57:55.059952       1 logs.go:41] http: TLS handshake error from 172.24.2.59:6348: EOF
```