### PR TITLE
Fix "install-kube-system" script when "clusterAutoscaler" is disabled.

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -578,7 +578,7 @@ write_files:
       kubectl apply -f "${mfdir}/kube-dns-sa.yaml"
 
       # Deployments
-      for manifest in {kube-dns-de,kube-dns-autoscaler-de,cluster-autoscaler-de,heapster-de{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}.yaml; do
+      for manifest in {kube-dns-de,kube-dns-autoscaler-de,{{ if .Addons.ClusterAutoscaler.Enabled }}cluster-autoscaler-de,{{ end }}heapster-de{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}.yaml; do
           kubectl apply -f "${mfdir}/$manifest"
       done
 


### PR DESCRIPTION
Hi @mumoshu it looks that leaving the 

      clusterAutoscaler:
        enabled: false

will break the "install-kube-system" script. This is the error in journald: 

    May 22 13:42:19 ip-10-0-1-49.ec2.internal install-kube-system[16493]: error: the path "/srv/kubernetes/manifests/cluster-autoscaler-de.yaml" does not exist