### PR TITLE
Try etcd version

### DIFF
--- a/README.iflix.md
+++ b/README.iflix.md
@@ -1,0 +1,16 @@
+# Kubernetes on AWS (kube-aws)
+
+## Install
+Steps:
+* Download from releases page the binary for your operating system.
+* Extract the archive and copy the binary to `/usr/local/bin`.
+
+## Release convention
+The internal convention for tag a release has been set to the following:
+```
+v<upstream-version>-<iflix-version>
+```
+ie.
+```
+v0.9.6-1
+```

--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -184,6 +184,7 @@ coreos:
           content: |
             [Service]
             Environment="ETCD_IMAGE_TAG=v{{.Etcd.Version}}"
+            Environment="ETCD_VERSION=v{{.Etcd.Version}}"
         {{end}}
       enable: true
       command: start


### PR DESCRIPTION
The etcadm service uses ETCD_VERSION to determine version, not ETCD_IMAGE_TAG.

To test this works, you can check the `rkt list` every now and then when it does a health check and see if its running the right version. Or manually try invoke a check... /etc/systemd/system/etcdadm-check.service