### PR TITLE
Improved node drainer

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1522,7 +1522,15 @@ func (e EtcdSettings) Valid() error {
 }
 
 func (c Experimental) Valid() error {
-	return c.Taints.Valid()
+	if err := c.Taints.Valid(); err != nil {
+		return err
+	}
+
+	if err := c.NodeDrainer.Valid(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 /*

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -79,9 +79,8 @@ func NewDefaultCluster() *Cluster {
 			Enabled: false,
 		},
 		NodeDrainer: model.NodeDrainer{
-			Enabled:       false,
-			DrainTimeout:  0,
-			DrainInterval: 5,
+			Enabled:      false,
+			DrainTimeout: 5,
 		},
 		NodeLabels: model.NodeLabels{},
 		Plugins: Plugins{

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -78,8 +78,10 @@ func NewDefaultCluster() *Cluster {
 		TargetGroup: TargetGroup{
 			Enabled: false,
 		},
-		NodeDrainer: NodeDrainer{
-			Enabled: false,
+		NodeDrainer: model.NodeDrainer{
+			Enabled:       false,
+			DrainTimeout:  0,
+			DrainInterval: 5,
 		},
 		NodeLabels: model.NodeLabels{},
 		Plugins: Plugins{
@@ -688,7 +690,7 @@ type Experimental struct {
 	Kube2IamSupport             Kube2IamSupport                `yaml:"kube2IamSupport,omitempty"`
 	LoadBalancer                LoadBalancer                   `yaml:"loadBalancer"`
 	TargetGroup                 TargetGroup                    `yaml:"targetGroup"`
-	NodeDrainer                 NodeDrainer                    `yaml:"nodeDrainer"`
+	NodeDrainer                 model.NodeDrainer              `yaml:"nodeDrainer"`
 	NodeLabels                  model.NodeLabels               `yaml:"nodeLabels"`
 	Plugins                     Plugins                        `yaml:"plugins"`
 	Dex                         model.Dex                      `yaml:"dex"`
@@ -748,10 +750,6 @@ type Kube2IamSupport struct {
 type KubeResourcesAutosave struct {
 	Enabled bool `yaml:"enabled"`
 	S3Path  string
-}
-
-type NodeDrainer struct {
-	Enabled bool `yaml:"enabled"`
 }
 
 type LoadBalancer struct {

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -726,10 +726,10 @@ func TestNodeDrainerConfig(t *testing.T) {
 			conf: `
 experimental:
   nodeDrainer:
-    enabled: false
+    enabled: true
 `,
 			nodeDrainer: model.NodeDrainer{
-				Enabled:      false,
+				Enabled:      true,
 				DrainTimeout: 5,
 			},
 		},

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -712,13 +712,15 @@ func TestNodeDrainerConfig(t *testing.T) {
 
 	validConfigs := []struct {
 		conf        string
-		nodeDrainer NodeDrainer
+		nodeDrainer model.NodeDrainer
 	}{
 		{
 			conf: `
 `,
-			nodeDrainer: NodeDrainer{
-				Enabled: false,
+			nodeDrainer: model.NodeDrainer{
+				Enabled:       false,
+				DrainTimeout:  0,
+				DrainInterval: 5,
 			},
 		},
 		{
@@ -727,8 +729,10 @@ experimental:
   nodeDrainer:
     enabled: false
 `,
-			nodeDrainer: NodeDrainer{
-				Enabled: false,
+			nodeDrainer: model.NodeDrainer{
+				Enabled:       false,
+				DrainTimeout:  0,
+				DrainInterval: 5,
 			},
 		},
 		{
@@ -736,9 +740,13 @@ experimental:
 experimental:
   nodeDrainer:
     enabled: true
+    drainTimeout: 3
+    drainInterval: 4
 `,
-			nodeDrainer: NodeDrainer{
-				Enabled: true,
+			nodeDrainer: model.NodeDrainer{
+				Enabled:       true,
+				DrainTimeout:  3,
+				DrainInterval: 4,
 			},
 		},
 	}

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -718,9 +718,8 @@ func TestNodeDrainerConfig(t *testing.T) {
 			conf: `
 `,
 			nodeDrainer: model.NodeDrainer{
-				Enabled:       false,
-				DrainTimeout:  0,
-				DrainInterval: 5,
+				Enabled:      false,
+				DrainTimeout: 5,
 			},
 		},
 		{
@@ -730,9 +729,8 @@ experimental:
     enabled: false
 `,
 			nodeDrainer: model.NodeDrainer{
-				Enabled:       false,
-				DrainTimeout:  0,
-				DrainInterval: 5,
+				Enabled:      false,
+				DrainTimeout: 5,
 			},
 		},
 		{
@@ -741,12 +739,10 @@ experimental:
   nodeDrainer:
     enabled: true
     drainTimeout: 3
-    drainInterval: 4
 `,
 			nodeDrainer: model.NodeDrainer{
-				Enabled:       true,
-				DrainTimeout:  3,
-				DrainInterval: 4,
+				Enabled:      true,
+				DrainTimeout: 3,
 			},
 		},
 	}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1072,7 +1072,7 @@ write_files:
             - replicationcontrollers
             verbs:
             - get
-          - apiGroups: ["policy"]
+          - apiGroups: [""]
             resources:
             - pods/eviction
             verbs:

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -571,6 +571,10 @@ write_files:
       kubectl apply -f "${mfdir}/calico.yaml"
       {{ end }}
 
+      {{ if .Experimental.NodeDrainer.Enabled }}
+      kubectl apply -f "${mfdir}/kube-node-drainer-asg-ds.yaml"
+      {{ end }}
+
       # Configmaps
       kubectl apply -f "${mfdir}/kube-dns-cm.yaml"
 
@@ -1020,6 +1024,94 @@ write_files:
 
       rkt rm --uuid-file=/var/run/coreos/decrypt-assets.uuid || :
 {{ end }}
+
+{{if .Experimental.NodeDrainer.Enabled}}
+  - path: /srv/kubernetes/manifests/kube-node-drainer-asg-ds.yaml
+    content: |
+        kind: DaemonSet
+        apiVersion: extensions/v1beta1
+        metadata:
+          name: kube-node-drainer-sg-ds
+          namespace: kube-system
+          labels:
+            k8s-app: kube-node-drainer-sg-ds
+        spec:
+          updateStrategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                k8s-app: kube-node-drainer-sg-ds
+              annotations:
+                scheduler.alpha.kubernetes.io/critical-pod: ''
+            spec:
+              tolerations:
+              - operator: Exists
+                effect: NoSchedule
+              - operator: Exists
+                effect: NoExecute
+              - operator: Exists
+                key: CriticalAddonsOnly
+              initContainers:
+                - name: hyperkube
+                  image: {{.HyperkubeImage.RepoWithTag}}
+                  command:
+                  - /bin/cp
+                  - -f
+                  - /hyperkube
+                  - /workdir/hyperkube
+                  volumeMounts:
+                  - mountPath: /workdir
+                    name: workdir
+              containers:
+                - name: main
+                  image: {{.AWSCliImage.RepoWithTag}}
+                  env:
+                  - name: NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  command:
+                  - /bin/sh
+                  - -xec
+                  - |
+                    kubectl()  { /lib/ld-musl-x86_64.so.1 /opt/bin/hyperkube kubectl "$@"; }
+                    metadata() { wget -O - -q http://169.254.169.254/2016-09-02/"$1"; }
+                    asg()      { aws --region="${REGION}" autoscaling "$@"; }
+
+                    INSTANCE_ID=$(metadata meta-data/instance-id)
+                    REGION=$(metadata dynamic/instance-identity/document | jq -r .region)
+                    [ -n "${REGION}" ]
+
+                    while sleep 30; do
+                      STATE=$(asg describe-auto-scaling-instances --region "${REGION}" --instance-ids "${INSTANCE_ID}" | jq -r '.AutoScalingInstances[].LifecycleState')
+                      if [ ! "${STATE}" = Terminating:Wait ]; then
+                        continue
+                      fi
+                      echo Node is in Terminating:Wait state, draining it
+
+                      if ! kubectl drain --ignore-daemonsets=true --delete-local-data=true --force=true --timeout=60s "${NODE_NAME}"; then
+                        echo Not all pods on this host can be evicted, will try again
+                        continue
+                      fi
+
+                      echo All evictable pods are gone, notifying AutoScalingGroup that instance ${INSTANCE_ID} can be shutdown
+                      ASG_NAME=$(asg describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}" | jq -r '.AutoScalingInstances[].AutoScalingGroupName')
+                      HOOK_NAME=$(asg describe-lifecycle-hooks --auto-scaling-group-name "${ASG_NAME}" | jq -r '.LifecycleHooks[].LifecycleHookName' | grep -i nodedrainer)
+
+                      echo Sending notification to ASG_NAME=${ASG_NAME} HOOK_NAME=${HOOK_NAME}
+                      asg complete-lifecycle-action --lifecycle-action-result CONTINUE --instance-id "${INSTANCE_ID}" --lifecycle-hook-name "${HOOK_NAME}" --auto-scaling-group-name "${ASG_NAME}"
+
+                      # sleep 5 mins + 1 mins, expecting that instance will be shut down in this time
+                      sleep 300
+                    done
+                  volumeMounts:
+                  - mountPath: /opt/bin
+                    name: workdir
+              volumes:
+                - name: workdir
+                  emptyDir: {}
+{{end}}
 
 {{if .Experimental.Plugins.Rbac.Enabled }}
   # TODO: remove the following binding once the TLS Bootstrapping feature is enabled by default, see:

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1075,9 +1075,13 @@ write_files:
                   - /bin/sh
                   - -xec
                   - |
-                    kubectl()  { /lib/ld-musl-x86_64.so.1 /opt/bin/hyperkube kubectl "$@"; }
                     metadata() { wget -O - -q http://169.254.169.254/2016-09-02/"$1"; }
                     asg()      { aws --region="${REGION}" autoscaling "$@"; }
+
+                    # Hyperkube binary is not statically linked, so we need to use
+                    # the musl interpreter to be able to run it in this image
+                    # See: https://github.com/kubernetes-incubator/kube-aws/pull/674#discussion_r118889687
+                    kubectl() { /lib/ld-musl-x86_64.so.1 /opt/bin/hyperkube kubectl "$@"; }
 
                     INSTANCE_ID=$(metadata meta-data/instance-id)
                     REGION=$(metadata dynamic/instance-identity/document | jq -r .region)

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -249,39 +249,6 @@ coreos:
         RequiredBy=rkt-api.service
 {{ end }}
 
-{{ if .NodeDrainer.Enabled }}
-    - name: kube-node-drainer-watch.service
-      command: start
-      enable: true
-      content: |
-          [Unit]
-          Description=drain this k8s node in response to auto scaling group lifecycle events
-
-          [Service]
-          Type=simple
-          Restart=on-failure
-          ExecStart=/opt/bin/kube-node-drainer-watch
-
-    - name: kube-node-drainer.service
-      enable: true
-      command: start
-      runtime: true
-      content: |
-        [Unit]
-        Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
-        After=multi-user.target
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=true
-        ExecStart=/bin/true
-        TimeoutStopSec=infinity
-        ExecStop=/opt/bin/kube-node-drainer
-
-        [Install]
-        WantedBy=multi-user.target
-{{ end }}
-
 {{if .UseCalico }}
     # https://github.com/coreos/docs/blob/5d7b1cccb8286185275b07db1495828be9fdb0ea/os/other-settings.md#tuning-sysctl-parameters
     - name: systemd-modules-load.service
@@ -573,69 +540,6 @@ write_files:
           '
 
       rkt rm --uuid-file=/var/run/coreos/cfn-signal.uuid || :
-
-  - path: /opt/bin/kube-node-drainer
-    permissions: 0700
-    content: |
-        #!/usr/bin/env bash
-        set -e
-
-        /usr/bin/rkt run \
-        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
-        --mount=volume=kube,target=/etc/kubernetes \
-        --uuid-file-save=/var/run/coreos/node-drainer.uuid \
-        --net=host \
-        {{.HyperkubeImage.RepoWithTag}} \
-          --exec=/kubectl -- \
-          --server={{.APIEndpointURL}}:443 \
-          --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
-          drain $(hostname) \
-          --delete-local-data \
-          --ignore-daemonsets \
-          --timeout={{.NodeDrainer.DrainTimeoutInSeconds}}s \
-          --force
-
-        /usr/bin/rkt rm --uuid-file=/var/run/coreos/node-drainer.uuid || :
-
-  - path: /opt/bin/kube-node-drainer-watch
-    permissions: 0700
-    content: |
-        #!/usr/bin/env bash
-        set -e
-
-        instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-        region=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')
-
-        retrieve_status() {
-          /usr/bin/rkt run \
-              --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
-              --mount volume=dns,target=/etc/resolv.conf \
-              --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false \
-              --mount volume=awsenv,target=/var/run/coreos \
-              --uuid-file-save=/var/run/coreos/node-drainer-current-instance-status.uuid \
-              --set-env instance_id=$instance_id --set-env region=$region \
-              --net=host \
-              --interactive \
-              --trust-keys-from-https \
-              quay.io/coreos/awscli:master --exec=/bin/sh -- -ec \
-              '
-              echo $(aws autoscaling describe-auto-scaling-instances --region=$region --instance-ids $instance_id)
-              '
-
-          (/usr/bin/rkt rm --uuid-file=/var/run/coreos/node-drainer-current-instance-status.uuid || :) > /dev/null 2>&1
-        }
-
-        echo Running drain watch loop...
-        while true; do
-          if retrieve_status | grep -q Terminating:Wait ; then
-            echo Instance terminating, draining node...
-            /opt/bin/kube-node-drainer
-            exit 0
-          else
-            echo Instance in service, nothing to do
-          fi
-          sleep 10
-        done
 
   - path: /opt/bin/cfn-etcd-environment
     owner: root:root

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -263,7 +263,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=true
         ExecStart=/bin/true
-        TimeoutStopSec=60s
+        TimeoutStopSec=infinity
         ExecStop=/bin/sh -c '/usr/bin/rkt run \
         --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
         --mount=volume=kube,target=/etc/kubernetes \
@@ -273,8 +273,11 @@ coreos:
           --server={{.APIEndpointURL}}:443 \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
           drain $(hostname) \
+          --delete-local-data \
           --ignore-daemonsets \
+          --timeout={{.NodeDrainer.DrainTimeoutInSeconds}} \
           --force'
+        ExecStopPost=/bin/sh -c 'sleep {{.NodeDrainer.DrainIntervalInSeconds}}'
 
         [Install]
         WantedBy=multi-user.target

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -250,6 +250,18 @@ coreos:
 {{ end }}
 
 {{ if .NodeDrainer.Enabled }}
+    - name: kube-node-drainer-watch.service
+      command: start
+      enable: true
+      content: |
+          [Unit]
+          Description=drain this k8s node in response to auto scaling group lifecycle events
+
+          [Service]
+          Type=simple
+          Restart=on-failure
+          ExecStart=/opt/bin/kube-node-drainer-watch
+
     - name: kube-node-drainer.service
       enable: true
       command: start
@@ -264,20 +276,7 @@ coreos:
         RemainAfterExit=true
         ExecStart=/bin/true
         TimeoutStopSec=infinity
-        ExecStop=/bin/sh -c '/usr/bin/rkt run \
-        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
-        --mount=volume=kube,target=/etc/kubernetes \
-        --net=host \
-        {{.HyperkubeImage.RepoWithTag}} \
-          --exec=/kubectl -- \
-          --server={{.APIEndpointURL}}:443 \
-          --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
-          drain $(hostname) \
-          --delete-local-data \
-          --ignore-daemonsets \
-          --timeout={{.NodeDrainer.DrainTimeoutInSeconds}}s \
-          --force'
-        ExecStopPost=/bin/sh -c 'sleep {{.NodeDrainer.DrainIntervalInSeconds}}'
+        ExecStop=/opt/bin/kube-node-drainer
 
         [Install]
         WantedBy=multi-user.target
@@ -574,6 +573,69 @@ write_files:
           '
 
       rkt rm --uuid-file=/var/run/coreos/cfn-signal.uuid || :
+
+  - path: /opt/bin/kube-node-drainer
+    permissions: 0700
+    content: |
+        #!/usr/bin/env bash
+        set -e
+
+        /usr/bin/rkt run \
+        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+        --mount=volume=kube,target=/etc/kubernetes \
+        --uuid-file-save=/var/run/coreos/node-drainer.uuid \
+        --net=host \
+        {{.HyperkubeImage.RepoWithTag}} \
+          --exec=/kubectl -- \
+          --server={{.APIEndpointURL}}:443 \
+          --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+          drain $(hostname) \
+          --delete-local-data \
+          --ignore-daemonsets \
+          --timeout={{.NodeDrainer.DrainTimeoutInSeconds}}s \
+          --force
+
+        /usr/bin/rkt rm --uuid-file=/var/run/coreos/node-drainer.uuid || :
+
+  - path: /opt/bin/kube-node-drainer-watch
+    permissions: 0700
+    content: |
+        #!/usr/bin/env bash
+        set -e
+
+        instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+        region=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')
+
+        retrieve_status() {
+          /usr/bin/rkt run \
+              --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
+              --mount volume=dns,target=/etc/resolv.conf \
+              --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false \
+              --mount volume=awsenv,target=/var/run/coreos \
+              --uuid-file-save=/var/run/coreos/node-drainer-current-instance-status.uuid \
+              --set-env instance_id=$instance_id --set-env region=$region \
+              --net=host \
+              --interactive \
+              --trust-keys-from-https \
+              quay.io/coreos/awscli:master --exec=/bin/sh -- -ec \
+              '
+              echo $(aws autoscaling describe-auto-scaling-instances --region=$region --instance-ids $instance_id)
+              '
+
+          (/usr/bin/rkt rm --uuid-file=/var/run/coreos/node-drainer-current-instance-status.uuid || :) > /dev/null 2>&1
+        }
+
+        echo Running drain watch loop...
+        while true; do
+          if retrieve_status | grep -q Terminating:Wait ; then
+            echo Instance terminating, draining node...
+            /opt/bin/kube-node-drainer
+            exit 0
+          else
+            echo Instance in service, nothing to do
+          fi
+          sleep 10
+        done
 
   - path: /opt/bin/cfn-etcd-environment
     owner: root:root

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -275,7 +275,7 @@ coreos:
           drain $(hostname) \
           --delete-local-data \
           --ignore-daemonsets \
-          --timeout={{.NodeDrainer.DrainTimeoutInSeconds}} \
+          --timeout={{.NodeDrainer.DrainTimeoutInSeconds}}s \
           --force'
         ExecStopPost=/bin/sh -c 'sleep {{.NodeDrainer.DrainIntervalInSeconds}}'
 

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -527,6 +527,11 @@ worker:
 #      # When enabled, `kubectl drain` is run on the node going to shut-down
 #      nodeDrainer:
 #        enabled: true
+#        # Time to wait, in minutes, for the `kubectl drain` command to finish. Set to `0` to disable.
+#        drainTimeout: 0
+#        # Time to wait, in minutes, after the `kubectl drain` command finishes. Use this to give some time for the
+#        # pods to be up and running elsewhere before the drained node is terminated.
+#        drainInterval: 5
 #
 #      # Kubernetes node labels to be added to worker nodes
 #      nodeLabels:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -524,12 +524,6 @@ worker:
 #      kube2IamSupport:
 #        enabled: true
 #
-#      # When enabled, `kubectl drain` is run on the node going to shut-down
-#      nodeDrainer:
-#        enabled: true
-#        # Maximum time to wait, in minutes, for the node to be completely drained. Must be an integer between 1 and 60.
-#        drainTimeout: 5
-#
 #      # Kubernetes node labels to be added to worker nodes
 #      nodeLabels:
 #        kube-aws.coreos.com/role: worker
@@ -1186,9 +1180,11 @@ addons:
 #   # This is intended to be used in combination with .controller.managedIamRoleName. See #297 for more information.
 #   kube2IamSupport:
 #     enabled: true
-#   # When enabled, `kubectl drain` is run on the node going to shut-down
+#   # When enabled, `kubectl drain` is run when the instance is being replaced by the auto scaling group
 #   nodeDrainer:
 #     enabled: true
+#     # Maximum time to wait, in minutes, for the node to be completely drained. Must be an integer between 1 and 60.
+#     drainTimeout: 5
 #   # Enable dex  integration - https://github.com/coreos/dex
 #   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
 #   # Notice: always use "https" for the "url", otherwise the Kubernetes API server will not start correctly.

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -527,11 +527,8 @@ worker:
 #      # When enabled, `kubectl drain` is run on the node going to shut-down
 #      nodeDrainer:
 #        enabled: true
-#        # Time to wait, in minutes, for the `kubectl drain` command to finish. Set to `0` to disable.
-#        drainTimeout: 0
-#        # Time to wait, in minutes, after the `kubectl drain` command finishes. Use this to give some time for the
-#        # pods to be up and running elsewhere before the drained node is terminated.
-#        drainInterval: 5
+#        # Maximum time to wait, in minutes, for the node to be completely drained. Must be an integer between 1 and 60.
+#        drainTimeout: 5
 #
 #      # Kubernetes node labels to be added to worker nodes
 #      nodeLabels:

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -230,6 +230,27 @@
                   "Resource" : "{{.KMSKeyARN}}"
                 },
                 {{end}}
+                {{if .Experimental.NodeDrainer.Enabled }}
+                {
+                  "Action": "sns:Publish",
+                  "Effect": "Allow",
+                  "Resource": { "Ref": "{{.Controller.LogicalName}}NodeDrainerLHT" }
+                },
+                {
+                  "Action": [
+                    "autoscaling:CompleteLifecycleAction",
+                    "autoscaling:DescribeAutoScalingInstances",
+                    "autoscaling:DescribeLifecycleHooks"
+                  ],
+                  "Condition": {
+                    "StringEquals": {
+                      "autoscaling:ResourceTag/aws:cloudformation:stack-id": { "Ref": "AWS::StackId" }
+                    }
+                  },
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {{end}}
                 {
                   "Action": [
                     "ecr:GetAuthorizationToken",
@@ -258,7 +279,8 @@
               "Effect": "Allow",
               "Principal": {
                 "Service": [
-                  "ec2.{{.Region.PublicDomainName}}"
+                  "ec2.{{.Region.PublicDomainName}}",
+                  "autoscaling.{{.Region.PublicDomainName}}"
                 ]
               }
             }
@@ -713,6 +735,27 @@
         ]]}}
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration"
+    },
+    {{end}}
+    {{if .Experimental.NodeDrainer.Enabled }}
+    "{{.Controller.LogicalName}}NodeDrainerLHT" : {
+      "Properties" : {
+        "DisplayName" : "SNS topic for the {{.Controller.LogicalName}} node drainer ASG lifecycle hook"
+      },
+      "Type" : "AWS::SNS::Topic"
+    },
+    "{{.Controller.LogicalName}}NodeDrainerLH" : {
+      "Properties" : {
+        "AutoScalingGroupName" : {
+          "Ref": "{{.Controller.LogicalName}}"
+        },
+        "DefaultResult" : "CONTINUE",
+        "HeartbeatTimeout" : "{{.Experimental.NodeDrainer.DrainTimeoutInSeconds}}",
+        "LifecycleTransition" : "autoscaling:EC2_INSTANCE_TERMINATING",
+        "NotificationTargetARN" : { "Ref": "{{.Controller.LogicalName}}NodeDrainerLHT" },
+        "RoleARN" : { "Fn::GetAtt": [ "IAMRoleController", "Arn" ] }
+      },
+      "Type" : "AWS::AutoScaling::LifecycleHook"
     },
     {{end}}
     "{{.Controller.LogicalName}}LC": {

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1,6 +1,16 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "kube-aws Kubernetes cluster {{.ClusterName}}",
+  "Parameters": {
+    "NotificationTargetARN": {
+      "Type": "String",
+      "Description": "ASG LifecycleHook notification target ARN"
+    },
+    "NotificationRoleARN": {
+      "Type": "String",
+      "Description": "Role to be used by ASG LifecycleHook to publish notification"
+    }
+  },
   "Resources": {
     "{{.Controller.LogicalName}}": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
@@ -232,22 +242,21 @@
                 {{end}}
                 {{if .Experimental.NodeDrainer.Enabled }}
                 {
-                  "Action": "sns:Publish",
-                  "Effect": "Allow",
-                  "Resource": { "Ref": "{{.Controller.LogicalName}}NodeDrainerLHT" }
-                },
-                {
                   "Action": [
-                    "autoscaling:CompleteLifecycleAction",
                     "autoscaling:DescribeAutoScalingInstances",
                     "autoscaling:DescribeLifecycleHooks"
                   ],
-                  "Condition": {
-                    "StringEquals": {
-                      "autoscaling:ResourceTag/aws:cloudformation:stack-id": { "Ref": "AWS::StackId" }
-                    }
-                  },
                   "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action": [
+                    "autoscaling:CompleteLifecycleAction"
+                  ],
+                  "Effect": "Allow",
+                  "Condition": {
+                    "Null": { "autoscaling:ResourceTag/kubernetes.io/cluster/{{.ClusterName}}": "false" }
+                  },
                   "Resource": "*"
                 },
                 {{end}}
@@ -279,8 +288,7 @@
               "Effect": "Allow",
               "Principal": {
                 "Service": [
-                  "ec2.{{.Region.PublicDomainName}}",
-                  "autoscaling.{{.Region.PublicDomainName}}"
+                  "ec2.{{.Region.PublicDomainName}}"
                 ]
               }
             }
@@ -738,12 +746,6 @@
     },
     {{end}}
     {{if .Experimental.NodeDrainer.Enabled }}
-    "{{.Controller.LogicalName}}NodeDrainerLHT" : {
-      "Properties" : {
-        "DisplayName" : "SNS topic for the {{.Controller.LogicalName}} node drainer ASG lifecycle hook"
-      },
-      "Type" : "AWS::SNS::Topic"
-    },
     "{{.Controller.LogicalName}}NodeDrainerLH" : {
       "Properties" : {
         "AutoScalingGroupName" : {
@@ -752,8 +754,8 @@
         "DefaultResult" : "CONTINUE",
         "HeartbeatTimeout" : "{{.Experimental.NodeDrainer.DrainTimeoutInSeconds}}",
         "LifecycleTransition" : "autoscaling:EC2_INSTANCE_TERMINATING",
-        "NotificationTargetARN" : { "Ref": "{{.Controller.LogicalName}}NodeDrainerLHT" },
-        "RoleARN" : { "Fn::GetAtt": [ "IAMRoleController", "Arn" ] }
+        "NotificationTargetARN" : { "Ref": "NotificationTargetARN" },
+        "RoleARN" : { "Ref": "NotificationRoleARN" }
       },
       "Type" : "AWS::AutoScaling::LifecycleHook"
     },

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -181,9 +181,8 @@ func (c *ProvidedConfig) Load(main *cfg.Config) error {
 
 	// Inherit parameters from the control plane stack
 	c.KubeClusterSettings = main.KubeClusterSettings
-
-	// Inherit cluster TLS bootstrap config from control plane stack
 	c.Experimental.TLSBootstrap = main.DeploymentSettings.Experimental.TLSBootstrap
+	c.Experimental.NodeDrainer = main.DeploymentSettings.Experimental.NodeDrainer
 
 	// Validate whole the inputs including inherited ones
 	if err := c.valid(); err != nil {

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -221,12 +221,6 @@
       "Metadata": {{template "Metadata" .}}
     },
     {{if .NodeDrainer.Enabled }}
-    "{{.LogicalName}}NodeDrainerLHT" : {
-      "Properties" : {
-        "DisplayName" : "SNS topic for the {{.LogicalName}} node drainer ASG lifecycle hook"
-      },
-      "Type" : "AWS::SNS::Topic"
-    },
     "{{.LogicalName}}NodeDrainerLH" : {
       "Properties" : {
         "AutoScalingGroupName" : {
@@ -235,8 +229,8 @@
         "DefaultResult" : "CONTINUE",
         "HeartbeatTimeout" : "{{.NodeDrainer.DrainTimeoutInSeconds}}",
         "LifecycleTransition" : "autoscaling:EC2_INSTANCE_TERMINATING",
-        "NotificationTargetARN" : { "Ref": "{{.LogicalName}}NodeDrainerLHT" },
-        "RoleARN" : { "Fn::GetAtt": [ "IAMRoleWorker", "Arn" ] }
+        "NotificationTargetARN" : { "Ref": "NotificationTargetARN" },
+        "RoleARN" : { "Ref": "NotificationRoleARN" }
       },
       "Type" : "AWS::AutoScaling::LifecycleHook"
     },
@@ -421,23 +415,20 @@
                 {{if .NodeDrainer.Enabled }}
                 {
                   "Action": [
-                    "sns:Publish"
-                  ],
-                  "Effect": "Allow",
-                  "Resource": { "Ref": "{{.LogicalName}}NodeDrainerLHT" }
-                },
-                {
-                  "Action": [
-                    "autoscaling:CompleteLifecycleAction",
                     "autoscaling:DescribeAutoScalingInstances",
                     "autoscaling:DescribeLifecycleHooks"
                   ],
-                  "Condition": {
-                    "StringEquals": {
-                      "autoscaling:ResourceTag/aws:cloudformation:stack-id": { "Ref": "AWS::StackId" }
-                    }
-                  },
                   "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action": [
+                    "autoscaling:CompleteLifecycleAction"
+                  ],
+                  "Effect": "Allow",
+                  "Condition": {
+                    "Null": { "autoscaling:ResourceTag/kubernetes.io/cluster/{{.ClusterName}}": "false" }
+                  },
                   "Resource": "*"
                 },
                 {{end}}
@@ -469,8 +460,7 @@
               "Effect": "Allow",
               "Principal": {
                 "Service": [
-                  "ec2.{{.Region.PublicDomainName}}",
-                  "autoscaling.{{.Region.PublicDomainName}}"
+                  "ec2.{{.Region.PublicDomainName}}"
                 ]
               }
             }
@@ -498,6 +488,14 @@
     "ControlPlaneStackName": {
       "Type": "String",
       "Description": "The name of a control-plane stack used to import values into this stack"
+    },
+    "NotificationTargetARN": {
+      "Type": "String",
+      "Description": "ASG LifecycleHook notification target ARN"
+    },
+    "NotificationRoleARN": {
+      "Type": "String",
+      "Description": "Role to be used by ASG LifecycleHook to publish notification"
     }
   },
   "Resources": {

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -220,22 +220,22 @@
       },
       "Metadata": {{template "Metadata" .}}
     },
-    {{if and .NodeDrainer.Enabled (gt .NodeDrainer.DrainInterval 0) }}
-    "{{.LogicalName}}LHT" : {
+    {{if .NodeDrainer.Enabled }}
+    "{{.LogicalName}}NodeDrainerLHT" : {
       "Properties" : {
-        "DisplayName" : "SNS topic for the {{.LogicalName}} ASG lifecycle hook"
+        "DisplayName" : "SNS topic for the {{.LogicalName}} node drainer ASG lifecycle hook"
       },
       "Type" : "AWS::SNS::Topic"
     },
-    "{{.LogicalName}}LH" : {
+    "{{.LogicalName}}NodeDrainerLH" : {
       "Properties" : {
         "AutoScalingGroupName" : {
           "Ref": "{{.LogicalName}}"
         },
         "DefaultResult" : "CONTINUE",
-        "HeartbeatTimeout" : "{{.NodeDrainer.DrainIntervalInSeconds}}",
+        "HeartbeatTimeout" : "{{.NodeDrainer.DrainTimeoutInSeconds}}",
         "LifecycleTransition" : "autoscaling:EC2_INSTANCE_TERMINATING",
-        "NotificationTargetARN" : { "Ref": "{{.LogicalName}}LHT" },
+        "NotificationTargetARN" : { "Ref": "{{.LogicalName}}NodeDrainerLHT" },
         "RoleARN" : { "Fn::GetAtt": [ "IAMRoleWorker", "Arn" ] }
       },
       "Type" : "AWS::AutoScaling::LifecycleHook"
@@ -420,9 +420,25 @@
                 {{end}}
                 {{if .NodeDrainer.Enabled }}
                 {
-                  "Action": "SNS:*",
+                  "Action": [
+                    "sns:Publish"
+                  ],
                   "Effect": "Allow",
-                  "Resource": { "Ref": "{{.LogicalName}}LHT" }
+                  "Resource": { "Ref": "{{.LogicalName}}NodeDrainerLHT" }
+                },
+                {
+                  "Action": [
+                    "autoscaling:CompleteLifecycleAction",
+                    "autoscaling:DescribeAutoScalingInstances",
+                    "autoscaling:DescribeLifecycleHooks"
+                  ],
+                  "Condition": {
+                    "StringEquals": {
+                      "autoscaling:ResourceTag/aws:cloudformation:stack-id": { "Ref": "AWS::StackId" }
+                    }
+                  },
+                  "Effect": "Allow",
+                  "Resource": "*"
                 },
                 {{end}}
                 {

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -220,7 +220,27 @@
       },
       "Metadata": {{template "Metadata" .}}
     },
-
+    {{if and .NodeDrainer.Enabled (gt .NodeDrainer.DrainInterval 0) }}
+    "{{.LogicalName}}LHT" : {
+      "Properties" : {
+        "DisplayName" : "SNS topic for the {{.LogicalName}} ASG lifecycle hook"
+      },
+      "Type" : "AWS::SNS::Topic"
+    },
+    "{{.LogicalName}}LH" : {
+      "Properties" : {
+        "AutoScalingGroupName" : {
+          "Ref": "{{.LogicalName}}"
+        },
+        "DefaultResult" : "CONTINUE",
+        "HeartbeatTimeout" : "{{.NodeDrainer.DrainIntervalInSeconds}}",
+        "LifecycleTransition" : "autoscaling:EC2_INSTANCE_TERMINATING",
+        "NotificationTargetARN" : { "Ref": "{{.LogicalName}}LHT" },
+        "RoleARN" : { "Fn::GetAtt": [ "IAMRoleWorker", "Arn" ] }
+      },
+      "Type" : "AWS::AutoScaling::LifecycleHook"
+    },
+    {{end}}
     "{{.LogicalName}}LC": {
       "Properties": {
         "BlockDeviceMappings": [
@@ -398,6 +418,13 @@
                   "Resource": "*"
                 },
                 {{end}}
+                {{if .NodeDrainer.Enabled }}
+                {
+                  "Action": "SNS:*",
+                  "Effect": "Allow",
+                  "Resource": { "Ref": "{{.LogicalName}}LHT" }
+                },
+                {{end}}
                 {
                   "Action": [
                     "ecr:GetAuthorizationToken",
@@ -426,7 +453,8 @@
               "Effect": "Allow",
               "Principal": {
                 "Service": [
-                  "ec2.{{.Region.PublicDomainName}}"
+                  "ec2.{{.Region.PublicDomainName}}",
+                  "autoscaling.{{.Region.PublicDomainName}}"
                 ]
               }
             }

--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "kube-aws Kubernetes cluster {{.ClusterName}}",
   "Resources": {
+    {{/* This queue is currently not used; for now, the only reason it exist is because we cannot create ASG Lifecycle Hooks without one of these. */}}
     "ASGNotificationTarget": {
       "Type": "AWS::SQS::Queue"
     },

