### PR TITLE
More flexible configuration for IAM and stable naming for roles

### DIFF
--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -155,7 +155,6 @@ func (c *Cluster) TemplateURL() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get template URL: %v", err)
 	}
-
 	return asset.URL(), nil
 }
 

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -275,6 +275,10 @@ func (c *Cluster) ConsumeDeprecatedKeys() {
 		fmt.Println("WARN: controllerInstanceType is deprecated and will be removed in v0.9.7. Please use controller.instanceType instead")
 		c.Controller.InstanceType = *c.DeprecatedControllerInstanceType
 	}
+	if c.Controller.DeprecatedControllerManagedIamRoleName != "" {
+		fmt.Println("WARN: controller.managedIamRoleName is deprecated and will be removed in v0.9.7. Please use controller.iam.managedIamRoleName instead")
+		c.Controller.IAMConfig.Role.Name = c.Controller.DeprecatedControllerManagedIamRoleName
+	}
 	if c.DeprecatedControllerCreateTimeout != nil {
 		fmt.Println("WARN: controllerCreateTimeout is deprecated and will be removed in v0.9.7. Please use controller.createTimeout instead")
 		c.Controller.CreateTimeout = *c.DeprecatedControllerCreateTimeout
@@ -1251,7 +1255,7 @@ func (c Cluster) valid() error {
 		fmt.Println(`WARNING: instance types "t2.nano" and "t2.micro" are not recommended. See https://github.com/kubernetes-incubator/kube-aws/issues/258 for more information`)
 	}
 
-	if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.ManagedIamRoleName, c.Region.String()); e != nil {
+	if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
 		return e
 	}
 

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -457,7 +457,7 @@ subnets:
 		}
 		if !reflect.DeepEqual(c.Subnets, conf.subnets) {
 			t.Errorf(
-				"parsed subnets %s does not match expected subnets %s in config: %s",
+				"parsed subnets %+v does not match expected subnets %+v in config: %s",
 				c.Subnets,
 				conf.subnets,
 				confBody,

--- a/core/controlplane/config/stack_config.go
+++ b/core/controlplane/config/stack_config.go
@@ -2,12 +2,13 @@ package config
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/kubernetes-incubator/kube-aws/coreos/userdatavalidation"
 	"github.com/kubernetes-incubator/kube-aws/filereader/jsontemplate"
 	"github.com/kubernetes-incubator/kube-aws/fingerprint"
 	"github.com/kubernetes-incubator/kube-aws/model"
-	"net/url"
-	"strings"
 )
 
 type StackConfig struct {

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -185,7 +185,26 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #  # ATTENTION: Consider limiting number of characters in clusterName and managedIamRoleName to avoid the resulting IAM
 #  # role name's length from exceeding the AWS limit: 64
 #  # See https://github.com/kubernetes-incubator/kube-aws/issues/347
-#  managedIamRoleName: "yourManagedRole"
+#  # if you omit this block kube-aws would create an IAM Role and a customer managed policy with a random name.
+#  #iam:
+#    # role:
+#       # This will create a named IAM Role managed by kube-aws with the name {AWS::Region}-$managedIamRoleName.
+#       # It will have attached a customer Managed Policy that you can modify afterwards if you need more permissions for your cluster.
+#       # Be careful with the Statements you modify because an update could overwrite your own.
+#       # the Statements included in the ManagedPolicy are the minimun ones required for the Controllers to run.
+#       # name: "yourManagedRole"
+#       # if you set managedPolicies here it will be attached in addition to the created managedPolicy in kube-aws for the cluster.
+#       # CAUTION: if you attach a more restrictive policy in some resources (i.e ec2:* Deny) you can make kube-aws fail.
+#       # managedPolicies:
+#       # -  arn: "arn:aws:iam::aws:policy/AdministratorAccess"
+#       # -  arn: "arn:aws:iam::YOURACCOUNTID:policy/YOURPOLICYNAME"
+
+#       # if you set an InstanceProfile kube-aws will NOT create any IAM Role and will use the configured instanceProfile.
+#       # CAUTION: you must ensure that the IAM Role linked to the listed InstanceProfile has enough permissions to ensure kube-aws to run.
+#       # if you dont know which permissions are required is recommended to create a cluster with a managed role.
+#       # instanceProfile:
+#       #   arn: "arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME"
+
 #  # If omitted, public subnets are created by kube-aws and used for controller nodes
 #  subnets:
 #    # References subnets defined under the top-level `subnets` key by their names
@@ -282,6 +301,25 @@ worker:
 #      # If not specified, defaults to `worker.apiEndpointName`
 #      apiEndpointName: versionedPublic
 #
+#     # if you omit this block kube-aws would create an IAM Role and a customer managed policy with a random name.
+#      #iam:
+#       # role:
+#       # This will create a named IAM Role managed by kube-aws with the name {AWS::Region}-$managedIamRoleName.
+#       # It will have attached a customer Managed Policy that you can modify afterwards if you need more permissions for your cluster.
+#       # Be careful with the Statements you modify because an update could overwrite your own.
+#       # the Statements included in the ManagedPolicy are the minimun ones required for the Controllers to run.
+#       #   name: "yourManagedRole"
+#       # if you set managedPolicies here it will be attached in addition to the created managedPolicy in kube-aws for the cluster.
+#       # CAUTION: if you attach a more restrictive policy in some resources (i.e ec2:* Deny) you can make kube-aws fail.
+#       #   managedPolicies:
+#       #     - arn: "arn:aws:iam::aws:policy/AdministratorAccess"
+#       #     - arn: "arn:aws:iam::YOURACCOUNTID:policy/YOURPOLICYNAME"
+
+#       # if you set an InstanceProfile kube-aws will NOT create any IAM Role and will use the configured instanceProfile.
+#       # CAUTION: you must ensure that the IAM Role linked to the listed InstanceProfile has enough permissions to ensure kube-aws to run.
+#       # if you dont know which permissions are required is recommended to create a cluster with a managed role.
+#       # instanceProfile:
+#       #   arn: "arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME"
 #      # Configuration for external managed ALBs Target Groups for worker nodes
 #      targetGroup:
 #        enabled: true

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -130,6 +130,7 @@
       },
       "DependsOn": ["{{$.Etcd.LogicalName}}{{minus $.Etcd.Count 1}}"]
     },
