### PR TITLE
Heapster service account and cluster role binding

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1249,6 +1249,22 @@ write_files:
           name: kube-aws:node-extensions
           apiGroup: rbac.authorization.k8s.io
 
+  # Allow heapster access to the built in cluster role via its service account
+  - path: /srv/kubernetes/rbac/cluster-role-bindings/heapster.yaml
+    content: |
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1beta1
+        metadata:
+          name: heapster
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: system:heapster
+        subjects:
+        - kind: ServiceAccount
+          name: heapster
+          namespace: kube-system
+
 {{ if .Experimental.TLSBootstrap.Enabled }}
   # Only allows certificate signing requests to be performed with the bootstrap token
   - path: /srv/kubernetes/rbac/cluster-roles/node-bootstrapper.yaml
@@ -1813,6 +1829,16 @@ write_files:
             port: 53
             protocol: TCP
 
+  - path: /srv/kubernetes/manifests/heapster-sa.yaml
+    content: |
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: heapster
+          namespace: kube-system
+          labels:
+            kubernetes.io/cluster-service: "true"
+
   - path: /srv/kubernetes/manifests/heapster-de.yaml
     content: |
         apiVersion: extensions/v1beta1
@@ -1841,6 +1867,7 @@ write_files:
               tolerations:
               - key: "CriticalAddonsOnly"
                 operator: "Exists"
+              serviceAccountName: heapster
               containers:
                 - image: {{ .HeapsterImage.RepoWithTag }}
                   name: heapster


### PR DESCRIPTION
For https://github.com/kubernetes-incubator/kube-aws/issues/685.

After this PR we still have these logs:

```
heapster-v1.3.0-2152587771-9cg3w heapster-nanny E0531 09:40:59.332643       1 nanny_lib.go:110] the server does not allow access to the requested resource (get deployments.extensions heapster-v1.3.0)
```

I agree with the comment https://github.com/kubernetes/heapster/issues/1589#issuecomment-291184395, it seems unwise to allow heapster to modify it's own config.

However, without this PR heapster constantly cycles replica sets when RBAC is enabled so at least this way it does not churn the pod and we have heapster running more constantly which is a start.