### PR TITLE
Fix kube-resources-autosave when kube2iam is enabled

### DIFF
--- a/contrib/kube2iam/kube2iam-calico-ds.yaml
+++ b/contrib/kube2iam/kube2iam-calico-ds.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube2iam
+  namespace: kube-system
+  labels:
+    app: kube2iam
+spec:
+  template:
+    metadata:
+      labels:
+        name: kube2iam
+    spec:
+      serviceAccountName: kube2iam
+      hostNetwork: true
+      containers:
+        - image: jtblin/kube2iam:latest
+          name: kube2iam
+          args:
+            - "--app-port=8282"
+            - "--base-role-arn=arn:aws:iam::YOUR_ACCOUNT_ID:role/"
+            - "--iptables=true"
+            - "--host-ip=$(HOST_IP)"
+            - "--host-interface=cali+"
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          ports:
+            - containerPort: 8282
+              hostPort: 8282
+              name: http
+          securityContext:
+            privileged: true

--- a/contrib/kube2iam/kube2iam-flannel-ds.yaml
+++ b/contrib/kube2iam/kube2iam-flannel-ds.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube2iam
+  namespace: kube-system
+  labels:
+    app: kube2iam
+spec:
+  template:
+    metadata:
+      labels:
+        name: kube2iam
+    spec:
+      serviceAccountName: kube2iam
+      hostNetwork: true
+      containers:
+        - image: jtblin/kube2iam:latest
+          name: kube2iam
+          args:
+            - "--app-port=8282"
+            - "--base-role-arn=arn:aws:iam::YOUR_ACCOUNT_ID:role/"
+            - "--iptables=true"
+            - "--host-ip=$(HOST_IP)"
+            - "--host-interface=cni0"
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          ports:
+            - containerPort: 8282
+              hostPort: 8282
+              name: http
+          securityContext:
+            privileged: true

--- a/contrib/kube2iam/rbac.yaml
+++ b/contrib/kube2iam/rbac.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube2iam
+  namespace: kube-system
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: kube2iam
+  name: kube2iam
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube2iam
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube2iam
+subjects:
+- kind: ServiceAccount
+  name: kube2iam
+  namespace: kube-system

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -920,6 +920,10 @@ write_files:
         replicas: 1
         template:
           metadata:
+          {{- if .Experimental.Kube2IamSupport.Enabled }}
+            annotations:
+              iam.amazonaws.com/role: {{ $.Region }}-{{.Controller.IAMConfig.Role.Name}}
+          {{- end }}
             name: kube-resources-autosave
             namespace: kube-system
             labels:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -521,6 +521,8 @@ worker:
 #
 #      # When enabled it will grant sts:assumeRole permission to the IAM roles for worker nodes.
 #      # This is intended to be used in combination with managedIamRoleName. See #297 for more information.
+#      # After the cluster is up, you have to manually deploy kube2iam DaemonSet and configure permissions in case RBAC is enabled.
+#      # Please check "contrib/kube2iam" directory for configuration examples.
 #      kube2IamSupport:
 #        enabled: true
 #


### PR DESCRIPTION
When `kube2iam` support is enabled and the DaemonSet was deployed,
`kube-resources-autosave` will fail to save the cluster state to S3 due
to missing role.

I added a condition to assign the `controller` role to
`kube-resources-autosave` deployment and also created examples for
`kube2iam`configuration.