### PR TITLE
WIP: ALB as a k8s API endpoint load balancer

### DIFF
--- a/core/controlplane/cluster/describer.go
+++ b/core/controlplane/cluster/describer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 )
 
 type ClusterDescriber interface {
@@ -13,24 +14,47 @@ type ClusterDescriber interface {
 }
 
 type clusterDescriberImpl struct {
-	clusterName             string
-	elbResourceLogicalNames []string
-	session                 *session.Session
-	stackName               string
+	clusterName                    string
+	classicElbResourceLogicalNames []string
+	elbResourceLogicalNames        []string
+	session                        *session.Session
+	stackName                      string
 }
 
-func NewClusterDescriber(clusterName string, stackName string, elbResourceLogicalNames []string, session *session.Session) ClusterDescriber {
+func NewClusterDescriber(clusterName string, stackName string, classicElbResourceLogicalNames []string, elbResourceLogicalNames []string, session *session.Session) ClusterDescriber {
 	return clusterDescriberImpl{
-		clusterName:             clusterName,
-		elbResourceLogicalNames: elbResourceLogicalNames,
-		stackName:               stackName,
-		session:                 session,
+		clusterName:                    clusterName,
+		classicElbResourceLogicalNames: classicElbResourceLogicalNames,
+		elbResourceLogicalNames:        elbResourceLogicalNames,
+		stackName:                      stackName,
+		session:                        session,
 	}
 }
 
 func (c clusterDescriberImpl) Info() (*Info, error) {
-	elbNameRefs := []*string{}
-	elbNames := []string{}
+	classicElbNameRefs := []*string{}
+	classicElbNames := []string{}
+	{
+		cfSvc := cloudformation.New(c.session)
+		for _, lb := range c.classicElbResourceLogicalNames {
+			resp, err := cfSvc.DescribeStackResource(
+				&cloudformation.DescribeStackResourceInput{
+					LogicalResourceId: aws.String(lb),
+					StackName:         aws.String(c.stackName),
+				},
+			)
+			if err != nil {
+				errmsg := "unable to get public IP of controller instance:\n" + err.Error()
+				return nil, fmt.Errorf(errmsg)
+			}
+			elbName := *resp.StackResourceDetail.PhysicalResourceId
+			classicElbNameRefs = append(classicElbNameRefs, &elbName)
+			classicElbNames = append(classicElbNames, elbName)
+		}
+	}
+
+	albArnRefs := []*string{}
+	albArns := []string{}
 	{
 		cfSvc := cloudformation.New(c.session)
 		for _, lb := range c.elbResourceLogicalNames {
@@ -44,29 +68,49 @@ func (c clusterDescriberImpl) Info() (*Info, error) {
 				errmsg := "unable to get public IP of controller instance:\n" + err.Error()
 				return nil, fmt.Errorf(errmsg)
 			}
-			elbNameRefs = append(elbNameRefs, resp.StackResourceDetail.PhysicalResourceId)
-			elbNames = append(elbNames, *resp.StackResourceDetail.PhysicalResourceId)
+			albArn := *resp.StackResourceDetail.PhysicalResourceId
+			albArnRefs = append(albArnRefs, &albArn)
+			albArns = append(albArns, albArn)
 		}
 	}
 
-	elbSvc := elb.New(c.session)
-
 	var info Info
 	{
-		resp, err := elbSvc.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
-			LoadBalancerNames: elbNameRefs,
-			PageSize:          aws.Int64(2),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("error describing load balancers %v: %v", elbNames, err)
-		}
-		if len(resp.LoadBalancerDescriptions) == 0 {
-			return nil, fmt.Errorf("could not find load balancers with names %v", elbNames)
+		dnsNames := []string{}
+
+		if len(classicElbNames) > 0 {
+			elbSvc := elb.New(c.session)
+			resp, err := elbSvc.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+				LoadBalancerNames: classicElbNameRefs,
+				PageSize:          aws.Int64(2),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error describing load balancers %v: %v", classicElbNames, err)
+			}
+			if len(resp.LoadBalancerDescriptions) == 0 {
+				return nil, fmt.Errorf("could not find load balancers with names %v", classicElbNames)
+			}
+
+			for _, d := range resp.LoadBalancerDescriptions {
+				dnsNames = append(dnsNames, *d.DNSName)
+			}
 		}
 
-		dnsNames := []string{}
-		for _, d := range resp.LoadBalancerDescriptions {
-			dnsNames = append(dnsNames, *d.DNSName)
+		if len(albArns) > 0 {
+			elbv2Svc := elbv2.New(c.session)
+			resp, err := elbv2Svc.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{
+				LoadBalancerArns: albArnRefs,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error describing application load balancers %v: %v", albArns, err)
+			}
+			if len(resp.LoadBalancers) == 0 {
+				return nil, fmt.Errorf("could not find appilcation load balancers with names %v", albArns)
+			}
+
+			for _, d := range resp.LoadBalancers {
+				dnsNames = append(dnsNames, *d.DNSName)
+			}
 		}
 
 		info.Name = c.clusterName

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1668,6 +1668,11 @@ func (c *Config) ManagedELBLogicalNames() []string {
 	return c.APIEndpoints.ManagedELBLogicalNames()
 }
 
+// ManageALBLogicalNames returns all the logical names of the cfn resources corresponding to ALBs managed by kube-aws for API endpoints
+func (c *Config) ManagedALBLogicalNames() []string {
+	return c.APIEndpoints.ManagedALBLogicalNames()
+}
+
 func WithTrailingDot(s string) string {
 	if s == "" {
 		return s

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1231,6 +1231,9 @@ write_files:
           - apiserver
           - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .ControllerCount }}{{end}}
           - --bind-address=0.0.0.0
+          {{if .APIEndpoints.AnyEndpointIsALBBacked}}
+          - --insecure-bind-address=0.0.0.0
+          {{end}}
           - --etcd-servers=#ETCD_ENDPOINTS#
           - --etcd-cafile=/etc/kubernetes/ssl/ca.pem
           - --etcd-certfile=/etc/kubernetes/ssl/etcd-client.pem

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1231,9 +1231,6 @@ write_files:
           - apiserver
           - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .ControllerCount }}{{end}}
           - --bind-address=0.0.0.0
-          {{if .APIEndpoints.AnyEndpointIsALBBacked}}
-          - --insecure-bind-address=0.0.0.0
-          {{end}}
           - --etcd-servers=#ETCD_ENDPOINTS#
           - --etcd-cafile=/etc/kubernetes/ssl/ca.pem
           - --etcd-certfile=/etc/kubernetes/ssl/etcd-client.pem

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -103,6 +103,14 @@ apiEndpoints:
 #    securityGroupIds:
 #    - sg-1234567
 #
+#    # Set to false provision an ALB instead of an ELB
+#    # Defaults to true for provisioning an ELB
+#    classic: true
+#
+#
+#    # ARN of the TLS cert associated to the ALB. Required when `classic` is set to false.
+#    certificateArn:
+#
 #  #
 #  # Common configuration #1: Unversioned, internet-facing API endpoint
 #  #

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -849,12 +849,12 @@
       "Type" : "AWS::ElasticLoadBalancingV2::TargetGroup",
       "Properties" : {
         "HealthCheckIntervalSeconds" : "10",
-        "HealthCheckPath" : "/healthz",
-        "HealthCheckPort" : "8080",
-        "HealthCheckProtocol" : "HTTP",
+        "HealthCheckPath" : "/",
+        "HealthCheckPort" : "443",
+        "HealthCheckProtocol" : "HTTPS",
         "HealthCheckTimeoutSeconds" : "8",
         "HealthyThresholdCount" : "3",
-        "Matcher" : { "HttpCode" : "200" },
+        "Matcher" : { "HttpCode" : "401" },
         "Name" : "{{$.ClusterName}}-api-{{$i}}",
         "Port" : "443",
         "Protocol" : "HTTPS",
@@ -1019,14 +1019,6 @@
             "IpProtocol": "tcp",
             "ToPort": 443
           },
-          {{if .APIEndpoints.AnyEndpointIsALBBacked}}
-          {
-            "SourceSecurityGroupId" : { "Ref" : "SecurityGroupElbAPIServer" },
-            "FromPort": 8080,
-            "IpProtocol": "tcp",
-            "ToPort": 8080
-          },
-          {{end}}
           {
             "SourceSecurityGroupId" : { "Ref" : "SecurityGroupWorker" },
             "FromPort": 443,

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -45,7 +45,14 @@
           {{- if gt $i 0}},{{end}}
           {{ $ref }}
           {{- end}}
+        ],
+        "TargetGroupARNs" : [
+          {{range $i, $ref := .APIEndpoints.TargetGroupARNRefs -}}
+          {{- if gt $i 0}},{{end}}
+          {{ $ref }}
+          {{- end}}
         ]
+
       },
       {{if .WaitSignal.Enabled}}
       "CreationPolicy" : {
@@ -795,6 +802,7 @@
       }
     },
     {{ end -}}
