### PR TITLE
Fix kubelet bootstrap for Kubernetes 1.7

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -650,8 +650,13 @@ write_files:
       done
 
       {{ if .Experimental.TLSBootstrap.Enabled }}
-      kubectl create -f "${mfdir}/cluster-roles/node-bootstrapper.yaml" | echo 'Failed to create the cluster role named "kube-aws:node-bootstrapper". Skipping'
-      kubectl create -f "${mfdir}/cluster-role-bindings/node-bootstrapper.yaml" | echo 'Failed to create the cluster role binding "kube-aws:node-bootstrapper". Skipping'
+      for manifest in {node-bootstrapper,kubelet-certificate-bootstrap}; do
+          kubectl apply -f "${mfdir}/cluster-roles/$manifest.yaml"
+      done
+
+      for manifest in {node-bootstrapper,kubelet-certificate-bootstrap}; do
+          kubectl apply -f "${mfdir}/cluster-role-bindings/$manifest.yaml"
+      done
       {{ end }}
       {{ end }}
 
@@ -1346,6 +1351,38 @@ write_files:
           namespace: kube-system
 
 {{ if .Experimental.TLSBootstrap.Enabled }}
+  # A ClusterRole which instructs the CSR approver to approve a user requesting
+  # node client credentials.
+  - path: /srv/kubernetes/rbac/cluster-roles/kubelet-certificate-bootstrap.yaml
+    content: |
+        kind: ClusterRole
+        apiVersion: rbac.authorization.k8s.io/v1beta1
+        metadata:
+          name: kube-aws:kubelet-certificate-bootstrap
+        rules:
+        - apiGroups:
+          - certificates.k8s.io
+          resources:
+          - certificatesigningrequests/nodeclient
+          verbs:
+          - create
+
+  # Approve all CSRs for the group "system:kubelet-bootstrap-token"
+  - path: /srv/kubernetes/rbac/cluster-role-bindings/kubelet-certificate-bootstrap.yaml
+    content: |
+        kind: ClusterRoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1beta1
+        metadata:
+          name: kube-aws:kubelet-certificate-bootstrap
+        subjects:
+        - kind: Group
+          name: system:kubelet-bootstrap
+          apiGroup: rbac.authorization.k8s.io
+        roleRef:
+          kind: ClusterRole
+          name: kube-aws:kubelet-certificate-bootstrap
+          apiGroup: rbac.authorization.k8s.io
+
   # Only allows certificate signing requests to be performed with the bootstrap token
   - path: /srv/kubernetes/rbac/cluster-roles/node-bootstrapper.yaml
     content: |
@@ -1355,7 +1392,7 @@ write_files:
           name: kube-aws:node-bootstrapper
         rules:
           - apiGroups:
-              - '*'
+              - certificates.k8s.io
             resources:
               - certificatesigningrequests
             verbs:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1134,8 +1134,7 @@ addons:
 #   # certificate signing requests (csr) made to the API server using the bootstrap token. It's recommended to
 #   # also enable the rbac plugin in order to limit requests using the bootstrap token to only be able to make
 #   # requests related to certificate provisioning.
-#   # The bootstrap token must be defined in ./credentials/tokens.csv; kube-aws creates this file automatically
-#   # with a randomly generated token when this setting is enabled.
+#   # The bootstrap token is automatically generated in ./credentials/kubelet-tls-bootstrap-token.
 #   tlsBootstrap:
 #     enabled: true
 #   # This option has not yet been tested with rkt as container runtime


### PR DESCRIPTION
This PR fixes the automatic approval of CSR requests made by worker nodes during the bootstrap process in Kubernetes 1.7 when RBAC is enabled.

Quoting the documentation:

> In 1.7 the experimental “group auto approver” controller is dropped in favor of the new csrapproving controller that ships as part of kube-controller-manager and is enabled by default. The controller uses the SubjectAccessReview API to determine if a given user is authorized to request a CSR, then approves based on the authorization outcome. To prevent conflicts with other approvers, the builtin approver doesn’t explicitly deny CSRs, only ignoring unauthorized requests.

So, for the kubelet bootstrap to work in Kubernetes 1.7, we need to add a cluster role+binding to instruct the CSR approver to auto-approve requests made on behalf of the kubelet bootstrap group `system:kubelet-bootstrap-token`.

As of now, we cannot enable the Node authorizer and the NodeRestriction admission controller since it will break our node drainer implementation. (more info:  https://github.com/kubernetes/kubernetes/issues/48666)

Ref.: #721