### PR TITLE
Use new K8S 1.6 AWS tagging scheme

### DIFF
--- a/Documentation/kubernetes-on-aws-prerequisites.md
+++ b/Documentation/kubernetes-on-aws-prerequisites.md
@@ -26,7 +26,7 @@ For example, if you're deploying a cluster to an existing VPC:
 * An internet gateway or a NAT gateway needs to be added to VPC before cluster can be created
   * Or [all the nodes will fail to launch because they can't pull docker images or ACIs required to run essential processes like fleet, hyperkube, etcd, awscli, cfn-signal, cfn-init.](https://github.com/kubernetes-incubator/kube-aws/issues/120)
 * Existing route tables must have a route to Internet in some form. For example, a default route to an internet gateway or to a NAT gateway via `0.0.0.0/0` would be needed or your cluster won't come up. See [a relevant issue about it](https://github.com/kubernetes-incubator/kube-aws/issues/121#issuecomment-266255407).
-* Existing route tables to be reused by kube-aws must be tagged with the key `KubernetesCluster` and your cluster's name for the value.
+* Existing route tables and/or subnets to be reused by kube-aws must be tagged with the key `kubernetes.io/cluster/$CLUSTER_NAME` and "shared" as a value.
   * Or [Kubernetes will fail to create ELBs correspond to Kubernetes services with `type=LoadBalancer`](https://github.com/kubernetes-incubator/kube-aws/issues/135)
 * ["DNS Hostnames" must be turned on before cluster can be created](https://github.com/kubernetes-incubator/kube-aws/issues/119)
   * Or etcd nodes are unable to communicate each other thus the cluster doesn't work at all

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -669,7 +669,7 @@ write_files:
            /usr/bin/aws \
              --region {{.Region}} ec2 create-tags \
              --resource $instance_id \
-             --tags '"'"'Key=KubernetesCluster,Value="{{.ClusterName}}"'"'"' '"'"'Key=Name,Value="{{.ClusterName}}-{{.StackName}}-kube-aws-worker"'"'"' '"'"'Key="kube-aws:node-pool:name",Value="{{.NodePoolName}}"'"'"'
+             --tags '"'"'Key=kubernetes.io/cluster/{{.ClusterName}},Value=""'"'"' '"'"'Key=Name,Value="{{.ClusterName}}-{{.StackName}}-kube-aws-worker"'"'"' '"'"'Key="kube-aws:node-pool:name",Value="{{.NodePoolName}}"'"'"'
            echo done.'
 
       sudo rkt rm --uuid-file=/var/run/coreos/tag-spot-instance.uuid

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -19,9 +19,9 @@
         "MinSize": "{{.MinControllerCount}}",
         "Tags": [
           {
-            "Key": "KubernetesCluster",
+            "Key": "kubernetes.io/cluster/{{.ClusterName}}",
             "PropagateAtLaunch": "true",
-            "Value": "{{.ClusterName}}"
+            "Value": "true"
           },
           {
             "Key": "Name",
@@ -427,8 +427,8 @@
           "VPCRegion": { "Ref": "AWS::Region" }
         }],
         "HostedZoneTags" : [{
-          "Key": "KubernetesCluster",
-          "Value": "{{$.ClusterName}}"
+          "Key": "kubernetes.io/cluster/{{$.ClusterName}}",
+          "Value": "true"
         }]
       }
     },
@@ -529,9 +529,9 @@
         "MinSize": "1",
         "Tags": [
           {
-            "Key": "KubernetesCluster",
+            "Key": "kubernetes.io/cluster/{{$.ClusterName}}",
             "PropagateAtLaunch": "true",
-            "Value": "{{$.ClusterName}}"
+            "Value": "true"
           },
           {
             "Key": "Name",
@@ -857,10 +857,6 @@
           {
             "Key": "Name",
             "Value": "{{$.ClusterName}}-sg-api-endpoint-{{$i}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
           }
         ],
         "VpcId": {{$.VPCRef}}
@@ -887,10 +883,6 @@
           {
             "Key": "Name",
             "Value": "{{$.ClusterName}}-sg-elb-api-server"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
           }
         ],
         "VpcId": {{$.VPCRef}}
@@ -954,10 +946,6 @@
           {
             "Key": "Name",
             "Value": "{{$.ClusterName}}-sg-controller"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
           }
         ],
         "VpcId": {{.VPCRef}}