+    {{ if not .Controller.IAMConfig.InstanceProfile.Arn }}
     "IAMInstanceProfileController": {
       "Properties": {
         "Path": "/",
@@ -141,6 +142,7 @@
       },
       "Type": "AWS::IAM::InstanceProfile"
     },
+    {{end}}
     "IAMInstanceProfileEtcd": {
       "Properties": {
         "Path": "/",
@@ -152,32 +154,15 @@
       },
       "Type": "AWS::IAM::InstanceProfile"
     },
-    "IAMRoleController": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
+    {{ if not .Controller.IAMConfig.InstanceProfile.Arn }}
+    "IAMManagedPolicyController" : {
+      "Type" : "AWS::IAM::ManagedPolicy",
+      "Properties" : {
+        "Description" : "Policy for managing kube-aws k8s controllers",
+        "Path" : "/",
+        "PolicyDocument" :   {
+          "Version":"2012-10-17",
           "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "ec2.{{.Region.PublicDomainName}}"
-                ]
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "Path": "/",
-        {{if .Controller.ManagedIamRoleName }}
-        "RoleName":  {"Fn::Join": ["",[{"Ref": "AWS::StackName"},"-",{"Ref": "AWS::Region"},"-","{{.Controller.ManagedIamRoleName}}"]]},
-        {{end}}
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
                 {
                   "Action": "ec2:*",
                   "Effect": "Allow",
@@ -188,13 +173,13 @@
                   "Effect": "Allow",
                   "Resource": "*"
                 },
-		{
+		            {
                   "Effect": "Allow",
-		  "Action": [
-			"s3:GetObject"
-		  ],
-		  "Resource": "arn:{{.Region.Partition}}:s3:::{{$.UserDataControllerS3Prefix}}*"
-		},
+                  "Action": [
+                  "s3:GetObject"
+                  ],
+                  "Resource": "arn:{{.Region.Partition}}:s3:::{{$.UserDataControllerS3Prefix}}*"
+		            },
                 {{if .WaitSignal.Enabled}}
                 {
                   "Action": "cloudformation:SignalResource",
@@ -257,15 +242,42 @@
                   "Resource": "*",
                   "Effect": "Allow"
                 }
+          ]
+        }
+      }
+    },
+    "IAMRoleController": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
               ],
