### PR TITLE
Bugfix: CloudWatchLogging always disabled for Worker nodes

### DIFF
--- a/Documentation/kubernetes-on-aws-journald-cloudwatch-logs.md
+++ b/Documentation/kubernetes-on-aws-journald-cloudwatch-logs.md
@@ -11,6 +11,14 @@ This feature is disabled by default and configurable in cluster.yaml:
 ```
 cloudWatchLogging:
  enabled: false
- imageWithTag: jollinshead/journald-cloudwatch-logs:0.1
  retentionInDays: 7
+```
+
+The docker image is also configurable:
+
+```
+journaldCloudWatchLogsImage:
+  repo: "jollinshead/journald-cloudwatch-logs"
+  tag: "0.1"
+  rktPullDocker: true
 ```

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -754,6 +754,13 @@ type CloudWatchLogging struct {
 	RetentionInDays int  `yaml:"retentionInDays"`
 }
 
+func (c *CloudWatchLogging) MergeIfEmpty(other CloudWatchLogging) {
+	if c.Enabled == false && c.RetentionInDays == 0 {
+		c.Enabled = other.Enabled
+		c.RetentionInDays = other.RetentionInDays
+	}
+}
+
 type LoadBalancer struct {
 	Enabled          bool     `yaml:"enabled"`
 	Names            []string `yaml:"names"`

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -178,8 +178,6 @@ func (c *ProvidedConfig) Load(main *cfg.Config) error {
 	c.KubeClusterSettings = main.KubeClusterSettings
 	c.Experimental.TLSBootstrap = main.DeploymentSettings.Experimental.TLSBootstrap
 	c.Experimental.NodeDrainer = main.DeploymentSettings.Experimental.NodeDrainer
-	c.DeploymentSettings.CloudWatchLogging = main.DeploymentSettings.CloudWatchLogging
-	c.DeploymentSettings.JournaldCloudWatchLogsImage = main.DeploymentSettings.JournaldCloudWatchLogsImage
 
 	// Validate whole the inputs including inherited ones
 	if err := c.valid(); err != nil {

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -178,6 +178,8 @@ func (c *ProvidedConfig) Load(main *cfg.Config) error {
 	c.KubeClusterSettings = main.KubeClusterSettings
 	c.Experimental.TLSBootstrap = main.DeploymentSettings.Experimental.TLSBootstrap
 	c.Experimental.NodeDrainer = main.DeploymentSettings.Experimental.NodeDrainer
+	c.DeploymentSettings.CloudWatchLogging = main.DeploymentSettings.CloudWatchLogging
+	c.DeploymentSettings.JournaldCloudWatchLogsImage = main.DeploymentSettings.JournaldCloudWatchLogsImage
 
 	// Validate whole the inputs including inherited ones
 	if err := c.valid(); err != nil {

--- a/core/nodepool/config/deployment.go
+++ b/core/nodepool/config/deployment.go
@@ -98,6 +98,7 @@ func (c DeploymentSettings) WithDefaultsFrom(main cfg.DeploymentSettings) Deploy
 	c.CalicoCniImage.MergeIfEmpty(main.CalicoCniImage)
 	c.PauseImage.MergeIfEmpty(main.PauseImage)
 	c.FlannelImage.MergeIfEmpty(main.FlannelImage)
+	c.JournaldCloudWatchLogsImage.MergeIfEmpty(main.JournaldCloudWatchLogsImage)
 
 	// Inherit main TLS bootstrap config
 	c.Experimental.TLSBootstrap = main.Experimental.TLSBootstrap
@@ -123,6 +124,9 @@ func (c DeploymentSettings) WithDefaultsFrom(main cfg.DeploymentSettings) Deploy
 	if c.ElasticFileSystemID == "" {
 		c.ElasticFileSystemID = main.ElasticFileSystemID
 	}
+
+	// Inherit main CloudWatchLogging config
+	c.CloudWatchLogging.MergeIfEmpty(main.CloudWatchLogging)
 
 	return c
 }


### PR DESCRIPTION
The worker nodes were using the default configuration for the CloudWatchLogging feature (default: disabled). Now they use overwriting values in the cluster.yaml file (if present).

The CloudWatchLogging documentation has been updated to reflect the most recent implementationn of the feature.