### PR TITLE
Fix node drain error when trying to evict pods from jobs

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1164,6 +1164,11 @@ write_files:
             - replicasets
             verbs:
             - get
+          - apiGroups: ["batch"]
+            resources:
+            - jobs
+            verbs:
+            - get
           - apiGroups: [""]
             resources:
             - replicationcontrollers


### PR DESCRIPTION
Without this permission, the `kube-node-drainer` unit fails when the node being drained contain job pods:

```
User "system:node:<name>" cannot get jobs.batch in the namespace "<ns>". (get jobs.batch <job-name>): <pod-name>; User "system:node:<name>" cannot get jobs.batch in the namespace "<ns>". (get jobs.batch <job-name>): <pod-name>
```