--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -2,9 +2,45 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "kube-aws Kubernetes cluster {{.ClusterName}}",
   "Resources": {
+    "ASGNotificationTarget": {
+      "Type": "AWS::SQS::Queue"
+    },
+    "ASGNotificationRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [ {
+            "Action": [ "sts:AssumeRole" ],
+            "Effect": "Allow",
+            "Principal": {
+              "Service": [ "autoscaling.amazonaws.com" ]
+            }
+          } ],
+          "Version": "2012-10-17"
+        },
+        "Policies": [{
+          "PolicyName": "root",
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [ {
+              "Effect": "Allow",
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueUrl"
+              ],
+              "Resource": { "Fn::GetAtt": [ "ASGNotificationTarget", "Arn" ] }
+            } ]
+          }
+        }]
+      },
+      "Type": "AWS::IAM::Role"
+    },
     "{{.ControlPlane.Name}}": {
       "Type" : "AWS::CloudFormation::Stack",
       "Properties" : {
+        "Parameters": {
+          "NotificationTargetARN": { "Fn::GetAtt": [ "ASGNotificationTarget", "Arn" ] },
+          "NotificationRoleARN": { "Fn::GetAtt": [ "ASGNotificationRole", "Arn" ] }
+        },
         "Tags" : [
           {
             "Key": "kubernetes.io/cluster/{{$.ClusterName}}",
@@ -22,7 +58,9 @@
       "Type" : "AWS::CloudFormation::Stack",
       "Properties" : {
         "Parameters": {
-          "ControlPlaneStackName": {"Fn::GetAtt" : [ "{{$.ControlPlane.Name}}" , "Outputs.StackName" ]}
+          "ControlPlaneStackName": {"Fn::GetAtt" : [ "{{$.ControlPlane.Name}}" , "Outputs.StackName" ]},
+          "NotificationTargetARN": { "Fn::GetAtt": [ "ASGNotificationTarget", "Arn" ] },
+          "NotificationRoleARN": { "Fn::GetAtt": [ "ASGNotificationRole", "Arn" ] }
         },
         "Tags" : [
           {

--- a/model/node_drainer.go
+++ b/model/node_drainer.go
@@ -1,0 +1,19 @@
+package model
+
+import (
+	"time"
+)
+
+type NodeDrainer struct {
+	Enabled       bool `yaml:"enabled"`
+	DrainTimeout  int  `yaml:"drainTimeout"`
+	DrainInterval int  `yaml:"drainInterval"`
+}
+
+func (nd *NodeDrainer) DrainTimeoutInSeconds() int {
+	return int((time.Duration(nd.DrainTimeout) * time.Minute) / time.Second)
+}
+
+func (nd *NodeDrainer) DrainIntervalInSeconds() int {
+	return int((time.Duration(nd.DrainInterval) * time.Minute) / time.Second)
+}

--- a/model/node_drainer.go
+++ b/model/node_drainer.go
@@ -22,5 +22,6 @@ func (nd *NodeDrainer) Valid() error {
 	if nd.DrainTimeout < 1 || nd.DrainTimeout > 60 {
 		return fmt.Errorf("Drain timeout must be an integer between 1 and 60, but was %d", nd.DrainTimeout)
 	}
+
 	return nil
 }

--- a/model/node_drainer.go
+++ b/model/node_drainer.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -16,4 +17,14 @@ func (nd *NodeDrainer) DrainTimeoutInSeconds() int {
 
 func (nd *NodeDrainer) DrainIntervalInSeconds() int {
 	return int((time.Duration(nd.DrainInterval) * time.Minute) / time.Second)
+}
+
+func (nd *NodeDrainer) Valid() error {
+	if nd.DrainTimeout < 0 || nd.DrainTimeout > 60 {
+		return fmt.Errorf("Drain timeout must be an integer between 0 and 60, but was %d", nd.DrainTimeout)
+	}
+	if nd.DrainInterval < 0 || nd.DrainInterval > 60 {
+		return fmt.Errorf("Drain interval must be an integer between 0 and 60, but was %d", nd.DrainInterval)
+	}
+	return nil
 }

--- a/model/node_drainer.go
+++ b/model/node_drainer.go
@@ -6,25 +6,21 @@ import (
 )
 
 type NodeDrainer struct {
-	Enabled       bool `yaml:"enabled"`
-	DrainTimeout  int  `yaml:"drainTimeout"`
-	DrainInterval int  `yaml:"drainInterval"`
+	Enabled      bool `yaml:"enabled"`
+	DrainTimeout int  `yaml:"drainTimeout"`
 }
 
 func (nd *NodeDrainer) DrainTimeoutInSeconds() int {
 	return int((time.Duration(nd.DrainTimeout) * time.Minute) / time.Second)
 }
 
-func (nd *NodeDrainer) DrainIntervalInSeconds() int {
-	return int((time.Duration(nd.DrainInterval) * time.Minute) / time.Second)
-}
-
 func (nd *NodeDrainer) Valid() error {
-	if nd.DrainTimeout < 0 || nd.DrainTimeout > 60 {
-		return fmt.Errorf("Drain timeout must be an integer between 0 and 60, but was %d", nd.DrainTimeout)
+	if !nd.Enabled {
+		return nil
 	}
-	if nd.DrainInterval < 0 || nd.DrainInterval > 60 {
-		return fmt.Errorf("Drain interval must be an integer between 0 and 60, but was %d", nd.DrainInterval)
+
+	if nd.DrainTimeout < 1 || nd.DrainTimeout > 60 {
+		return fmt.Errorf("Drain timeout must be an integer between 1 and 60, but was %d", nd.DrainTimeout)
 	}
 	return nil
 }

--- a/model/node_drainer_test.go
+++ b/model/node_drainer_test.go
@@ -63,3 +63,53 @@ func TestDrainIntervalInSeconds(t *testing.T) {
 		}
 	}
 }
+
+func TestValid(t *testing.T) {
+	testCases := []struct {
+		drainTimeout  int
+		drainInterval int
+		isValid       bool
+	}{
+		// Invalid, drainTimeout is < 0
+		{
+			drainTimeout: -1,
+		},
+
+		// Invalid, drainTimeout > 60
+		{
+			drainTimeout: 61,
+		},
+
+		// Invalid, drainInterval < 0
+		{
+			drainInterval: -1,
+		},
+
+		// Invalid, drainInterval > 60
+		{
+			drainInterval: 61,
+		},
+
+		// Valid
+		{
+			drainTimeout:  0,
+			drainInterval: 60,
+		},
+	}
+
+	for _, testCase := range testCases {
+		drainer := NodeDrainer{
+			DrainTimeout:  testCase.drainTimeout,
+			DrainInterval: testCase.drainInterval,
+		}
+
+		err := drainer.Valid()
+		if testCase.isValid && err != nil {
+			t.Errorf("Expected node drainer to be valid, but it was not: %v", err)
+		}
+
+		if !testCase.isValid && err == nil {
+			t.Errorf("Expected node drainer to be invalid, but it was not")
+		}
+	}
+}

--- a/model/node_drainer_test.go
+++ b/model/node_drainer_test.go
@@ -1,0 +1,65 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestDrainTimeoutInSeconds(t *testing.T) {
+	testCases := []struct {
+		timeoutInMins int
+		timeoutInSecs int
+	}{
+		{
+			timeoutInMins: 0,
+			timeoutInSecs: 0,
+		},
+		{
+			timeoutInMins: 1,
+			timeoutInSecs: 60,
+		},
+		{
+			timeoutInMins: 2,
+			timeoutInSecs: 120,
+		},
+	}
+
+	for _, testCase := range testCases {
+		drainer := NodeDrainer{
+			DrainTimeout: testCase.timeoutInMins,
+		}
+		actual := drainer.DrainTimeoutInSeconds()
+		if actual != testCase.timeoutInSecs {
+			t.Errorf("Expected drain timeout in secs to be %d, but was %d", testCase.timeoutInSecs, actual)
+		}
+	}
+}
+
+func TestDrainIntervalInSeconds(t *testing.T) {
+	testCases := []struct {
+		intervalInMins int
+		intervalInSecs int
+	}{
+		{
+			intervalInMins: 0,
+			intervalInSecs: 0,
+		},
+		{
+			intervalInMins: 1,
+			intervalInSecs: 60,
+		},
+		{
+			intervalInMins: 2,
+			intervalInSecs: 120,
+		},
+	}
+
+	for _, testCase := range testCases {
+		drainer := NodeDrainer{
+			DrainInterval: testCase.intervalInMins,
+		}
+		actual := drainer.DrainIntervalInSeconds()
+		if actual != testCase.intervalInSecs {
+			t.Errorf("Expected drain interval in secs to be %d, but was %d", testCase.intervalInSecs, actual)
+		}
+	}
+}

--- a/model/node_drainer_test.go
+++ b/model/node_drainer_test.go
@@ -34,78 +34,52 @@ func TestDrainTimeoutInSeconds(t *testing.T) {
 	}
 }
 
-func TestDrainIntervalInSeconds(t *testing.T) {
-	testCases := []struct {
-		intervalInMins int
-		intervalInSecs int
-	}{
-		{
-			intervalInMins: 0,
-			intervalInSecs: 0,
-		},
-		{
-			intervalInMins: 1,
-			intervalInSecs: 60,
-		},
-		{
-			intervalInMins: 2,
-			intervalInSecs: 120,
-		},
-	}
-
-	for _, testCase := range testCases {
-		drainer := NodeDrainer{
-			DrainInterval: testCase.intervalInMins,
-		}
-		actual := drainer.DrainIntervalInSeconds()
-		if actual != testCase.intervalInSecs {
-			t.Errorf("Expected drain interval in secs to be %d, but was %d", testCase.intervalInSecs, actual)
-		}
-	}
-}
-
 func TestValid(t *testing.T) {
 	testCases := []struct {
-		drainTimeout  int
-		drainInterval int
-		isValid       bool
+		enabled      bool
+		drainTimeout int
+		isValid      bool
 	}{
-		// Invalid, drainTimeout is < 0
+		// Invalid, drainTimeout is < 1
 		{
-			drainTimeout: -1,
+			enabled:      true,
+			drainTimeout: 0,
 			isValid:      false,
 		},
 
 		// Invalid, drainTimeout > 60
 		{
+			enabled:      true,
 			drainTimeout: 61,
 			isValid:      false,
 		},
 
-		// Invalid, drainInterval < 0
+		// Valid, disabled
 		{
-			drainInterval: -1,
-			isValid:       false,
+			enabled:      false,
+			drainTimeout: 0,
+			isValid:      true,
 		},
 
-		// Invalid, drainInterval > 60
+		// Valid, timeout within boundaries
 		{
-			drainInterval: 61,
-			isValid:       false,
+			enabled:      true,
+			drainTimeout: 1,
+			isValid:      true,
 		},
 
-		// Valid
+		// Valid, timeout within boundaries
 		{
-			drainTimeout:  0,
-			drainInterval: 60,
-			isValid:       true,
+			enabled:      true,
+			drainTimeout: 60,
+			isValid:      true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		drainer := NodeDrainer{
-			DrainTimeout:  testCase.drainTimeout,
-			DrainInterval: testCase.drainInterval,
+			Enabled:      testCase.enabled,
+			DrainTimeout: testCase.drainTimeout,
 		}
 
 		err := drainer.Valid()

--- a/model/node_drainer_test.go
+++ b/model/node_drainer_test.go
@@ -73,27 +73,32 @@ func TestValid(t *testing.T) {
 		// Invalid, drainTimeout is < 0
 		{
 			drainTimeout: -1,
+			isValid:      false,
 		},
 
 		// Invalid, drainTimeout > 60
 		{
 			drainTimeout: 61,
+			isValid:      false,
 		},
 
 		// Invalid, drainInterval < 0
 		{
 			drainInterval: -1,
+			isValid:       false,
 		},
 
 		// Invalid, drainInterval > 60
 		{
 			drainInterval: 61,
+			isValid:       false,
 		},
 
 		// Valid
 		{
 			drainTimeout:  0,
 			drainInterval: 60,
+			isValid:       true,
 		},
 	}
 

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3658,6 +3658,30 @@ etcd:
 			expectedErrorMessage: "`etcd.disasterRecovery.automated` is set to true for enabling automated disaster recovery. However the feature is available only for etcd version 3",
 		},
 		{
+			context: "WithInvalidNodeDrainTimeout",
+			configYaml: minimalValidConfigYaml + `
+worker:
+  nodePools:
+  - name: pool1
+    nodeDrainer:
+      enabled: true
+      drainTimeout: 100
+`,
+			expectedErrorMessage: "Drain timeout must be an integer between 0 and 60, but was 100",
+		},
+		{
+			context: "WithInvalidNodeDrainInterval",
+			configYaml: minimalValidConfigYaml + `
+worker:
+  nodePools:
+  - name: pool1
+    nodeDrainer:
+      enabled: true
+      drainInterval: 100
+`,
+			expectedErrorMessage: "Drain interval must be an integer between 0 and 60, but was 100",
+		},
+		{
 			context: "WithInvalidTaint",
 			configYaml: minimalValidConfigYaml + `
 worker:

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -127,8 +127,10 @@ func TestMainClusterConfig(t *testing.T) {
 				StaticClients:   []model.StaticClient{},
 				StaticPasswords: []model.StaticPassword{},
 			},
-			NodeDrainer: controlplane_config.NodeDrainer{
-				Enabled: false,
+			NodeDrainer: model.NodeDrainer{
+				Enabled:       false,
+				DrainTimeout:  0,
+				DrainInterval: 5,
 			},
 			NodeLabels: model.NodeLabels{},
 			Taints:     model.Taints{},
@@ -1190,6 +1192,8 @@ experimental:
       userID: '08a8684b-db88-4b73-90a9-3cd1661f5466'
   nodeDrainer:
     enabled: true
+    drainTimeout: 3
+    drainInterval: 4
   nodeLabels:
     kube-aws.coreos.com/role: worker
   plugins:
@@ -1275,8 +1279,10 @@ worker:
 								{Email: "admin@example.com", Hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W", Username: "admin", UserId: "08a8684b-db88-4b73-90a9-3cd1661f5466"},
 							},
 						},
-						NodeDrainer: controlplane_config.NodeDrainer{
-							Enabled: true,
+						NodeDrainer: model.NodeDrainer{
+							Enabled:       true,
+							DrainTimeout:  3,
+							DrainInterval: 4,
 						},
 						NodeLabels: model.NodeLabels{
 							"kube-aws.coreos.com/role": "worker",
@@ -1393,8 +1399,10 @@ worker:
 							Arns:             []string{"arn:aws:elasticloadbalancing:eu-west-1:xxxxxxxxxxxx:targetgroup/manuallymanagedetg/xxxxxxxxxxxxxxxx"},
 							SecurityGroupIds: []string{"sg-12345678"},
 						},
-						NodeDrainer: controlplane_config.NodeDrainer{
-							Enabled: true,
+						NodeDrainer: model.NodeDrainer{
+							Enabled:       true,
+							DrainTimeout:  0,
+							DrainInterval: 5,
 						},
 						NodeLabels: model.NodeLabels{
 							"kube-aws.coreos.com/role": "worker",

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -128,9 +128,8 @@ func TestMainClusterConfig(t *testing.T) {
 				StaticPasswords: []model.StaticPassword{},
 			},
 			NodeDrainer: model.NodeDrainer{
-				Enabled:       false,
-				DrainTimeout:  0,
-				DrainInterval: 5,
+				Enabled:      false,
+				DrainTimeout: 5,
 			},
 			NodeLabels: model.NodeLabels{},
 			Taints:     model.Taints{},
@@ -1193,7 +1192,6 @@ experimental:
   nodeDrainer:
     enabled: true
     drainTimeout: 3
-    drainInterval: 4
   nodeLabels:
     kube-aws.coreos.com/role: worker
   plugins:
@@ -1280,9 +1278,8 @@ worker:
 							},
 						},
 						NodeDrainer: model.NodeDrainer{
-							Enabled:       true,
-							DrainTimeout:  3,
-							DrainInterval: 4,
+							Enabled:      true,
+							DrainTimeout: 3,
 						},
 						NodeLabels: model.NodeLabels{
 							"kube-aws.coreos.com/role": "worker",
@@ -1354,6 +1351,7 @@ worker:
         - sg-12345678
     nodeDrainer:
       enabled: true
+      drainTimeout: 5
     nodeLabels:
       kube-aws.coreos.com/role: worker
     taints:
@@ -1400,9 +1398,8 @@ worker:
 							SecurityGroupIds: []string{"sg-12345678"},
 						},
 						NodeDrainer: model.NodeDrainer{
-							Enabled:       true,
-							DrainTimeout:  0,
-							DrainInterval: 5,
+							Enabled:      true,
+							DrainTimeout: 5,
 						},
 						NodeLabels: model.NodeLabels{
 							"kube-aws.coreos.com/role": "worker",
@@ -3667,19 +3664,7 @@ worker:
       enabled: true
       drainTimeout: 100
 `,
-			expectedErrorMessage: "Drain timeout must be an integer between 0 and 60, but was 100",
-		},
-		{
-			context: "WithInvalidNodeDrainInterval",
-			configYaml: minimalValidConfigYaml + `
-worker:
-  nodePools:
-  - name: pool1
-    nodeDrainer:
-      enabled: true
-      drainInterval: 100
-`,
-			expectedErrorMessage: "Drain interval must be an integer between 0 and 60, but was 100",
+			expectedErrorMessage: "Drain timeout must be an integer between 1 and 60, but was 100",
 		},
 		{
 			context: "WithInvalidTaint",

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1349,6 +1349,7 @@ worker:
         - arn:aws:elasticloadbalancing:eu-west-1:xxxxxxxxxxxx:targetgroup/manuallymanagedetg/xxxxxxxxxxxxxxxx
       securityGroupIds:
         - sg-12345678
+    # Ignored, uses global setting
     nodeDrainer:
       enabled: true
       drainTimeout: 5
@@ -1398,8 +1399,8 @@ worker:
 							SecurityGroupIds: []string{"sg-12345678"},
 						},
 						NodeDrainer: model.NodeDrainer{
-							Enabled:      true,
-							DrainTimeout: 5,
+							Enabled:      false,
+							DrainTimeout: 0,
 						},
 						NodeLabels: model.NodeLabels{
 							"kube-aws.coreos.com/role": "worker",
@@ -3657,12 +3658,10 @@ etcd:
 		{
 			context: "WithInvalidNodeDrainTimeout",
 			configYaml: minimalValidConfigYaml + `
-worker:
-  nodePools:
-  - name: pool1
-    nodeDrainer:
-      enabled: true
-      drainTimeout: 100
+experimental:
+  nodeDrainer:
+    enabled: true
+    drainTimeout: 100
 `,
 			expectedErrorMessage: "Drain timeout must be an integer between 1 and 60, but was 100",
 		},


### PR DESCRIPTION
**This PR is ready to review.**

This PR introduces a rewrite of the node draining logic (based on ASG lifecycle hooks) + a fix for a bug in RBAC-enabled clusters that causes pods not to be evicted (see #673).

Now, if the node drainer is enabled, the install script creates a DaemonSet that executes a control loop implemented in bash that checks the current state of each instance and, if the auto scaling group signals some instance must be terminated, the script will detect the change and will perform the node draining - with retries in case the drain command takes too long to finish.

The old node draining systemd unit was removed, as they don't really work in practice: since the node draining could take more than a few seconds to finish, it don't usually have time to finish draining the node before AWS halts the instance. (In case the operator wants to terminate some arbitrary instance, it's up to the operator to drain the node before terminating it)

Fixes #673.