-              "Version": "2012-10-17"
-            },
-            "PolicyName": "root"
-          }
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.{{.Region.PublicDomainName}}"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        {{if .Controller.IAMConfig.Role.Name }}
+        "RoleName":  {"Fn::Join": ["",[{"Ref": "AWS::Region"},"-","{{.Controller.IAMConfig.Role.Name}}"]]},
+        {{end}}
+        "ManagedPolicyArns": [ 
+          {{range $policyIndex, $policyArn := .Controller.IAMConfig.Role.ManagedPolicies }}
+            "{{$policyArn.Arn}}",
+          {{end}}
+          {"Ref": "IAMManagedPolicyController"}
         ]
       },
       "Type": "AWS::IAM::Role"
     },
+    {{end}}
     "IAMRoleEtcd": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -716,9 +728,13 @@
             }
           }
         ],
+        {{if .Controller.IAMConfig.InstanceProfile.Arn }}
+        "IamInstanceProfile": "{{.Controller.IAMConfig.InstanceProfile.Arn}}",
+        {{else}}
         "IamInstanceProfile": {
           "Ref": "IAMInstanceProfileController"
         },
+        {{end}}
         "ImageId": "{{.AMI}}",
         "InstanceType": "{{.Controller.InstanceType}}",
         {{if .KeyName}}"KeyName": "{{.KeyName}}",{{end}}
@@ -1516,6 +1532,13 @@
     },
     {{end}}
     {{end}}
+    {{ if not .Controller.IAMConfig.InstanceProfile.Arn }}
+    "ControllerIAMRoleArn": {
+      "Description": "The ARN of the IAM role for Controllers",
+      "Value": { "Fn::GetAtt": ["IAMRoleController", "Arn"] },
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-ControllerIAMRoleArn" } }
+    },
+    {{end}}
     "WorkerSecurityGroup" : {
       "Description" : "The security group assigned to worker nodes",
       "Value" :  { "Ref" : "SecurityGroupWorker" },
@@ -1524,11 +1547,6 @@
     "StackName": {
       "Description": "The name of this stack which is used by node pool stacks to import outputs from this stack",
       "Value": { "Ref": "AWS::StackName" }
-    },
-    "ControllerIAMRoleArn": {
-      "Description": "The ARN of the IAM role for this Node Pool",
-      "Value": { "Fn::GetAtt": ["IAMRoleController", "Arn"] },
-      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-ControllerIAMRoleArn" } }
     }
   }
 }

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -78,11 +78,17 @@
             {{if $spec.SpotPrice}}
             "SpotPrice": "{{$spec.SpotPrice}}",
             {{end}}
+            {{if $.IAMConfig.InstanceProfile.Arn }}
+            "IamInstanceProfile": {
+              "Arn": "{{$.IAMConfig.InstanceProfile.Arn}}" 
+            },
+            {{else}}
             "IamInstanceProfile": {
               "Arn": {
                 "Fn::GetAtt" : ["IAMInstanceProfileWorker", "Arn"]
               }
             },
+            {{end}}
             "BlockDeviceMappings": [
               {
                 "DeviceName": "/dev/xvda",
@@ -233,9 +239,11 @@
           }
           {{- end -}}
         ],
-        "IamInstanceProfile": {
-          "Ref": "IAMInstanceProfileWorker"
-        },
+         {{if .IAMConfig.InstanceProfile.Arn }}
+        "IamInstanceProfile": "{{.IAMConfig.InstanceProfile.Arn}}",
+        {{else}}
+        "IamInstanceProfile": { "Ref": "IAMInstanceProfileWorker" },
+        {{end}}
         "ImageId": "{{.AMI}}",
         "InstanceType": "{{.InstanceType}}",
         {{if .KeyName}}"KeyName": "{{.KeyName}}",{{end}}
@@ -253,23 +261,13 @@
         "UserData": {{template "UserData" $}}
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration"
+    {{if not .IAMConfig.InstanceProfile.Arn}}
     },
