### PR TITLE
Deny direct command execution on privileged containers

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -37,6 +37,9 @@ func NewDefaultCluster() *Cluster {
 			PodSecurityPolicy{
 				Enabled: false,
 			},
+			DenyEscalatingExec{
+				Enabled: false,
+			},
 		},
 		AuditLog: AuditLog{
 			Enabled: false,
@@ -521,10 +524,15 @@ type Experimental struct {
 }
 
 type Admission struct {
-	PodSecurityPolicy PodSecurityPolicy `yaml:"podSecurityPolicy"`
+	PodSecurityPolicy  PodSecurityPolicy  `yaml:"podSecurityPolicy"`
+	DenyEscalatingExec DenyEscalatingExec `yaml:"denyEscalatingExec"`
 }
 
 type PodSecurityPolicy struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type DenyEscalatingExec struct {
 	Enabled bool `yaml:"enabled"`
 }
 

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1468,7 +1468,7 @@ write_files:
           - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
           {{ end }}
           - --advertise-address=$private_ipv4
-          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }},ResourceQuota
+          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }},ResourceQuota,{{if .Experimental.Admission.DenyEscalatingExec.Enabled}}DenyEscalatingExec{{end}}
           - --anonymous-auth=false
           {{if .Experimental.Dex.Enabled}}
           - --oidc-issuer-url={{.Experimental.Dex.Url}}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1090,6 +1090,8 @@ addons:
 #   admission:
 #     podSecurityPolicy:
 #       enabled: true
+#     denyEscalatingExec:
+#       enabled: true
 #   # Used to provide `/etc/environment` env vars with values from arbitrary CloudFormation refs
 #   awsEnvironment:
 #     enabled: true

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -80,6 +80,9 @@ func TestMainClusterConfig(t *testing.T) {
 				PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
 					Enabled: false,
 				},
+				DenyEscalatingExec: controlplane_config.DenyEscalatingExec{
+					Enabled: false,
+				},
 			},
 			AuditLog: controlplane_config.AuditLog{
 				Enabled: false,
@@ -1128,6 +1131,8 @@ experimental:
   admission:
     podSecurityPolicy:
       enabled: true
+    denyEscalatingExec:
+      enabled: true
   auditLog:
     enabled: true
     maxage: 100
@@ -1206,6 +1211,9 @@ worker:
 					expected := controlplane_config.Experimental{
 						Admission: controlplane_config.Admission{
 							PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
+								Enabled: true,
+							},
+							DenyEscalatingExec: controlplane_config.DenyEscalatingExec{
 								Enabled: true,
 							},
 						},


### PR DESCRIPTION
Deny host access through privileged containers with the help of
https://kubernetes.io/docs/admin/admission-controllers/#denyescalatingexec