### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,12 @@
 #  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
 
 reviewers:
+- c-knowles
+- danielfm
 - mumoshu
+- redbaron
 approvers:
+- c-knowles
+- danielfm
 - mumoshu
+- redbaron


### PR DESCRIPTION
Ref #717

Please note that the owner names are just ordered alphabetically.

@redbaron @danielfm @c-knowles AFAIK, this `OWNERS` file must be updated like this to tell k8s-bot who are reviewers and approvers.
// For example I believe the `/approve` command is allowed only for reviewers listed in this file. I don't know if the command is actually enabled on this repo, though 😉 