-{{end}}
-{
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "kube-aws Kubernetes node pool {{.ClusterName}} {{.NodePoolName}}",
-  "Parameters" : {
-    "ControlPlaneStackName": {
-      "Type": "String",
-      "Description": "The name of a control-plane stack used to import values into this stack"
-    }
-  },
-  "Resources": {
-    {{if .SpotFleet.Enabled}}
-    {{template "SpotFleet" .}}
     {{else}}
-    {{template "AutoScaling" .}}
+    }
     {{end}}
+{{end}}
+{{define "IAMRole"}}
     "IAMInstanceProfileWorker": {
       "Properties": {
         "Path": "/",
@@ -281,32 +279,14 @@
       },
       "Type": "AWS::IAM::InstanceProfile"
     },
-    "IAMRoleWorker": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
+    "IAMManagedPolicyWorker" : {
+      "Type" : "AWS::IAM::ManagedPolicy",
+      "Properties" : {
+        "Description" : "Policy for managing kube-aws k8s Node Pool {{.NodePoolName}} ",
+        "Path" : "/",
+        "PolicyDocument" :   {
+          "Version":"2012-10-17",
           "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "ec2.{{.Region.PublicDomainName}}"
-                ]
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "Path": "/",
-        {{if .ManagedIamRoleName }}
-        "RoleName":  {"Fn::Join": ["",[{"Ref": "AWS::StackName"},"-",{"Ref": "AWS::Region"},"-","{{.ManagedIamRoleName}}"]]},
-        {{end}}
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
                 {
                   "Action": "ec2:Describe*",
                   "Effect": "Allow",
@@ -393,13 +373,13 @@
                   "Effect": "Allow",
                   "Resource": "*"
                 },
+                {{end}}
                 {{if or .LoadBalancer.Enabled  .TargetGroup.Enabled}}
                 {
                   "Action": "elasticloadbalancing:*",
                   "Effect": "Allow",
                   "Resource": "*"
                 },
-                {{end}}
                 {{end}}
                 {
                   "Action": [
@@ -414,22 +394,69 @@
                   "Resource": "*",
                   "Effect": "Allow"
                 }
+            ]
+        }
+      }
+    },
+    "IAMRoleWorker": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
               ],
-              "Version": "2012-10-17"
-            },
-            "PolicyName": "root"
-          }
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.{{.Region.PublicDomainName}}"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        {{if .IAMConfig.Role.Name }}
+        "RoleName":  {"Fn::Join": ["",[{"Ref": "AWS::Region"},"-","{{.IAMConfig.Role.Name}}"]]},
+        {{end}}
+        "ManagedPolicyArns": [ 
+          {{range $policyIndex, $policyArn := .IAMConfig.Role.ManagedPolicies }}
+            "{{$policyArn.Arn}}",
+          {{end}}
+          {"Ref": "IAMManagedPolicyWorker"}
         ]
       },
       "Type": "AWS::IAM::Role"
     }
+{{end}}
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "kube-aws Kubernetes node pool {{.ClusterName}} {{.NodePoolName}}",
+  "Parameters" : {
+    "ControlPlaneStackName": {
+      "Type": "String",
+      "Description": "The name of a control-plane stack used to import values into this stack"
+    }
+  },
+  "Resources": {
+    {{if .SpotFleet.Enabled}}
+    {{template "SpotFleet" .}}
+    {{else}}
+    {{template "AutoScaling" .}}
+    {{end}}
+    {{if not .IAMConfig.InstanceProfile.Arn}}
+    {{template "IAMRole" .}}
+    {{end}}
   },
   "Outputs": {
+    {{if not .IAMConfig.InstanceProfile.Arn }}
     "WorkerIAMRoleArn": {
       "Description": "The ARN of the IAM role for this Node Pool",
       "Value": { "Fn::GetAtt": ["IAMRoleWorker", "Arn"] },
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-WorkerIAMRoleArn" } }
     },
+    {{end}}
     "StackName": {
       "Description": "The name of this stack",
       "Value": { "Ref": "AWS::StackName" }

--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -42,24 +42,29 @@
     }{{end}}
   },
   "Outputs": {
-    "ControlPlaneStackName": {
-      "Description": "The name of the control plane stack",
-      "Value": {"Fn::GetAtt" : [ "{{$.ControlPlane.Name}}" , "Outputs.StackName" ]}
-    },
+    {{ if $.ControlPlane.NeedToExportIAMroles }}
     "ControllerIAMRoleArn": {
       "Description": "The IAM Role ARN for controller nodes",
       "Value": {"Fn::GetAtt" : [ "{{$.ControlPlane.Name}}" , "Outputs.ControllerIAMRoleArn" ]},
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-ControllerIAMRoleArn" } }
-    }{{range $_, $p := .NodePools}},
-    "NodePool{{ $p.Name }}StackName": {
-      "Description": "The name of the {{$p.Name}} node pool stack",
-      "Value": {"Fn::GetAtt" : [ "{{$p.Name}}", "Outputs.StackName" ]},
-      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-NodePool{{$p.Name}}StackName" } }
     },
+    {{end}}
+    "ControlPlaneStackName": {
+      "Description": "The name of the control plane stack",
+      "Value": {"Fn::GetAtt" : [ "{{$.ControlPlane.Name}}" , "Outputs.StackName" ]}
+    }{{range $_, $p := .NodePools}},
+    {{ if $p.NeedToExportIAMroles }}
     "NodePool{{ $p.Name }}WorkerIAMRoleArn": {
       "Description": "The IAM Role ARN for workers in the {{$p.Name}} node pool stack",
       "Value": {"Fn::GetAtt" : [ "{{$p.Name}}", "Outputs.WorkerIAMRoleArn" ]},
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-NodePool{{$p.Name}}WorkerIAMRoleArn" } }
-    }{{end}}
+    },
+    {{end}}
+    "NodePool{{ $p.Name }}StackName": {
+      "Description": "The name of the {{$p.Name}} node pool stack",
+      "Value": {"Fn::GetAtt" : [ "{{$p.Name}}", "Outputs.StackName" ]},
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-NodePool{{$p.Name}}StackName" } }
+    }
+    {{end}}
   }
 }

