### PR TITLE
core: Add ListBucket explicitly to EtcdSnapshotsS3Bucket

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -412,7 +412,15 @@
                 {
                   "Effect": "Allow",
                   "Action": [
-                    "s3:List*"
+                    "s3:ListBucket"
+                  ],
+                  "Resource": "arn:{{.Region.Partition}}:s3:::{{$.EtcdSnapshotsS3Bucket}}"
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:List*",
+                    "s3:GetObject*"
                   ],
                   "Resource": "arn:{{.Region.Partition}}:s3:::{{$.EtcdSnapshotsS3Bucket}}",
                   "Condition": {


### PR DESCRIPTION
Adds 's3:ListBucket' permission explicitly to statement with only bucket ARN.
Adds 's3:GetObject*' permission to statement with s3:prefix and bucket ARN.

Should fix `etcd3` `snapshot.db` recovery process.

This should fix S3 permission denied errors during `etcdadm-reconfigure` such as:

    etcdadm[28736]: /opt/bin/etcdadm: info: member_remote_snapshot_exists: checking existence of s3://test-etcd-fail-example/kube-aws/clusters/etcd-fail/instances/9f6c6e20-400f-11e7
    etcdadm[28736]: An error occurred (AccessDenied) when calling the ListObjects operation: Access Denied

Fixes #660