+    {{if .LoadBalancer.Classic}}
     "{{.LoadBalancer.LogicalName}}" : {
       "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties" : {
@@ -836,6 +844,74 @@
         ]
       }
     },
+    {{else}}
+    "{{.LoadBalancer.TargetGroupLogicalName}}" : {
+      "Type" : "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties" : {
+        "HealthCheckIntervalSeconds" : "10",
+        "HealthCheckPath" : "/healthz",
+        "HealthCheckPort" : "8080",
+        "HealthCheckProtocol" : "HTTP",
+        "HealthCheckTimeoutSeconds" : "8",
+        "HealthyThresholdCount" : "3",
+        "Matcher" : { "HttpCode" : "200" },
+        "Name" : "{{$.ClusterName}}-api-{{$i}}",
+        "Port" : "443",
+        "Protocol" : "HTTPS",
+        "Tags" : [
+          {"Key": "Name", "Value": "{{$.ClusterName}}-api-{{$i}}"}
+        ],
+        "TargetGroupAttributes" : [
+          { "Key" : "deregistration_delay.timeout_seconds", "Value" : "60" },
+          { "Key" : "stickiness.enabled", "Value" : "false" }
+        ],
+        "UnhealthyThresholdCount" : "3",
+        "VpcId" : {{$.VPCRef}}
+      }
+    },
+    "{{.LoadBalancer.LogicalName}}" : {
+      "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties" : {
+        "LoadBalancerAttributes" : [
+          { "Key" : "access_logs.s3.enabled", "Value" : "false" },
+          { "Key" : "deletion_protection.enabled", "Value" : "false" },
+          { "Key" : "idle_timeout.timeout_seconds", "Value" : "60" }
+        ],
+        "Name" : "{{$.ClusterName}}-{{.LoadBalancer.LogicalName}}",
+        "Scheme": "{{if .LoadBalancer.Private}}internal{{else}}internet-facing{{end}}",
+        "SecurityGroups": [
+          {{range $sgIndex, $sgRef := .LoadBalancer.SecurityGroupRefs}}
+          {{if gt $sgIndex 0}},{{end}}
+          {{$sgRef}}
+          {{end}}
+        ],
+        "Subnets" : [
+          {{range $index, $subnet := .LoadBalancer.Subnets}}
+          {{if gt $index 0}},{{end}}
+          {{$subnet.Ref}}
+          {{end}}
+        ],
+        "Tags" : [
+          {"Key": "Name", "Value": "{{$.ClusterName}}-{{.LoadBalancer.LogicalName}}" }
+        ]
+      }
+    },
+    "{{.LoadBalancer.LogicalName}}Listener" : {
+      "Type" : "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties" : {
+        "Certificates": [{
+          "CertificateArn": "{{.LoadBalancer.CertificateARN}}"
+        }],
+        "DefaultActions" : [{
+          "TargetGroupArn" : { "Ref" : "{{.LoadBalancer.TargetGroupLogicalName}}" },
+          "Type" : "forward"
+        }],
+        "LoadBalancerArn" : { "Ref" : "{{.LoadBalancer.LogicalName}}" },
+        "Port" : "443",
+        "Protocol" : "HTTPS"
+      }
+    },
+    {{end}}
     {{if .LoadBalancer.ManageSecurityGroup -}}
     "{{.LoadBalancer.SecurityGroupLogicalName}}" : {
       "Properties": {
@@ -943,6 +1019,14 @@
             "IpProtocol": "tcp",
             "ToPort": 443
           },
+          {{if .APIEndpoints.AnyEndpointIsALBBacked}}
+          {
+            "SourceSecurityGroupId" : { "Ref" : "SecurityGroupElbAPIServer" },
+            "FromPort": 8080,
+            "IpProtocol": "tcp",
+            "ToPort": 8080
+          },
+          {{end}}
           {
             "SourceSecurityGroupId" : { "Ref" : "SecurityGroupWorker" },
             "FromPort": 443,

--- a/core/root/describer.go
+++ b/core/root/describer.go
@@ -93,7 +93,7 @@ func (c clusterDescriberImpl) Info() (*Info, error) {
 			return nil, fmt.Errorf("found multiple load balancers with name %s: %v", cpStackName, resp)
 		}
 
-		cpDescriber := cluster.NewClusterDescriber(c.clusterName, cpStackName, c.cpConfig.ManagedELBLogicalNames(), c.session)
+		cpDescriber := cluster.NewClusterDescriber(c.clusterName, cpStackName, c.cpConfig.ManagedELBLogicalNames(), c.cpConfig.ManagedALBLogicalNames(), c.session)
 
 		cpInfo, err := cpDescriber.Info()
 

--- a/e2e/run
+++ b/e2e/run
@@ -128,6 +128,21 @@ configure() {
   find .
 }
 
+prereq() {
+  cd ${WORK_DIR}
+
+  if aws iam get-server-certificate --server-certificate-name $KUBE_AWS_CLUSTER_NAME; then
+    aws iam delete-server-certificate --server-certificate-name $KUBE_AWS_CLUSTER_NAME
+  fi
+
+  echo Uploading the TLS certificate used by AWS ALB
+  aws iam upload-server-certificate \
+    --server-certificate-name $KUBE_AWS_CLUSTER_NAME \
+    --certificate-body file://credentials/apiserver.pem \
+    --certificate-chain file://credentials/ca.pem \
+    --private-key file://credentials/apiserver-key.pem
+}
+
 kube-aws() {
   cd ${WORK_DIR}
   ${KUBE_AWS_CMD} "$@"
@@ -316,7 +331,7 @@ status() {
   ${KUBE_AWS_CMD} status
 }
 
-main_destroy() {
+destroy() {
   status=$(main_status)
 
   if [ "$status" != "" ]; then
@@ -329,9 +344,6 @@ main_destroy() {
   else
     echo $(main_stack_name) does not exist. skipping.
   fi
-
-  cd ${WORK_DIR}
-  rm -Rf cluster.yaml user-data/ credentials/ stack-templates/
 }
 
 update() {
@@ -514,11 +526,12 @@ all() {
 
 rerun() {
   all_destroy
+  clean
   all
 }
 
 all_destroy() {
-  main_destroy
+  destroy
   if [ "${KUBE_AWS_DEPLOY_TO_EXISTING_VPC}" != "" ]; then
     testinfra_destroy
   fi

--- a/model/api_endpoint_lb.go
+++ b/model/api_endpoint_lb.go
@@ -12,6 +12,11 @@ const DefaultRecordSetTTL = 300
 type APIEndpointLB struct {
 	// APIAccessAllowedSourceCIDRs is network ranges of sources you'd like Kubernetes API accesses to be allowed from, in CIDR notation
 	APIAccessAllowedSourceCIDRs CIDRRanges `yaml:"apiAccessAllowedSourceCIDRs,omitempty"`
+	// Classic is set to true for provisioning an ELB, false for an ALB
+	// TODO Default to true
+	Classic bool `yaml:"classic,omitempty"`
+	// CertificateARN is the ARN of an existing TLS certificate
+	CertificateARN string `yaml:"certificateArn,omitempty"`
 	// CreateRecordSet is set to false when you want to disable creation of the record set for this api load balancer
 	CreateRecordSet *bool `yaml:"createRecordSet,omitempty"`
 	// Identifier specifies an existing load-balancer used for load-balancing controller nodes and serving this endpoint

--- a/model/derived/api_endpoint_lb.go
+++ b/model/derived/api_endpoint_lb.go
@@ -54,6 +54,14 @@ func (b APIEndpointLB) SecurityGroupLogicalName() string {
 	return fmt.Sprintf("APIEndpoint%sSG", strings.Title(b.Name))
 }
 
+func (b APIEndpointLB) TargetGroupLogicalName() string {
+	return fmt.Sprintf("APITG%s", b.Name)
+}
+
+func (b APIEndpointLB) TargetGroupARNRef() string {
+	return fmt.Sprintf(`{"Ref":"%s"}`, b.TargetGroupLogicalName())
+}
+
 // SecurityGroupRefs contains CloudFormation resource references for additional SGs associated to this LB
 func (b APIEndpointLB) SecurityGroupRefs() []string {
 	refs := []string{}

--- a/model/derived/api_endpoints.go
+++ b/model/derived/api_endpoints.go
@@ -73,16 +73,6 @@ func NewAPIEndpoints(configs []model.APIEndpoint, allSubnets []model.Subnet) (AP
 	return endpoints, nil
 }
 
-func (e APIEndpoints) AnyEndpointIsALBBacked() bool {
-	for _, endpoint := range e {
-		lb := endpoint.LoadBalancer
-		if lb.Enabled() && !lb.Classic {
-			return true
-		}
-	}
-	return false
-}
-
 // FindByName finds an API endpoint in this set by its name
 func (e APIEndpoints) FindByName(name string) (*APIEndpoint, error) {
 	endpoint, exists := e[name]


### PR DESCRIPTION
* `apiEndpoints[].classic` is added. It must be explicitly set to `false` to use ALB instead of ELB
* `apiEndpoints[].certificateArn` is required when ALB is enabled.
  * Run `aws iam upload-server-certificate --server-certificate-name kube1 --certificate-body file://credentials/apiserver.pem --certificate-chain file://credentials/ca.pem --private-key file://credentials/apiserver-key.pem` after `kube-aws render credentials` to upload certs and obtain the ARN.
* One big concern is that when one of API endpoints is backed by ALB, kube-apiserver must bind the insecure-port to be more open to the world(from `127.0.0.1` to `0.0.0.0`) for ALB health-checks.

Closes #608

TODO:

- [ ] Make `classic` true by default
