### PR TITLE
Improve taints validation

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1573,13 +1573,7 @@ func (e EtcdSettings) Valid() error {
 }
 
 func (c Experimental) Valid() error {
-	for _, taint := range c.Taints {
-		if taint.Effect != "NoSchedule" && taint.Effect != "PreferNoSchedule" {
-			return fmt.Errorf("Effect must be NoSchedule or PreferNoSchedule, but was %s", taint.Effect)
-		}
-	}
-
-	return nil
+	return c.Taints.Valid()
 }
 
 /*

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -88,6 +88,10 @@ func ConfigFromBytes(data []byte) (*Config, error) {
 	}
 
 	for i, np := range nodePools {
+		if err := np.Experimental.Taints.Valid(); err != nil {
+			return nil, fmt.Errorf("invalid taints for node pool at index %d: %v", i, err)
+		}
+
 		if np.APIEndpointName == "" {
 			if c.Worker.APIEndpointName == "" {
 				if len(cpConfig.APIEndpoints) > 1 {

--- a/model/taint.go
+++ b/model/taint.go
@@ -17,6 +17,26 @@ func (t Taints) String() string {
 	return strings.Join(ts, ",")
 }
 
+// Valid returns an error if the list of taints are invalid as a group
+func (t Taints) Valid() error {
+	keyEffects := map[string]int{}
+
+	for _, taint := range t {
+		if err := taint.Valid(); err != nil {
+			return err
+		}
+
+		keyEffect := taint.Key + ":" + taint.Effect
+		if _, ok := keyEffects[keyEffect]; ok {
+			return fmt.Errorf("taints must be unique by key and effect pair")
+		} else {
+			keyEffects[keyEffect] = 1
+		}
+	}
+
+	return nil
+}
+
 // Taint is a k8s node taint which is added to nodes which requires pods to tolerate
 type Taint struct {
 	Key    string `yaml:"key"`
@@ -27,4 +47,17 @@ type Taint struct {
 // String returns a taint represented in string
 func (t Taint) String() string {
 	return fmt.Sprintf("%s=%s:%s", t.Key, t.Value, t.Effect)
+}
+
+// Valid returns an error if the taint is invalid
+func (t Taint) Valid() error {
+	if len(t.Key) == 0 {
+		return fmt.Errorf("expected taint key to be a non-empty string")
+	}
+
+	if t.Effect != "NoSchedule" && t.Effect != "PreferNoSchedule" && t.Effect != "NoExecute" {
+		return fmt.Errorf("invalid taint effect: %s", t.Effect)
+	}
+
+	return nil
 }

--- a/model/taint_test.go
+++ b/model/taint_test.go
@@ -1,0 +1,182 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestTaintString(t *testing.T) {
+	taint := Taint{
+		Key:    "key",
+		Value:  "val",
+		Effect: "NoSchedule",
+	}
+
+	expected := "key=val:NoSchedule"
+	actual := taint.String()
+	if actual != expected {
+		t.Errorf("Expected taint string to be '%s', but was '%s", expected, actual)
+	}
+}
+
+func TestTaintValid(t *testing.T) {
+	testCases := []struct {
+		key     string
+		effect  string
+		isValid bool
+	}{
+		// Empty key
+		{
+			key:     "",
+			effect:  "",
+			isValid: false,
+		},
+
+		// Invalid effect
+		{
+			key:     "dedicated",
+			effect:  "UnknownEffect",
+			isValid: false,
+		},
+
+		// Valid taint
+		{
+			key:     "dedicated",
+			effect:  "NoSchedule",
+			isValid: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		taint := Taint{
+			Key:    testCase.key,
+			Value:  "",
+			Effect: testCase.effect,
+		}
+
+		err := taint.Valid()
+
+		if testCase.isValid && err != nil {
+			t.Errorf("Expected taint to be valid, but got error: %v", err)
+
+		}
+		if !testCase.isValid && err == nil {
+			t.Errorf("Expected taint to be invalid, but it was not")
+		}
+	}
+}
+
+func TestTaintsString(t *testing.T) {
+	taints := Taints([]Taint{
+		{
+			Key:    "key-1",
+			Value:  "val",
+			Effect: "NoSchedule",
+		},
+		{
+			Key:    "key-2",
+			Value:  "val",
+			Effect: "NoSchedule",
+		},
+	})
+
+	expected := "key-1=val:NoSchedule,key-2=val:NoSchedule"
+	actual := taints.String()
+	if actual != expected {
+		t.Errorf("Expected taints string to be '%s', but was '%s", expected, actual)
+	}
+}
+
+func TestTaintsValid(t *testing.T) {
+	testCases := []struct {
+		taints  Taints
+		isValid bool
+	}{
+		// Unspecified key
+		{
+			taints: Taints{
+				{
+					Key:    "",
+					Effect: "NoSchedule",
+				},
+			},
+			isValid: false,
+		},
+
+		// Duplicate key/effect pair
+		{
+			taints: Taints{
+				{
+					Key:    "dedicated",
+					Effect: "NoSchedule",
+				},
+				{
+					Key:    "dedicated",
+					Effect: "NoSchedule",
+				},
+			},
+			isValid: false,
+		},
+
+		// Valid
+		{
+			taints: Taints{
+				{
+					Key:    "dedicated",
+					Effect: "NoSchedule",
+				},
+				{
+					Key:    "dedicated",
+					Effect: "NoExecute",
+				},
+			},
+			isValid: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := testCase.taints.Valid()
+
+		if testCase.isValid && err != nil {
+			t.Errorf("Expected taint to be valid, but got error: %v", err)
+		}
+
+		if !testCase.isValid && err == nil {
+			t.Errorf("Expected taint to be invalid, but it was not")
+		}
+
+	}
+}
+
+func TestTaintsUniqKeys(t *testing.T) {
+	taints := Taints([]Taint{
+		{
+			Key:    "key-1",
+			Value:  "val",
+			Effect: "NoSchedule",
+		},
+		{
+			Key:    "key-2",
+			Value:  "val",
+			Effect: "NoSchedule",
+		},
+
+		// Ignored since the key-1 is already in use
+		{
+			Key:    "key-1",
+			Value:  "val-2",
+			Effect: "NoSchedule",
+		},
+	})
+
+	actual := taints.UniqKeys()
+
+	if len(actual) != 2 {
+		t.Errorf("Expected uniq taints list to contain 2 items, but it has %d", len(actual))
+	}
+
+	for _, taint := range actual {
+		if taint.Value != "val" {
+			t.Errorf("Expected taint value to be 'val', but was '%s'", taint.Value)
+		}
+	}
+}

--- a/model/taint_test.go
+++ b/model/taint_test.go
@@ -143,7 +143,6 @@ func TestTaintsValid(t *testing.T) {
 		if !testCase.isValid && err == nil {
 			t.Errorf("Expected taint to be invalid, but it was not")
 		}
-
 	}
 }
 

--- a/model/taint_test.go
+++ b/model/taint_test.go
@@ -145,37 +145,3 @@ func TestTaintsValid(t *testing.T) {
 		}
 	}
 }
-
-func TestTaintsUniqKeys(t *testing.T) {
-	taints := Taints([]Taint{
-		{
-			Key:    "key-1",
-			Value:  "val",
-			Effect: "NoSchedule",
-		},
-		{
-			Key:    "key-2",
-			Value:  "val",
-			Effect: "NoSchedule",
-		},
-
-		// Ignored since the key-1 is already in use
-		{
-			Key:    "key-1",
-			Value:  "val-2",
-			Effect: "NoSchedule",
-		},
-	})
-
-	actual := taints.UniqKeys()
-
-	if len(actual) != 2 {
-		t.Errorf("Expected uniq taints list to contain 2 items, but it has %d", len(actual))
-	}
-
-	for _, taint := range actual {
-		if taint.Value != "val" {
-			t.Errorf("Expected taint value to be 'val', but was '%s'", taint.Value)
-		}
-	}
-}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3400,7 +3400,7 @@ worker:
       value: bar
       effect: UnknownEffect
 `,
-			expectedErrorMessage: "Effect must be NoSchedule or PreferNoSchedule, but was UnknownEffect",
+			expectedErrorMessage: "invalid taint effect: UnknownEffect",
 		},
 		{
 			context: "WithAwsNodeLabelEnabledForTooLongClusterNameAndPoolName",

--- a/test/integration/nodepool_test.go
+++ b/test/integration/nodepool_test.go
@@ -87,7 +87,7 @@ taints:
     value: bar
     effect: UnknownEffect
 `,
-			expectedErrorMessage: "Effect must be NoSchedule or PreferNoSchedule, but was UnknownEffect",
+			expectedErrorMessage: "invalid taint effect: UnknownEffect",
 		},
 		{
 			context: "WithVpcIdAndVPCCIDRSpecified",


### PR DESCRIPTION
This PR prevents users from creating clusters with invalid taints in both the controller and node pools.

These are the rules:

- Key must be provided
- Effect must be: `NoSchedule`, `PreferNoSchedule`, and `NoExecute`
- Key/effect pair must be unique