### PR TITLE
Spot fleet detailed monitoring

### DIFF
--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -72,6 +72,7 @@
           {{if or (gt $subnetIndex 0) (gt $specIndex 0) }},{{end}}
           {
             "ImageId": "{{$.AMI}}",
+            "Monitoring": { "Enabled": "true" },
             "InstanceType": "{{$spec.InstanceType}}",
             {{if $.KeyName}}"KeyName": "{{$.KeyName}}",{{end}}
             "WeightedCapacity": {{$spec.WeightedCapacity}},


### PR DESCRIPTION
Added support for detailed monitoring as default behavior when creating a spot fleet node pool. Addresses issue https://github.com/kubernetes-incubator/kube-aws/issues/623