### PR TITLE
calico-node - DaemonSet tolerating all taints

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -715,12 +715,12 @@ write_files:
               scheduler.alpha.kubernetes.io/critical-pod: ''
           spec:
             tolerations:
-            - key: "node.alpha.kubernetes.io/role"
-              operator: "Equal"
-              value: "master"
-              effect: "NoSchedule"
-            - key: "CriticalAddonsOnly"
-              operator: "Exists"
+            - operator: Exists
+              effect: NoSchedule
+            - operator: Exists
+              effect: NoExecute
+            - operator: Exists
+              key: CriticalAddonsOnly
             hostNetwork: true
             containers:
               - name: calico-node


### PR DESCRIPTION
When using taints in Node Pools together with calico the stack
always fail in Cloudformation since cfn-signal sytemd unit checks
if calico is up before signaling success