@@ -1056,10 +1044,6 @@
           {
             "Key": "Name",
             "Value": "{{$.ClusterName}}-sg-worker"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
           }
         ],
         "VpcId": {{.VPCRef}}
@@ -1231,10 +1215,6 @@
           {
             "Key": "Name",
             "Value": "{{$.ClusterName}}-sg-etcd"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
           }
         ],
         "VpcId": {{.VPCRef}}
@@ -1294,10 +1274,6 @@
           {
             "Key": "Name",
             "Value": "{{$.ClusterName}}-sg-mount-target"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
           }
         ],
         "VpcId": {{.VPCRef}}
@@ -1314,10 +1290,6 @@
             {
               "Key": "Name",
               "Value": "SharedData"
-            },
-            {
-              "Key": "KubernetesCluster",
-              "Value": "{{.ClusterName}}"
             }
           ]
         }
@@ -1348,10 +1320,6 @@
           {
             "Key": "Name",
             "Value": "{{$.ClusterName}}-{{$subnet.LogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
           }
         ],
         "VpcId": {{$.VPCRef}}
@@ -1374,10 +1342,6 @@
           {
             "Key": "Name",
             "Value": "{{$.ClusterName}}-{{$subnet.RouteTableLogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
           }
         ],
         "VpcId": {{$.VPCRef}}
@@ -1453,10 +1417,6 @@
           {
             "Key": "Name",
             "Value": "{{$.ClusterName}}-{{.InternetGatewayLogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
           }
         ]
       },
@@ -1471,8 +1431,8 @@
         "InstanceTenancy": "default",
         "Tags": [
           {
-            "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
+            "Key": "kubernetes.io/cluster/{{.ClusterName}}",
+            "Value": "true"
           },
           {
             "Key": "Name",

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -146,9 +146,9 @@
         "MinSize": "{{.MinCount}}",
         "Tags": [
           {
-            "Key": "KubernetesCluster",
+            "Key": "kubernetes.io/cluster/{{ .ClusterName }}",
             "PropagateAtLaunch": "true",
-            "Value": "{{.ClusterName}}"
+            "Value": "true"
           },
           {
             "Key": "kube-aws:node-pool:name",

--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -7,8 +7,8 @@
       "Properties" : {
         "Tags" : [
           {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
+            "Key": "kubernetes.io/cluster/{{$.ClusterName}}",
+            "Value": "true"
           }{{range $k, $v := $.ControlPlane.Tags}},
           {
             "Key":"{{$k}}",
@@ -26,8 +26,8 @@
         },
         "Tags" : [
           {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
+            "Key": "kubernetes.io/cluster/{{$.ClusterName}}",
+            "Value": "true"
           }{{range $k, $v := $p.Tags}},
           {
             "Key":"{{$k}}",

--- a/etcdadm/etcdadm
+++ b/etcdadm/etcdadm
@@ -142,8 +142,11 @@ cluster_num_running_nodes() {
   # TODO aws autoscaling describe-auto-scaling-group
   if [ -f /sys/hypervisor/uuid ] && [ `head -c 3 /sys/hypervisor/uuid` == ec2 ]; then
     local describe_instances
-    describe_instances=$(_awscli_command ec2 describe-instances --filter Name=tag:kube-aws:role,Values=etcd Name=tag:KubernetesCluster,Values=$KUBERNETES_CLUSTER Name=instance-state-name,Values=running)
-    $describe_instances | jq -r '[ .Reservations[].Instances[] ] | length'
+    describe_instances_legacy_tagging=$(_awscli_command ec2 describe-instances --filter Name=tag:kube-aws:role,Values=etcd Name=tag:KubernetesCluster,Values=$KUBERNETES_CLUSTER Name=instance-state-name,Values=running)
+    describe_instances_new_tagging=$(_awscli_command ec2 describe-instances --filter Name=tag:kube-aws:role,Values=etcd Name=tag-key,Values=kubernetes.io/cluster/$KUBERNETES_CLUSTER Name=instance-state-name,Values=running)
+    C1=$($describe_instances_legacy_tagging | jq -r '[ .Reservations[].Instances[] ] | length')
+    C2=$($describe_instances_new_tagging | jq -r '[ .Reservations[].Instances[] ] | length')
+    echo $(( C1 + C2 ))
   else
     local f
     local n


### PR DESCRIPTION
KubernetesCluster is deprecated in favour of `kubernetes.io/cluster/$NAME`