### PR TITLE
Re: cluster-autoscaler support

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -58,7 +58,7 @@ func NewDefaultCluster() *Cluster {
 		AwsNodeLabels: AwsNodeLabels{
 			Enabled: false,
 		},
-		ClusterAutoscalerSupport: ClusterAutoscalerSupport{
+		ClusterAutoscalerSupport: model.ClusterAutoscalerSupport{
 			Enabled: false,
 		},
 		TLSBootstrap: TLSBootstrap{
@@ -81,7 +81,7 @@ func NewDefaultCluster() *Cluster {
 		NodeDrainer: NodeDrainer{
 			Enabled: false,
 		},
-		NodeLabels: NodeLabels{},
+		NodeLabels: model.NodeLabels{},
 		Plugins: Plugins{
 			Rbac: Rbac{
 				Enabled: false,
@@ -104,34 +104,35 @@ func NewDefaultCluster() *Cluster {
 
 	return &Cluster{
 		DeploymentSettings: DeploymentSettings{
-			ClusterName:                 "kubernetes",
-			VPCCIDR:                     "10.0.0.0/16",
-			ReleaseChannel:              "stable",
-			K8sVer:                      k8sVer,
-			ContainerRuntime:            "docker",
-			Subnets:                     []model.Subnet{},
-			EIPAllocationIDs:            []string{},
-			MapPublicIPs:                true,
-			Experimental:                experimental,
-			ManageCertificates:          true,
-			HyperkubeImage:              model.Image{Repo: "quay.io/coreos/hyperkube", Tag: k8sVer, RktPullDocker: false},
-			AWSCliImage:                 model.Image{Repo: "quay.io/coreos/awscli", Tag: "master", RktPullDocker: false},
-			CalicoNodeImage:             model.Image{Repo: "quay.io/calico/node", Tag: "v1.2.1", RktPullDocker: false},
-			CalicoCniImage:              model.Image{Repo: "quay.io/calico/cni", Tag: "v1.8.3", RktPullDocker: false},
-			CalicoPolicyControllerImage: model.Image{Repo: "quay.io/calico/kube-policy-controller", Tag: "v0.6.0", RktPullDocker: false},
-			CalicoCtlImage:              model.Image{Repo: "quay.io/calico/ctl", Tag: "v1.2.1", RktPullDocker: false},
-			ClusterAutoscalerImage:      model.Image{Repo: "gcr.io/google_containers/cluster-proportional-autoscaler-amd64", Tag: "1.1.1", RktPullDocker: false},
-			KubeDnsImage:                model.Image{Repo: "gcr.io/google_containers/k8s-dns-kube-dns-amd64", Tag: "1.14.2", RktPullDocker: false},
-			KubeDnsMasqImage:            model.Image{Repo: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64", Tag: "1.14.2", RktPullDocker: false},
-			KubeReschedulerImage:        model.Image{Repo: "gcr.io/google-containers/rescheduler", Tag: "v0.3.0", RktPullDocker: false},
-			DnsMasqMetricsImage:         model.Image{Repo: "gcr.io/google_containers/k8s-dns-sidecar-amd64", Tag: "1.14.2", RktPullDocker: false},
-			ExecHealthzImage:            model.Image{Repo: "gcr.io/google_containers/exechealthz-amd64", Tag: "1.2", RktPullDocker: false},
-			HeapsterImage:               model.Image{Repo: "gcr.io/google_containers/heapster", Tag: "v1.3.0", RktPullDocker: false},
-			AddonResizerImage:           model.Image{Repo: "gcr.io/google_containers/addon-resizer", Tag: "1.7", RktPullDocker: false},
-			KubeDashboardImage:          model.Image{Repo: "gcr.io/google_containers/kubernetes-dashboard-amd64", Tag: "v1.6.1", RktPullDocker: false},
-			PauseImage:                  model.Image{Repo: "gcr.io/google_containers/pause-amd64", Tag: "3.0", RktPullDocker: false},
-			FlannelImage:                model.Image{Repo: "quay.io/coreos/flannel", Tag: "v0.7.1", RktPullDocker: false},
-			DexImage:                    model.Image{Repo: "quay.io/coreos/dex", Tag: "v2.4.1", RktPullDocker: false},
+			ClusterName:                        "kubernetes",
+			VPCCIDR:                            "10.0.0.0/16",
+			ReleaseChannel:                     "stable",
+			K8sVer:                             k8sVer,
+			ContainerRuntime:                   "docker",
+			Subnets:                            []model.Subnet{},
+			EIPAllocationIDs:                   []string{},
+			MapPublicIPs:                       true,
+			Experimental:                       experimental,
+			ManageCertificates:                 true,
+			HyperkubeImage:                     model.Image{Repo: "quay.io/coreos/hyperkube", Tag: k8sVer, RktPullDocker: false},
+			AWSCliImage:                        model.Image{Repo: "quay.io/coreos/awscli", Tag: "master", RktPullDocker: false},
+			CalicoNodeImage:                    model.Image{Repo: "quay.io/calico/node", Tag: "v1.2.1", RktPullDocker: false},
+			CalicoCniImage:                     model.Image{Repo: "quay.io/calico/cni", Tag: "v1.8.3", RktPullDocker: false},
+			CalicoPolicyControllerImage:        model.Image{Repo: "quay.io/calico/kube-policy-controller", Tag: "v0.6.0", RktPullDocker: false},
+			CalicoCtlImage:                     model.Image{Repo: "quay.io/calico/ctl", Tag: "v1.2.1", RktPullDocker: false},
+			ClusterAutoscalerImage:             model.Image{Repo: "quay.io/kube-aws/cluster-autoscaler", Tag: "b432362a70f925d94240fe0bb772bd05fb8ad8d6", RktPullDocker: false},
+			ClusterProportionalAutoscalerImage: model.Image{Repo: "gcr.io/google_containers/cluster-proportional-autoscaler-amd64", Tag: "1.1.1", RktPullDocker: false},
+			KubeDnsImage:                       model.Image{Repo: "gcr.io/google_containers/k8s-dns-kube-dns-amd64", Tag: "1.14.2", RktPullDocker: false},
+			KubeDnsMasqImage:                   model.Image{Repo: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64", Tag: "1.14.2", RktPullDocker: false},
+			KubeReschedulerImage:               model.Image{Repo: "gcr.io/google-containers/rescheduler", Tag: "v0.3.0", RktPullDocker: false},
+			DnsMasqMetricsImage:                model.Image{Repo: "gcr.io/google_containers/k8s-dns-sidecar-amd64", Tag: "1.14.2", RktPullDocker: false},
+			ExecHealthzImage:                   model.Image{Repo: "gcr.io/google_containers/exechealthz-amd64", Tag: "1.2", RktPullDocker: false},
+			HeapsterImage:                      model.Image{Repo: "gcr.io/google_containers/heapster", Tag: "v1.3.0", RktPullDocker: false},
+			AddonResizerImage:                  model.Image{Repo: "gcr.io/google_containers/addon-resizer", Tag: "1.7", RktPullDocker: false},
+			KubeDashboardImage:                 model.Image{Repo: "gcr.io/google_containers/kubernetes-dashboard-amd64", Tag: "v1.6.1", RktPullDocker: false},
+			PauseImage:                         model.Image{Repo: "gcr.io/google_containers/pause-amd64", Tag: "3.0", RktPullDocker: false},
+			FlannelImage:                       model.Image{Repo: "quay.io/coreos/flannel", Tag: "v0.7.1", RktPullDocker: false},
+			DexImage:                           model.Image{Repo: "quay.io/coreos/dex", Tag: "v2.4.1", RktPullDocker: false},
 		},
 		KubeClusterSettings: KubeClusterSettings{
 			DNSServiceIP: "10.3.0.10",
@@ -494,24 +495,25 @@ type DeploymentSettings struct {
 	WaitSignal             WaitSignal        `yaml:"waitSignal"`
 
 	// Images repository
-	HyperkubeImage              model.Image `yaml:"hyperkubeImage,omitempty"`
-	AWSCliImage                 model.Image `yaml:"awsCliImage,omitempty"`
-	CalicoNodeImage             model.Image `yaml:"calicoNodeImage,omitempty"`
-	CalicoCniImage              model.Image `yaml:"calicoCniImage,omitempty"`
-	CalicoCtlImage              model.Image `yaml:"calicoCtlImage,omitempty"`
-	CalicoPolicyControllerImage model.Image `yaml:"calicoPolicyControllerImage,omitempty"`
-	ClusterAutoscalerImage      model.Image `yaml:"clusterAutoscalerImage,omitempty"`
-	KubeDnsImage                model.Image `yaml:"kubeDnsImage,omitempty"`
-	KubeDnsMasqImage            model.Image `yaml:"kubeDnsMasqImage,omitempty"`
-	KubeReschedulerImage        model.Image `yaml:"kubeReschedulerImage,omitempty"`
-	DnsMasqMetricsImage         model.Image `yaml:"dnsMasqMetricsImage,omitempty"`
-	ExecHealthzImage            model.Image `yaml:"execHealthzImage,omitempty"`
-	HeapsterImage               model.Image `yaml:"heapsterImage,omitempty"`
-	AddonResizerImage           model.Image `yaml:"addonResizerImage,omitempty"`
-	KubeDashboardImage          model.Image `yaml:"kubeDashboardImage,omitempty"`
-	PauseImage                  model.Image `yaml:"pauseImage,omitempty"`
-	FlannelImage                model.Image `yaml:"flannelImage,omitempty"`
-	DexImage                    model.Image `yaml:"dexImage,omitempty"`
+	HyperkubeImage                     model.Image `yaml:"hyperkubeImage,omitempty"`
+	AWSCliImage                        model.Image `yaml:"awsCliImage,omitempty"`
+	CalicoNodeImage                    model.Image `yaml:"calicoNodeImage,omitempty"`
+	CalicoCniImage                     model.Image `yaml:"calicoCniImage,omitempty"`
+	CalicoCtlImage                     model.Image `yaml:"calicoCtlImage,omitempty"`
+	CalicoPolicyControllerImage        model.Image `yaml:"calicoPolicyControllerImage,omitempty"`
+	ClusterAutoscalerImage             model.Image `yaml:"clusterAutoscalerImage,omitempty"`
+	ClusterProportionalAutoscalerImage model.Image `yaml:"clusterProportionalAutoscalerImage,omitempty"`
+	KubeDnsImage                       model.Image `yaml:"kubeDnsImage,omitempty"`
+	KubeDnsMasqImage                   model.Image `yaml:"kubeDnsMasqImage,omitempty"`
+	KubeReschedulerImage               model.Image `yaml:"kubeReschedulerImage,omitempty"`
+	DnsMasqMetricsImage                model.Image `yaml:"dnsMasqMetricsImage,omitempty"`
+	ExecHealthzImage                   model.Image `yaml:"execHealthzImage,omitempty"`
+	HeapsterImage                      model.Image `yaml:"heapsterImage,omitempty"`
+	AddonResizerImage                  model.Image `yaml:"addonResizerImage,omitempty"`
+	KubeDashboardImage                 model.Image `yaml:"kubeDashboardImage,omitempty"`
+	PauseImage                         model.Image `yaml:"pauseImage,omitempty"`
+	FlannelImage                       model.Image `yaml:"flannelImage,omitempty"`
+	DexImage                           model.Image `yaml:"dexImage,omitempty"`
 }
 
 // Part of configuration which is specific to worker nodes
@@ -673,24 +675,26 @@ type Cluster struct {
 }
 
 type Experimental struct {
-	Admission                   Admission                `yaml:"admission"`
-	AuditLog                    AuditLog                 `yaml:"auditLog"`
-	Authentication              Authentication           `yaml:"authentication"`
-	AwsEnvironment              AwsEnvironment           `yaml:"awsEnvironment"`
-	AwsNodeLabels               AwsNodeLabels            `yaml:"awsNodeLabels"`
-	ClusterAutoscalerSupport    ClusterAutoscalerSupport `yaml:"clusterAutoscalerSupport"`
-	TLSBootstrap                TLSBootstrap             `yaml:"tlsBootstrap"`
-	EphemeralImageStorage       EphemeralImageStorage    `yaml:"ephemeralImageStorage"`
-	Kube2IamSupport             Kube2IamSupport          `yaml:"kube2IamSupport,omitempty"`
-	LoadBalancer                LoadBalancer             `yaml:"loadBalancer"`
-	TargetGroup                 TargetGroup              `yaml:"targetGroup"`
-	NodeDrainer                 NodeDrainer              `yaml:"nodeDrainer"`
-	NodeLabels                  NodeLabels               `yaml:"nodeLabels"`
-	Plugins                     Plugins                  `yaml:"plugins"`
-	Dex                         model.Dex                `yaml:"dex"`
-	DisableSecurityGroupIngress bool                     `yaml:"disableSecurityGroupIngress"`
-	NodeMonitorGracePeriod      string                   `yaml:"nodeMonitorGracePeriod"`
-	Taints                      model.Taints             `yaml:"taints"`
+	Admission      Admission      `yaml:"admission"`
+	AuditLog       AuditLog       `yaml:"auditLog"`
+	Authentication Authentication `yaml:"authentication"`
+	AwsEnvironment AwsEnvironment `yaml:"awsEnvironment"`
+	AwsNodeLabels  AwsNodeLabels  `yaml:"awsNodeLabels"`
+	// When cluster-autoscaler support is enabled, not only controller nodes but this node pool is also given
+	// a node label and IAM permissions to run cluster-autoscaler
+	ClusterAutoscalerSupport    model.ClusterAutoscalerSupport `yaml:"clusterAutoscalerSupport"`
+	TLSBootstrap                TLSBootstrap                   `yaml:"tlsBootstrap"`
+	EphemeralImageStorage       EphemeralImageStorage          `yaml:"ephemeralImageStorage"`
+	Kube2IamSupport             Kube2IamSupport                `yaml:"kube2IamSupport,omitempty"`
+	LoadBalancer                LoadBalancer                   `yaml:"loadBalancer"`
+	TargetGroup                 TargetGroup                    `yaml:"targetGroup"`
+	NodeDrainer                 NodeDrainer                    `yaml:"nodeDrainer"`
+	NodeLabels                  model.NodeLabels               `yaml:"nodeLabels"`
+	Plugins                     Plugins                        `yaml:"plugins"`
+	Dex                         model.Dex                      `yaml:"dex"`
+	DisableSecurityGroupIngress bool                           `yaml:"disableSecurityGroupIngress"`
+	NodeMonitorGracePeriod      string                         `yaml:"nodeMonitorGracePeriod"`
+	Taints                      model.Taints                   `yaml:"taints"`
 	model.UnknownKeys           `yaml:",inline"`
 }
 
@@ -727,10 +731,6 @@ type AwsNodeLabels struct {
 	Enabled bool `yaml:"enabled"`
 }
 
-type ClusterAutoscalerSupport struct {
-	Enabled bool `yaml:"enabled"`
-}
-
 type TLSBootstrap struct {
 	Enabled bool `yaml:"enabled"`
 }
@@ -752,27 +752,6 @@ type KubeResourcesAutosave struct {
 
 type NodeDrainer struct {
 	Enabled bool `yaml:"enabled"`
-}
-
-type NodeLabels map[string]string
-
-func (l NodeLabels) Enabled() bool {
-	return len(l) > 0
-}
-
-// Returns key=value pairs separated by ',' to be passed to kubelet's `--node-labels` flag
-func (l NodeLabels) String() string {
-	labels := []string{}
-	keys := []string{}
-	for k, _ := range l {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		v := l[k]
-		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
-	}
-	return strings.Join(labels, ",")
 }
 
 type LoadBalancer struct {
@@ -1103,6 +1082,14 @@ func (c Cluster) NestedStackName() string {
 	// Convert stack name into something valid as a cfn resource name or
 	// we'll end up with cfn errors like "Template format error: Resource name test5-controlplane is non alphanumeric"
 	return strings.Title(strings.Replace(c.StackName(), "-", "", -1))
+}
+
+func (c Cluster) NodeLabels() model.NodeLabels {
+	labels := c.Experimental.NodeLabels
+	if c.Addons.ClusterAutoscaler.Enabled {
+		labels["kube-aws.coreos.com/cluster-autoscaler-supported"] = "true"
+	}
+	return labels
 }
 
 // Etcdadm returns the content of the etcdadm script to be embedded into cloud-config-etcd

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -197,7 +197,7 @@ coreos:
         --container-runtime={{.ContainerRuntime}} \
         --rkt-path=/usr/bin/rkt \
         --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
-        --node-labels node-role.kubernetes.io/master{{if .Experimental.NodeLabels.Enabled}},{{.Experimental.NodeLabels.String}} \
+        --node-labels node-role.kubernetes.io/master{{if .NodeLabels.Enabled}},{{.NodeLabels.String}} \
         {{end}} \
         --register-with-taints=node.alpha.kubernetes.io/role=master:NoSchedule \
         --allow-privileged=true \
@@ -578,7 +578,7 @@ write_files:
       kubectl apply -f "${mfdir}/kube-dns-sa.yaml"
 
       # Deployments
-      for manifest in {kube-dns-de,kube-dns-autoscaler-de,heapster-de{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}.yaml; do
+      for manifest in {kube-dns-de,kube-dns-autoscaler-de,cluster-autoscaler-de,heapster-de{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}.yaml; do
           kubectl apply -f "${mfdir}/$manifest"
       done
 
@@ -1530,7 +1530,7 @@ write_files:
                 operator: "Exists"
               containers:
               - name: autoscaler
-                image: {{ .ClusterAutoscalerImage.RepoWithTag }}
+                image: {{ .ClusterProportionalAutoscalerImage.RepoWithTag }}
                 resources:
                     requests:
                         cpu: "20m"
@@ -1794,6 +1794,64 @@ write_files:
                     - --container=heapster
                     - --poll-period=300000
                     - --estimator=exponential
+
+  {{if .Addons.ClusterAutoscaler.Enabled}}
+  - path: /srv/kubernetes/manifests/cluster-autoscaler-de.yaml
+    content: |
+        apiVersion: extensions/v1beta1
+        kind: Deployment
+        metadata:
+          name: cluster-autoscaler
+          namespace: kube-system
+          labels:
+            app: cluster-autoscaler
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: cluster-autoscaler
+          template:
+            metadata:
+              labels:
+                app: cluster-autoscaler
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: "kube-aws.coreos.com/cluster-autoscaler-supported"
+                        operator: "In"
+                        values:
+                        - "true"
+              tolerations:
+              - key: "node.alpha.kubernetes.io/role"
+                operator: "Equal"
+                value: "master"
+                effect: "NoSchedule"
+              containers:
+                - image: {{ .ClusterAutoscalerImage.RepoWithTag }}
+                  name: cluster-autoscaler
+                  resources:
+                    limits:
+                      cpu: 100m
+                      memory: 300Mi
+                    requests:
+                      cpu: 100m
+                      memory: 300Mi
+                  command:
+                    - ./cluster-autoscaler
+                    - --v=4
+                    - --stderrthreshold=info
+                    - --cloud-provider=aws
+                    - --skip-nodes-with-local-storage=false
+                    - --expander=least-waste
+                    - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled
+                  env:
+                    - name: AWS_REGION
+                      value: {{.Region}}
+                  imagePullPolicy: "Always"
+  {{end}}
 
   - path: /srv/kubernetes/manifests/heapster-svc.yaml
     content: |

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -192,7 +192,7 @@ coreos:
         --container-runtime={{.ContainerRuntime}} \
         --rkt-path=/usr/bin/rkt \
         --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
-        {{if .Experimental.NodeLabels.Enabled}}--node-labels {{.Experimental.NodeLabels.String}} \
+        {{if .Experimental.NodeLabels.Enabled}}--node-labels {{.NodeLabels.String}} \
         {{end}}--register-node=true \
         {{if .Experimental.Taints}}--register-with-taints={{.Experimental.Taints.String}}\
         {{end}}--allow-privileged=true \

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -481,13 +481,14 @@ worker:
 #      # Optional settings for both ASG-based and SpotFleet-based node pools
 #      #
 #
-#      # Tag the cloudformation stack with the key `kube-aws:cluster-autoscaler:scale-specs` with the value containing
-#      # source of truth for cluster-autoscaler to update their autoscaling target and its min/max size.
-#      # Currently, enabling this configuration doesn't automatically deploy cluster-autoscaler itself.
-#      # Please read [the original issue](https://github.com/kubernetes-incubator/kube-aws/issues/148) carefully for more information.
-#      clusterAutoscaler:
-#        minSize: 1
-#        maxSize: 3
+#      # Autoscaling by adding/removing nodes according to resource usage
+#      autoscaling:
+#        # Make this node pool an autoscaling-target of k8s cluster-autoscaler
+#        #
+#        # Beware that making this an autoscaing-target doesn't automatically deploy cluster-autoscaler itself -
+#        # turn on `addons.clusterAutoscaler.enabled` to deploy it on controller nodes.
+#        clusterAutoscaler:
+#          enabled: true
 #
 #      # Used to provide `/etc/environment` env vars with values from arbitrary CloudFormation refs
 #      awsEnvironment:
@@ -500,7 +501,8 @@ worker:
 #      awsNodeLabels:
 #        enabled: true
 #
-#      # Will provision worker nodes with IAM permissions to run cluster-autoscaler
+#      # Will provision worker nodes with IAM permissions to run cluster-autoscaler and add node labels so that
+#      # cluster-autoscaler pods are scheduled to nodes in this node pool
 #      clusterAutoscalerSupport:
 #        enabled: true
 #
@@ -1128,6 +1130,13 @@ worker:
 
 # Addon features
 addons:
+  # Will provision controller nodes with IAM permissions to run cluster-autoscaler and
+  # create a cluster-autoscaler deployment in the cluster
+  # CA runs only on controller nodes by default. Turn on `worker.nodePools[].clusterAutoscalerSupport.enabled` to
+  # add nodes from a node pool to be where CA runs
+  clusterAutoscaler:
+    enabled: false
+
   # When enabled, Kubernetes rescheduler is deployed to the cluster controller(s)
   # This feature is experimental currently so may not be production ready
   rescheduler:
@@ -1159,9 +1168,6 @@ addons:
 #   # Add predefined set of labels to the controller nodes
 #   # The set includes names of launch configurations and autoscaling groups
 #   awsNodeLabels:
-#     enabled: true
-#   # Will provision controller nodes with IAM permissions to run cluster-autoscaler
-#   clusterAutoscalerSupport:
 #     enabled: true
 #   # If enabled, instructs the controller manager to automatically issue TLS certificates to worker nodes via
 #   # certificate signing requests (csr) made to the API server using the bootstrap token. It's recommended to

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -203,12 +203,13 @@
                   "Resource": [ "*" ]
                 },
                 {{end}}
-                {{if .Experimental.ClusterAutoscalerSupport.Enabled}}
+                {{if .Addons.ClusterAutoscaler.Enabled}}
                 {
                 "Effect": "Allow",
                   "Action": [
                     "autoscaling:DescribeAutoScalingGroups",
                     "autoscaling:DescribeAutoScalingInstances",
+                    "autoscaling:DescribeTags",
                     "autoscaling:SetDesiredCapacity",
                     "autoscaling:TerminateInstanceInAutoScalingGroup"
                   ],

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -145,6 +145,13 @@
         ],
         "MinSize": "{{.MinCount}}",
         "Tags": [
+          {{if .Autoscaling.ClusterAutoscaler.Enabled}}
+          {
+            "Key": "{{.Autoscaling.ClusterAutoscaler.AutoDiscoveryTagKey}}",
+            "PropagateAtLaunch": "false",
+            "Value": ""
+          },
+          {{end}}
           {
             "Key": "kubernetes.io/cluster/{{ .ClusterName }}",
             "PropagateAtLaunch": "true",
@@ -355,15 +362,25 @@
                   "Resource": [ "*" ]
                 },
                 {{end}}
-                {{if .ClusterAutoscalerSupport.Enabled}}
+                {{if .Addons.ClusterAutoscaler.Enabled}}
                 {
-                "Effect": "Allow",
                   "Action": [
                     "autoscaling:DescribeAutoScalingGroups",
                     "autoscaling:DescribeAutoScalingInstances",
+                    "autoscaling:DescribeTags",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action": [
                     "autoscaling:SetDesiredCapacity",
                     "autoscaling:TerminateInstanceInAutoScalingGroup"
                   ],
+                  "Condition": {
+                    "Null": { "autoscaling:ResourceTag/kubernetes.io/cluster/{{.ClusterName}}": "false" }
+                  },
+                  "Effect": "Allow",
                   "Resource": "*"
                 },
                 {{end}}

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -107,10 +107,15 @@ func ConfigFromBytes(data []byte) (*Config, error) {
 			return nil, fmt.Errorf("invalid node pool at index %d: %v", i, err)
 		}
 
+		if np.Autoscaling.ClusterAutoscaler.Enabled && !cpConfig.Addons.ClusterAutoscaler.Enabled {
+			return nil, errors.New("Autoscaling with cluster-autoscaler can't be enabled for node pools because " +
+				"you didn't enabled the cluster-autoscaler addon. Enable it by turning on `addons.clusterAutoscaler.enabled`")
+		}
+
 		if err := failFastWhenUnknownKeysFound([]unknownKeyValidation{
 			{np, fmt.Sprintf("worker.nodePools[%d]", i)},
 			{np.AutoScalingGroup, fmt.Sprintf("worker.nodePools[%d].autoScalingGroup", i)},
-			{np.ClusterAutoscaler, fmt.Sprintf("worker.nodePools[%d].clusterAutoscaler", i)},
+			{np.Autoscaling.ClusterAutoscaler, fmt.Sprintf("worker.nodePools[%d].autoscaling.clusterAutoscaler", i)},
 			{np.SpotFleet, fmt.Sprintf("worker.nodePools[%d].spotFleet", i)},
 		}); err != nil {
 			return nil, err
@@ -127,11 +132,12 @@ func ConfigFromBytes(data []byte) (*Config, error) {
 		{c.Etcd.DataVolume, "etcd.dataVolume"},
 		{c.Controller, "controller"},
 		{c.Controller.AutoScalingGroup, "controller.autoScalingGroup"},
-		{c.Controller.ClusterAutoscaler, "controller.clusterAutoscaler"},
+		{c.Controller.Autoscaling.ClusterAutoscaler, "controller.autoscaling.clusterAutoscaler"},
 		{c.Controller.RootVolume, "controller.rootVolume"},
 		{c.Experimental, "experimental"},
 		{c.Addons, "addons"},
 		{c.Addons.Rescheduler, "addons.rescheduler"},
+		{c.Addons.ClusterAutoscaler, "addons.clusterAutoscaler"},
 	}
 
 	for i, np := range c.Worker.NodePools {

--- a/e2e/run
+++ b/e2e/run
@@ -78,7 +78,7 @@ main_all() {
       up
     fi
     if [ "$KUBE_AWS_UPDATE" != "" ]; then
-      update
+      scale_out
     fi
   fi
 }
@@ -104,6 +104,13 @@ init() {
 
   customize_cluster_yaml
 }
+
+regenerate_stack() {
+  cd ${WORK_DIR}
+
+  ${KUBE_AWS_CMD} render stack
+}
+
 
 regenerate_credentials() {
   cd ${WORK_DIR}
@@ -156,11 +163,15 @@ customize_cluster_yaml() {
 worker:
   nodePools:
   - name: asg1
+    autoscaling:
+      # this pool is an autoscaling-target of CA
+      clusterAutoscaler:
+        enabled: true
+    # give this pool permissions to run CA
+    clusterAutoscalerSupport:
+      enabled: true
   - name: asg2
     autoScalingGroup:
-      minSize: 0
-      maxSize: 2
-    clusterAutoscaler:
       minSize: 0
       maxSize: 2
   - name: asg3
@@ -201,6 +212,8 @@ worker:
   - name: fleet1
     spotFleet:
       targetCapacity: 1
+    clusterAutoscalerSupport:
+      enabled: true
   - name: fleet2
     spotFleet:
       targetCapacity: 2
@@ -210,9 +223,11 @@ worker:
       enabled: true
       environment:
         CFNSTACK: '{\"Ref\":\"AWS::StackId\"}'
-    clusterAutoscaler:
-      minSize: 1
-      maxSize: 3
+    autoscaling:
+      clusterAutoscaler:
+        enabled: true
+    clusterAutoscalerSupport:
+      enabled: true
     nodeDrainer:
       enabled: true
     nodeLabels:
@@ -249,6 +264,9 @@ experimental:
   awsNodeLabels:
     enabled: true
   auditLog:
+    enabled: true
+addons:
+  clusterAutoscaler:
     enabled: true
 # etcd configuration
 etcd:
@@ -337,7 +355,12 @@ main_destroy() {
 update() {
   cd ${WORK_DIR}
 
-  ${KUBE_AWS_CMD} update --s3-uri ${KUBE_AWS_S3_URI} || true
+  ${KUBE_AWS_CMD} update --s3-uri ${KUBE_AWS_S3_URI} --pretty-print || true
+  aws cloudformation wait stack-update-complete --stack-name ${KUBE_AWS_CLUSTER_NAME}
+}
+
+scale_out() {
+  cd ${WORK_DIR}
 
   SED_CMD="sed -e 's/count: 1/count: 2/' -e 's/controllerCount: 2/controllerCount: 3/'"
   diff --unified cluster.yaml <(cat cluster.yaml | sh -c "${SED_CMD}") || true
@@ -522,6 +545,10 @@ all_destroy() {
   if [ "${KUBE_AWS_DEPLOY_TO_EXISTING_VPC}" != "" ]; then
     testinfra_destroy
   fi
+}
+
+kubesys() {
+  kubectl --namespace kube-system "$@"
 }
 
 if [ "$1" == "" ]; then

--- a/model/addons.go
+++ b/model/addons.go
@@ -1,7 +1,13 @@
 package model
 
 type Addons struct {
-	Rescheduler Rescheduler `yaml:"rescheduler"`
+	Rescheduler       Rescheduler              `yaml:"rescheduler"`
+	ClusterAutoscaler ClusterAutoscalerSupport `yaml:"clusterAutoscaler,omitempty"`
+	UnknownKeys       `yaml:",inline"`
+}
+
+type ClusterAutoscalerSupport struct {
+	Enabled     bool `yaml:"enabled"`
 	UnknownKeys `yaml:",inline"`
 }
 

--- a/model/autoscaling.go
+++ b/model/autoscaling.go
@@ -1,0 +1,5 @@
+package model
+
+type Autoscaling struct {
+	ClusterAutoscaler ClusterAutoscaler `yaml:"clusterAutoscaler,omitempty"`
+}

--- a/model/controller.go
+++ b/model/controller.go
@@ -7,8 +7,8 @@ import (
 
 // TODO Merge this with NodePoolConfig
 type Controller struct {
-	AutoScalingGroup                       AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
-	ClusterAutoscaler                      ClusterAutoscaler `yaml:"clusterAutoscaler,omitempty"`
+	AutoScalingGroup                       AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
+	Autoscaling                            Autoscaling      `yaml:"autoscaling,omitempty"`
 	EC2Instance                            `yaml:",inline"`
 	LoadBalancer                           ControllerElb       `yaml:"loadBalancer,omitempty"`
 	IAMConfig                              IAMConfig           `yaml:"iam,omitempty"`
@@ -62,7 +62,7 @@ func (c Controller) Validate() error {
 		return err
 	}
 
-	if c.ClusterAutoscaler.Enabled() {
+	if c.Autoscaling.ClusterAutoscaler.Enabled {
 		return errors.New("cluster-autoscaler can't be enabled for a control plane because " +
 			"allowing so for a group of controller nodes spreading over 2 or more availability zones " +
 			"results in unreliability while scaling nodes out.")

--- a/model/node_labels.go
+++ b/model/node_labels.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type NodeLabels map[string]string
+
+func (l NodeLabels) Enabled() bool {
+	return len(l) > 0
+}
+
+// Returns key=value pairs separated by ',' to be passed to kubelet's `--node-labels` flag
+func (l NodeLabels) String() string {
+	labels := []string{}
+	keys := []string{}
+	for k, _ := range l {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := l[k]
+		if len(v) > 0 {
+			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+		} else {
+			labels = append(labels, fmt.Sprintf("%s", k))
+		}
+	}
+	return strings.Join(labels, ",")
+}

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -6,9 +6,9 @@ import (
 )
 
 type NodePoolConfig struct {
-	AutoScalingGroup                     AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
-	ClusterAutoscaler                    ClusterAutoscaler `yaml:"clusterAutoscaler"`
-	SpotFleet                            SpotFleet         `yaml:"spotFleet,omitempty"`
+	Autoscaling                          Autoscaling      `yaml:"autoscaling,omitempty"`
+	AutoScalingGroup                     AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
+	SpotFleet                            SpotFleet        `yaml:"spotFleet,omitempty"`
 	EC2Instance                          `yaml:",inline"`
 	IAMConfig                            IAMConfig `yaml:"iam,omitempty"`
 	DeprecatedNodePoolManagedIamRoleName string    `yaml:"managedIamRoleName,omitempty"`
@@ -25,13 +25,12 @@ type NodePoolConfig struct {
 }
 
 type ClusterAutoscaler struct {
-	MinSize     int `yaml:"minSize"`
-	MaxSize     int `yaml:"maxSize"`
+	Enabled     bool `yaml:"enabled,omitempty"`
 	UnknownKeys `yaml:",inline"`
 }
 
-func (a ClusterAutoscaler) Enabled() bool {
-	return a.MinSize > 0
+func (a ClusterAutoscaler) AutoDiscoveryTagKey() string {
+	return "k8s.io/cluster-autoscaler/enabled"
 }
 
 func NewDefaultNodePoolConfig() NodePoolConfig {


### PR DESCRIPTION
In #151, we've introduced the initial, incomplete, almost theoretical support for cluster-autoscaler. The situation has changed considerably since then - Now we can finally complete the cluster-autoscaler support.

## Features

* Automatically scale out a node group by adding node(s) when one or more pods in the group become unschedulable due to insufficient resource.
* Automatically scales in a node group by removing node(s) that is safe to be done so. Basically, a node group is safe to be removed when it is not running a critical k8s component

## kube-aws scope changes

* CA is now deployed automatically
  * More concretely, a k8s deployment for cluster-autoscaler is automatically created on a k8s cluster when cluster-autoscaler addon is enabled in cluster.yaml

## Configuration changes

A valid cluster.yaml for a CA-enabled cluster would now look like:
```yaml
# cluster-autoscaler addon is deployed and enabled to watch node groups so that it can scale in/out node group(s) that is registered as an autoscaling target.
addons:
  clusterAutoscaler:
    enabled: true
worker:
  nodePools:
  - name: scaled
    # Make this node pool an autoscaling target
    autoscaling:
      clusterAutoscaler:
        enabled: true
  - name: notScaled
    # This node pool is not an autoscaling target
```

* The former `experimental.clusterAutoscalerSupport.enabled` is dropped for controller nodes in favor of `addons.clusterAutoscaler.enabled`
* `worker.nodePools[].clusterAutoscaler.minSize` and `maxSize` are dropped in favor of `worker.nodePools[].autoscaling.clustserAutoscaler.enabled` and the auto discovery feature of cluster-autoscaler
* `worker.nodePools[].clusterAutoscalerSupport` is kept as-is, but not necessarily be `true` because when you've enabled `addons.clusterAutoscaler`, kube-aws by default gives enough IAM permissions to only controller nodes and CA is scheduled there.
* This work currently relies on the docker image built from a fork of cluster-autoscaler which supports the automatic node group discovery feature

## cloud-config-controller changes

* Add cluster-autoscaler deployment to be created when the CA addon is enabled

## Go changes

* The former `ClusterAutoscalerImage` is renamed to `ClusterProportionalAutoscalerImage`
* Introduce `ClusterAutoscalerImage`(`clusterAutoscalerImage` in cluster.yaml) for the cluster-autoscaler docker image reference
* `ClusterAutoscalerSupport` is no-op in controller nodes, used only for worker nodes. `Addons.ClusterAutoscaler` is used instead to give controller nodes appropriate IAM permissions and deploy CA to them.
* Most of CA related types and funcs are moved from `core/controlplane/config` to the `model` package

## IAM changes

* `autoscaling:DescribeTags` is allowed in IAM to allow enabling the automatic node group discovery feature of cluster-autoscaler

## Gotchas

Note that a node running cluster-autoscaler or kube-resources-autosave can not be scaled in:

```
09 05:29:21.523426       1 cluster.go:74] Fast evaluation: ip-10-0-0-68.ap-northeast-1.compute.internal for removal
I0509 05:29:21.523467       1 cluster.go:88] Fast evaluation: node ip-10-0-0-68.ap-northeast-1.compute.internal cannot be removed: non-deamons set, non-mirrored, kube-system pod present: cluster-autoscaler-998591511-thcpj
I0509 05:29:21.523479       1 cluster.go:74] Fast evaluation: ip-10-0-0-133.ap-northeast-1.compute.internal for removal
I0509 05:29:21.523488       1 cluster.go:103] Fast evaluation: node ip-10-0-0-133.ap-northeast-1.compute.internal may be removed
I0509 05:29:21.523493       1 cluster.go:74] Fast evaluation: ip-10-0-0-150.ap-northeast-1.compute.internal for removal
I0509 05:29:21.523530       1 cluster.go:88] Fast evaluation: node ip-10-0-0-150.ap-northeast-1.compute.internal cannot be removed: non-deamons set, non-mirrored, kube-system pod present: kube-resources-autosave-2845171460-1cbs5
```
