### PR TITLE
Remove unused sysctl override for nf_conntrack_max

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -38,14 +38,6 @@ coreos:
         ExecStartPre=/opt/bin/cfn-etcd-environment
         ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
 
-{{if .UseCalico }}
-    # https://github.com/coreos/docs/blob/5d7b1cccb8286185275b07db1495828be9fdb0ea/os/other-settings.md#tuning-sysctl-parameters
-    - name: systemd-modules-load.service
-      command: restart
-    - name: systemd-sysctl.service
-      command: restart
-{{ end }}
-
 {{if .Experimental.AwsEnvironment.Enabled}}
     - name: set-aws-environment.service
       enable: true
@@ -2157,14 +2149,6 @@ write_files:
           }
         }
       }
-
-  # http://docs.projectcalico.org/v2.0/usage/configuration/
-  - path: /etc/modules-load.d/nf.conf
-    content: |
-      nf_conntrack
-  - path: /etc/sysctl.d/nf.conf
-    content: |
-      net.netfilter.nf_conntrack_max=1000000
 
 {{ end }}
 

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -249,14 +249,6 @@ coreos:
         RequiredBy=rkt-api.service
 {{ end }}
 
-{{if .UseCalico }}
-    # https://github.com/coreos/docs/blob/5d7b1cccb8286185275b07db1495828be9fdb0ea/os/other-settings.md#tuning-sysctl-parameters
-    - name: systemd-modules-load.service
-      command: restart
-    - name: systemd-sysctl.service
-      command: restart
-{{ end }}
-
 {{if .AwsEnvironment.Enabled}}
     - name: set-aws-environment.service
       enable: true
@@ -853,15 +845,6 @@ write_files:
           }
         }
       }
-
-  # http://docs.projectcalico.org/v2.0/usage/configuration/
-  - path: /etc/modules-load.d/nf.conf
-    content: |
-      nf_conntrack
-  - path: /etc/sysctl.d/nf.conf
-    content: |
-      net.netfilter.nf_conntrack_max=1000000
-
 {{ end }}
 
 {{ if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}


### PR DESCRIPTION
Kube-proxy, by default, [automatically sets](https://kubernetes.io/docs/admin/kube-proxy/) `nf_conntrack_max` to `<n-cores> * <value of conntrack-max-per-core>` when it starts, so it's useless to try to override `nf_conntrack_max` in some systemd unit.

If we wish to override this value, the best way to do so is by providing the `--conntrack-min` (or `--conntrack-max-per-core`) argument to kube-proxy, which also takes care of setting a proportional value to conntrack `hashsize`.

Closes #708