### PR TITLE
Propagate etcd version from cluster.yaml to etcdadm

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -725,6 +725,9 @@
                   "'\n",
                   "ETCDADM_MEMBER_INDEX='",
                     "{{$etcdIndex}}",
+                  "'\n",
+                  "ETCD_VERSION='",
+                    "{{$.Etcd.Version}}",
                   "'\n"
                 ]]}
               }


### PR DESCRIPTION
Without this additional propagation `etcdadm` falls back to default `3.1.3` version as in
https://github.com/iflix-letsplay/kube-aws/blob/master/etcdadm/etcdadm#L88

In case when any other version is specified in `cluster.yaml` it will create the deviation between running etcd version and the one that is used for periodic snapshotting, e.g. running `3.1.8` in the main container and still using default `3.1.3` for `etcdadm` based operations.

This PR fixes the deviation.