### PR TITLE
Add cluster kube-aws version to outputs

### DIFF
--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -97,6 +97,11 @@
     }{{end}}
   },
   "Outputs": {
+    "KubeAwsVersion": {
+      "Description": "The version number of kube-aws which was used to create this cluster",
+      "Value": "{{$.KubeAwsVersion}}",
+      "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-KubeAwsVersion" } }
+    },
     {{ if $.ControlPlane.NeedToExportIAMroles }}
     "ControllerIAMRoleArn": {
       "Description": "The IAM Role ARN for controller nodes",

--- a/core/root/template_params.go
+++ b/core/root/template_params.go
@@ -16,6 +16,10 @@ func (p TemplateParams) ClusterName() string {
 	return p.cluster.controlPlane.ClusterName
 }
 
+func (p TemplateParams) KubeAwsVersion() string {
+	return controlplane.VERSION
+}
+
 func (p TemplateParams) CloudWatchLogging() config.CloudWatchLogging {
 	return p.cluster.controlPlane.CloudWatchLogging
 }


### PR DESCRIPTION
It's just an idea. We have few clusters of kubernetes which is managed by kube-aws but there is no way how to check with version of kube-aws is used for creating or updating this cluster. So we don't know if we need proceed update on this clusters.

Btw usage of CloudFormation output is just an idea we should use CloudFormation tags needer.

PS: I have no experience with Go so I'm just trying if this works.