### PR TITLE
Provide real-time feedback from Journald logs when updating/creating …

### DIFF
--- a/Documentation/kubernetes-on-aws-journald-cloudwatch-logs.md
+++ b/Documentation/kubernetes-on-aws-journald-cloudwatch-logs.md
@@ -14,6 +14,7 @@ cloudWatchLogging:
  retentionInDays: 7
 ```
 
+
 The docker image is also configurable:
 
 ```
@@ -22,3 +23,34 @@ journaldCloudWatchLogsImage:
   tag: "0.1"
   rktPullDocker: true
 ```
+
+## kube-aws up/update feedback
+
+During kube-aws up/update, filtered Journald logs can be printed to stdout.
+This feature is configurable in cluster.yaml under the *cloudWatchLogging* section, and requires *cloudWatchLogging* to be enabled.
+( Default values: )
+
+```
+cloudWatchLogging:
+ enabled: false
+ imageWithTag: jollinshead/journald-cloudwatch-logs:0.1
+ retentionInDays: 7
+ localStreaming:
+  enabled: true,
+  filter:  `{ $.priority = "CRIT" || $.priority = "WARNING" && $.transport = "journal" && $.systemdUnit = "init.scope" }`,
+  interval: 60
+```
+
+NOTE: Due to high initial entropy, *.service* failures may occur during the early stages of booting.
+In this context Entropy refers to the disorder of *.service*s (starting, failing, restarting).
+
+### Parameters
+
+#### Filter
+By default the filter is configured for *.service* failures and messages flagged as 'critical'.
+See [the official AWS documentation](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html) for more information.
+
+#### Interval
+Since some messages are produced frequently, to avoid excessive spam, an 'interval' parameter is provided.
+This 'interval' value determines the time between printing two identical messages to stdout.
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Check out our getting started tutorial on launching your first Kubernetes cluste
   * [Backup Kubernetes resources](/Documentation/kubernetes-on-aws-backup.md)
   * [Restore Kubernetes resources](/contrib/cluster-backup/README.md)
   * [Journald logging to AWS CloudWatch](/Documentation/kubernetes-on-aws-journald-cloudwatch-logs.md)
+    * [kube-aws up/update feedback](/Documentation/kubernetes-on-aws-journald-cloudwatch-logs.md)
 
 ## Examples
 

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -116,6 +116,11 @@ func NewDefaultCluster() *Cluster {
 			CloudWatchLogging: CloudWatchLogging{
 				Enabled:         false,
 				RetentionInDays: 7,
+				LocalStreaming: LocalStreaming{
+					Enabled:  true,
+					Filter:   `{ $.priority = "CRIT" || $.priority = "WARNING" && $.transport = "journal" && $.systemdUnit = "init.scope" }`,
+					interval: 60,
+				},
 			},
 			HyperkubeImage:                     model.Image{Repo: "quay.io/coreos/hyperkube", Tag: k8sVer, RktPullDocker: false},
 			AWSCliImage:                        model.Image{Repo: "quay.io/coreos/awscli", Tag: "master", RktPullDocker: false},
@@ -752,6 +757,18 @@ type KubeResourcesAutosave struct {
 type CloudWatchLogging struct {
 	Enabled         bool `yaml:"enabled"`
 	RetentionInDays int  `yaml:"retentionInDays"`
+	LocalStreaming  `yaml:"localStreaming"`
+}
+
+type LocalStreaming struct {
+	Enabled  bool   `yaml:"enabled"`
+	Filter   string `yaml:"filter"`
+	interval int    `yaml:"interval"`
+}
+
+func (c *LocalStreaming) Interval() int64 {
+	// Convert from seconds to milliseconds (and return as int64 type)
+	return int64(c.interval * 1000)
 }
 
 func (c *CloudWatchLogging) MergeIfEmpty(other CloudWatchLogging) {

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1141,6 +1141,12 @@ worker:
 #cloudWatchLogging:
 # enabled: false
 # retentionInDays: 7
+# # When enabled, feedback from Journald logs (with an applied filter) will be outputted during kube-aws 'apply | up'.
+# # It is enabled by default - provided cloudWatchLogging is enabled.
+# localStreaming:
+#  enabled: true,
+#  filter:  `{ $.priority = "CRIT" || $.priority = "WARNING" && $.transport = "journal" && $.systemdUnit = "init.scope" }`,
+#  interval: 60
 
 # Addon features
 addons:

--- a/model/cloudwatch_logging.go
+++ b/model/cloudwatch_logging.go
@@ -1,0 +1,12 @@
+package model
+
+type SystemdMessageResponse struct {
+	InstanceId  string `json:"instanceId,omitempty"`
+	Hostname    string `json:"hostname,omitempty"`
+	CmdName     string `json:"cmdName,omitempty"`
+	Exe         string `json:"exe,omitempty"`
+	CmdLine     string `json:"cmdLine,omitempty"`
+	SystemdUnit string `json:"systemdUnit,omitempty"`
+	Priority    string `json:"priority,omitempty"`
+	Message     string `json:"message,omitempty"`
+}


### PR DESCRIPTION
During kube-aws up/update, filtered Journald logs can be printed to stdout.
This feature is configurable in cluster.yaml under the *cloudWatchLogging* section, and requires *cloudWatchLogging* to be enabled.
( Default values: )

```
cloudWatchLogging:
 enabled: false
 imageWithTag: jollinshead/journald-cloudwatch-logs:0.1
 retentionInDays: 7
 localStreaming:
  enabled: true,
  filter:  `{ $.priority = "CRIT" || $.priority = "WARNING" && $.transport = "journal" && $.systemdUnit = "init.scope" }`,
  interval: 60
```

NOTE: Due to high initial entropy, *.service* failures may occur during the early stages of booting.

By default the filter is configured for *.service* failures and messages flagged as 'critical'.
See [the official AWS documentation](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html) for more information.

Since some messages are produced frequently, to avoid excessive spam, an 'interval' parameter is provided.
This 'interval' value determines the time between printing two identical messages to stdout.