### PR TITLE
Fix unable to backup namespaced resources

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -912,7 +912,7 @@ write_files:
                       ingresses jobs limitranges networkpolicies  persistentvolumeclaims pods podsecuritypolicies podtemplates replicasets
                       replicationcontrollers resourcequotas secrets serviceaccounts services statefulsets thirdpartyresources
                       poddisruptionbudgets roles rolebindings) ;
-                      for ns in $(jq -r '.metadata.name' < ${DUMP_DIR}/namespaces.json);do
+                      for ns in $(jq -r '.items[].metadata.name' < ${DUMP_DIR}/namespaces.json);do
                         echo "Searching in namespace: ${ns}" ;
                         mkdir -p ${DUMP_DIR}/${ns} ;
                         for r in ${RESOURCES_IN_NAMESPACE[@]};do


### PR DESCRIPTION
The kube-resources-autosave script is unable to find the list of namespaces
and so it tries to backup resources from `null` namespace.

Log from kube-resources-autosave-dumper:

```
(...snip...)
++ jq -r .metadata.name
+ for ns in '$(jq -r '\''.metadata.name'\'' < ${DUMP_DIR}/namespaces.json)'
+ echo 'Searching in namespace: null'
+ mkdir -p /kube-resources-autosave/tmp/2017-05-09_15-18-57/null
Searching in namespace: null
(...snip...)
```