### PR TITLE
Add "Role" tag to all nodes.

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -46,6 +46,11 @@
             "Value": "{{.ClusterName}}-{{.StackName}}-kube-aws-controller"
           },
           {
+            "Key": "Role",
+            "PropagateAtLaunch": "true",
+            "Value": "Master"
+          },
+          {
             "Key": "kubernetes.io/role/master",
             "PropagateAtLaunch": "true",
             "Value": ""
@@ -626,6 +631,11 @@
             "Key": "Name",
             "PropagateAtLaunch": "true",
             "Value": "{{$.ClusterName}}-{{$.StackName}}-kube-aws-etcd-{{$etcdIndex}}"
+          },
+          {
+            "Key": "Role",
+            "PropagateAtLaunch": "true",
+            "Value": "Etcd"
           },
           {
             "Key": "kube-aws:role",

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -148,6 +148,11 @@
             "Key": "Name",
             "PropagateAtLaunch": "true",
             "Value": "{{.ClusterName}}-{{.StackName}}-kube-aws-worker"
+          },
+          {
+            "Key": "Role",
+            "PropagateAtLaunch": "true",
+            "Value": "Worker"
           }
         ],
         {{if .LoadBalancer.Enabled}}


### PR DESCRIPTION
Hi @mumoshu, @redbaron, I remember the "Role" key tag was used for workers in `kube-aws` and removed at some point.  I'm already using the "Role" tag for all of the EC2 instances and this PR will help organising them better. If there was a specific reason for removing the "Role" tag and you find it unnecessary, I'll just use another method to create the tags automatically. 

Also, if anyone interested, I created a simple solution to add tags to instances in a spot fleet.
Here is the [repo](https://github.com/camilb/kube-aws-spot-fleet-tags)

Thanks!