--- a/core/root/template_params.go
+++ b/core/root/template_params.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"fmt"
+
 	controlplane "github.com/kubernetes-incubator/kube-aws/core/controlplane/cluster"
 	nodepool "github.com/kubernetes-incubator/kube-aws/core/nodepool/cluster"
 )
@@ -24,6 +25,7 @@ type NestedStack interface {
 	Name() string
 	Tags() map[string]string
 	TemplateURL() (string, error)
+	NeedToExportIAMroles() bool
 }
 
 type controlPlane struct {
@@ -36,6 +38,10 @@ func (p controlPlane) Name() string {
 
 func (p controlPlane) Tags() map[string]string {
 	return p.controlPlane.StackTags
+}
+
+func (p controlPlane) NeedToExportIAMroles() bool {
+	return p.controlPlane.Controller.IAMConfig.InstanceProfile.Arn == ""
 }
 
 func (p controlPlane) TemplateURL() (string, error) {
@@ -68,6 +74,10 @@ func (p nodePool) TemplateURL() (string, error) {
 	}
 
 	return u, nil
+}
+
+func (p nodePool) NeedToExportIAMroles() bool {
+	return p.nodePool.IAMConfig.InstanceProfile.Arn == ""
 }
 
 func (c TemplateParams) ControlPlane() NestedStack {

--- a/model/controller.go
+++ b/model/controller.go
@@ -7,16 +7,17 @@ import (
 
 // TODO Merge this with NodePoolConfig
 type Controller struct {
-	AutoScalingGroup   AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
-	ClusterAutoscaler  ClusterAutoscaler `yaml:"clusterAutoscaler,omitempty"`
-	EC2Instance        `yaml:",inline"`
-	LoadBalancer       ControllerElb       `yaml:"loadBalancer,omitempty"`
-	ManagedIamRoleName string              `yaml:"managedIamRoleName,omitempty"`
-	SecurityGroupIds   []string            `yaml:"securityGroupIds"`
-	Subnets            []Subnet            `yaml:"subnets,omitempty"`
-	CustomFiles        []CustomFile        `yaml:"customFiles,omitempty"`
-	CustomSystemdUnits []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
-	UnknownKeys        `yaml:",inline"`
+	AutoScalingGroup                       AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
+	ClusterAutoscaler                      ClusterAutoscaler `yaml:"clusterAutoscaler,omitempty"`
+	EC2Instance                            `yaml:",inline"`
+	LoadBalancer                           ControllerElb       `yaml:"loadBalancer,omitempty"`
+	IAMConfig                              IAMConfig           `yaml:"iam,omitempty"`
+	DeprecatedControllerManagedIamRoleName string              `yaml:"managedIamRoleName,omitempty"`
+	SecurityGroupIds                       []string            `yaml:"securityGroupIds"`
+	Subnets                                []Subnet            `yaml:"subnets,omitempty"`
+	CustomFiles                            []CustomFile        `yaml:"customFiles,omitempty"`
+	CustomSystemdUnits                     []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
+	UnknownKeys                            `yaml:",inline"`
 }
 
 const DefaultControllerCount = 1
@@ -65,6 +66,15 @@ func (c Controller) Validate() error {
 		return errors.New("cluster-autoscaler can't be enabled for a control plane because " +
 			"allowing so for a group of controller nodes spreading over 2 or more availability zones " +
 			"results in unreliability while scaling nodes out.")
+	}
+	if c.IAMConfig.InstanceProfile.Arn != "" && (c.IAMConfig.Role.Name != "" || c.DeprecatedControllerManagedIamRoleName != "") {
+		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
+	}
+	if c.IAMConfig.InstanceProfile.Arn != "" && len(c.IAMConfig.Role.ManagedPolicies) > 0 {
+		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
+	}
+	if err := c.IAMConfig.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/model/iamconfig.go
+++ b/model/iamconfig.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type IAMConfig struct {
+	Role            IAMRole            `yaml:"role,omitempty"`
+	InstanceProfile IAMInstanceProfile `yaml:"instanceProfile,omitempty"`
+	UnknownKeys     `yaml:",inline"`
+}
+
+type IAMRole struct {
+	Name            string             `yaml:"name,omitempty"`
+	ManagedPolicies []IAMManagedPolicy `yaml:"managedPolicies,omitempty"`
+}
+
+type IAMManagedPolicy struct {
+	Arn string `yaml:"arn,omitempty"`
+}
+
+type IAMInstanceProfile struct {
+	Arn string `yaml:"arn,omitempty"`
+}
+
+func (c IAMConfig) Validate() error {
+
+	managedPolicyRegexp := regexp.MustCompile(`arn:aws:iam::((\d{12})|aws):policy/([a-zA-Z0-9-=,\\.@_]{1,128})`)
+	instanceProfileRegexp := regexp.MustCompile(`arn:aws:iam::(\d{12}):instance-profile/([a-zA-Z0-9-=,\\.@_]{1,128})`)
+	for _, policy := range c.Role.ManagedPolicies {
+		if !managedPolicyRegexp.MatchString(policy.Arn) {
+			return fmt.Errorf("invalid managed policy arn, your managed policy must match this (=arn:aws:iam::(YOURACCOUNTID|aws):policy/POLICYNAME), provided this (%s)", policy.Arn)
+		}
+	}
+	if c.InstanceProfile.Arn != "" {
+		if !instanceProfileRegexp.MatchString(c.InstanceProfile.Arn) {
+			return fmt.Errorf("invalid instance profile, your instance profile must match (=arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME), provided (%s)", c.InstanceProfile.Arn)
+		}
+
+	}
+	return nil
+
+}


### PR DESCRIPTION
this PR aims to fix issue #500 allowing Node Pools to use an existing instance profile. It also includes a brief improvement for IAM Roles managed by kube-aws supporting customer managed policies (ref #340), it also makes IAM Roles fixed and not depending on the stack name if you have configured managedIAMRoleName.

If kube-aws manages the IAM Role it will create a customer managed policy for controllers and for workers, then it will create an IAM Role with this policy attached, that enables policy updates without the need to recreating the whole stack and kube-aws users can tailor the policies to their current needs.

if kube-aws uses an existing InstanceProfile it will not create an IAM Role and the InstanceProfile used should be attached to an IAM Role with the enough level of grants to make the cluster work.

By default if you don't configure an iam block in your worker/controller  kube-aws would manage the role for you.

if you set iam.managedIamRoleName, the IAM Role will be created with the name {AWS::Region}-$managedIamRoleName.

if you set iam.existingInstanceProfile, kube-aws will use that instance profile.

if you set both, kube-aws would fail as these options are incompatible.

```
#  #iam:
#       # This will create a named IAM Role managed by kube-aws with the name {AWS::Region}-$managedIamRoleName.
#       # It will have attached a customer Managed Policy that you can modify afterwards if you need more permissions for your cluster.
#       # Be careful with the Statements you modify because an update could overwrite your own.
#       # the Statements included in the ManagedPolicy are the minimun ones required for the Controllers to run.
#       # managedIamRoleName: "yourManagedRole"
#       # ATTENTION: if you decide to use an existing InstanceProfile you need to ensure it has the needed permissions for kube-aws to run.
#       # kube-aws will not manage and never manage this InstanceProfile. IAM Roles will not be created by kube-aws in this case.
#       # existingInstanceProfile: "arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILEID"
```

probably we can expand this to define custom iam policies in cluster.yaml, i think this model brings flexibility without confusing cluster.yaml more, but i'm happy to hear your thoughts.

i will be very glad if this is merged, @jpb (this is related to your #556 work), @c-knowles this is implementing customer managed policies. 

