### PR TITLE
Remove deprecated keys in cluster.yaml

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -228,8 +228,6 @@ func (c *Cluster) Load() error {
 
 	c.HostedZoneID = withHostedZoneIDPrefix(c.HostedZoneID)
 
-	c.ConsumeDeprecatedKeys()
-
 	if err := c.valid(); err != nil {
 		return fmt.Errorf("invalid cluster: %v", err)
 	}
@@ -259,90 +257,6 @@ func (c *Cluster) Load() error {
 	}
 
 	return nil
-}
-
-func (c *Cluster) ConsumeDeprecatedKeys() {
-	// TODO Remove deprecated keys in v0.9.7
-	if c.DeprecatedControllerCount != nil {
-		fmt.Println("WARN: controllerCount is deprecated and will be removed in v0.9.7. Please use controller.count instead")
-		c.Controller.Count = *c.DeprecatedControllerCount
-	}
-	if c.DeprecatedControllerTenancy != nil {
-		fmt.Println("WARN: controllerTenancy is deprecated and will be removed in v0.9.7. Please use controller.tenancy instead")
-		c.Controller.Tenancy = *c.DeprecatedControllerTenancy
-	}
-	if c.DeprecatedControllerInstanceType != nil {
-		fmt.Println("WARN: controllerInstanceType is deprecated and will be removed in v0.9.7. Please use controller.instanceType instead")
-		c.Controller.InstanceType = *c.DeprecatedControllerInstanceType
-	}
-	if c.Controller.DeprecatedControllerManagedIamRoleName != "" {
-		fmt.Println("WARN: controller.managedIamRoleName is deprecated and will be removed in v0.9.7. Please use controller.iam.managedIamRoleName instead")
-		c.Controller.IAMConfig.Role.Name = c.Controller.DeprecatedControllerManagedIamRoleName
-	}
-	if c.DeprecatedControllerCreateTimeout != nil {
-		fmt.Println("WARN: controllerCreateTimeout is deprecated and will be removed in v0.9.7. Please use controller.createTimeout instead")
-		c.Controller.CreateTimeout = *c.DeprecatedControllerCreateTimeout
-	}
-	if c.DeprecatedControllerRootVolumeIOPS != nil {
-		fmt.Println("WARN: controllerRootVolumeIOPS is deprecated and will be removed in v0.9.7. Please use controller.rootVolume.iops instead")
-		c.Controller.RootVolume.IOPS = *c.DeprecatedControllerRootVolumeIOPS
-	}
-	if c.DeprecatedControllerRootVolumeSize != nil {
-		fmt.Println("WARN: controllerRootVolumeSize is deprecated and will be removed in v0.9.7. Please use controller.rootVolume.size instead")
-		c.Controller.RootVolume.Size = *c.DeprecatedControllerRootVolumeSize
-	}
-	if c.DeprecatedControllerRootVolumeType != nil {
-		fmt.Println("WARN: controllerRootVolumeType is deprecated and will be removed in v0.9.7. Please use controller.rootVolume.type instead")
-		c.Controller.RootVolume.Type = *c.DeprecatedControllerRootVolumeType
-	}
-
-	if c.DeprecatedEtcdCount != nil {
-		fmt.Println("WARN: etcdCount is deprecated and will be removed in v0.9.7. Please use etcd.count instead")
-		c.Etcd.Count = *c.DeprecatedEtcdCount
-	}
-	if c.DeprecatedEtcdTenancy != nil {
-		fmt.Println("WARN: etcdTenancy is deprecated and will be removed in v0.9.7. Please use etcd.tenancy instead")
-		c.Etcd.Tenancy = *c.DeprecatedEtcdTenancy
-	}
-	if c.DeprecatedEtcdInstanceType != nil {
-		fmt.Println("WARN: etcdInstanceType is deprecated and will be removed in v0.9.7. Please use etcd.instanceType instead")
-		c.Etcd.InstanceType = *c.DeprecatedEtcdInstanceType
-	}
-	//if c.DeprecatedEtcdCreateTimeout != nil {
-	//	c.Etcd.CreateTimeout = *c.DeprecatedEtcdCreateTimeout
-	//}
-	if c.DeprecatedEtcdRootVolumeIOPS != nil {
-		fmt.Println("WARN: etcdRootVolumeIOPS is deprecated and will be removed in v0.9.7. Please use etcd.rootVolume.iops instead")
-		c.Etcd.RootVolume.IOPS = *c.DeprecatedEtcdRootVolumeIOPS
-	}
-	if c.DeprecatedEtcdRootVolumeSize != nil {
-		fmt.Println("WARN: etcdRootVolumeSize is deprecated and will be removed in v0.9.7. Please use etcd.rootVolume.size instead")
-		c.Etcd.RootVolume.Size = *c.DeprecatedEtcdRootVolumeSize
-	}
-	if c.DeprecatedEtcdRootVolumeType != nil {
-		fmt.Println("WARN: etcdRootVolumeType is deprecated and will be removed in v0.9.7. Please use etcd.rootVolume.type instead")
-		c.Etcd.RootVolume.Type = *c.DeprecatedEtcdRootVolumeType
-	}
-	if c.DeprecatedEtcdDataVolumeIOPS != nil {
-		fmt.Println("WARN: etcdDataVolumeIOPS is deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.iops instead")
-		c.Etcd.DataVolume.IOPS = *c.DeprecatedEtcdDataVolumeIOPS
-	}
-	if c.DeprecatedEtcdDataVolumeSize != nil {
-		fmt.Println("WARN: etcdDataVolumeSize is deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.size instead")
-		c.Etcd.DataVolume.Size = *c.DeprecatedEtcdDataVolumeSize
-	}
-	if c.DeprecatedEtcdDataVolumeType != nil {
-		fmt.Println("WARN: etcdDataVolumeType is deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.type instead")
-		c.Etcd.DataVolume.Type = *c.DeprecatedEtcdDataVolumeType
-	}
-	if c.DeprecatedEtcdDataVolumeEphemeral != nil {
-		fmt.Println("WARN: etcdDataVolumeEphemeral is deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.ephemeral instead")
-		c.Etcd.DataVolume.Ephemeral = *c.DeprecatedEtcdDataVolumeEphemeral
-	}
-	if c.DeprecatedEtcdDataVolumeEncrypted != nil {
-		fmt.Println("WARN: etcdDataVolumeEncrypted is deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.encrypted instead")
-		c.Etcd.DataVolume.Encrypted = *c.DeprecatedEtcdDataVolumeEncrypted
-	}
 }
 
 func (c *Cluster) SetDefaults() {
@@ -533,120 +447,12 @@ type DefaultWorkerSettings struct {
 
 // Part of configuration which is specific to controller nodes
 type ControllerSettings struct {
-	model.Controller                   `yaml:"controller,omitempty"`
-	DeprecatedControllerCount          *int    `yaml:"controllerCount,omitempty"`
-	DeprecatedControllerCreateTimeout  *string `yaml:"controllerCreateTimeout,omitempty"`
-	DeprecatedControllerInstanceType   *string `yaml:"controllerInstanceType,omitempty"`
-	DeprecatedControllerRootVolumeType *string `yaml:"controllerRootVolumeType,omitempty"`
-	DeprecatedControllerRootVolumeIOPS *int    `yaml:"controllerRootVolumeIOPS,omitempty"`
-	DeprecatedControllerRootVolumeSize *int    `yaml:"controllerRootVolumeSize,omitempty"`
-	DeprecatedControllerTenancy        *string `yaml:"controllerTenancy,omitempty"`
-}
-
-func (c ControllerSettings) ControllerCount() int {
-	fmt.Println("WARN: ControllerCount is deprecated and will be removed in v0.9.7. Please use Controller.Count instead")
-	return c.Controller.Count
-}
-
-func (c ControllerSettings) ControllerCreateTimeout() string {
-	fmt.Println("WARN: ControllerCreateTimeout is deprecated and will be removed in v0.9.7. Please use Controller.CreateTimeout instead")
-	return c.Controller.CreateTimeout
-}
-
-func (c ControllerSettings) ControllerInstanceType() string {
-	fmt.Println("WARN: ControllerInstanceType is deprecated and will be removed in v0.9.7. Please use Controller.InstanceType instead")
-	return c.Controller.InstanceType
-}
-
-func (c ControllerSettings) ControllerRootVolumeType() string {
-	fmt.Println("WARN: ControllerRootVolumeType is deprecated and will be removed in v0.9.7. Please use Controller.RootVolume.Type instead")
-	return c.Controller.RootVolume.Type
-}
-
-func (c ControllerSettings) ControllerRootVolumeIOPS() int {
-	fmt.Println("WARN: ControllerRootVolumeIOPS is deprecated and will be removed in v0.9.7. Please use Controller.RootVolume.IOPS instead")
-	return c.Controller.RootVolume.IOPS
-}
-
-func (c ControllerSettings) ControllerRootVolumeSize() int {
-	fmt.Println("WARN: ControllerRootVolumeSize is deprecated and will be removed in v0.9.7. Please use Controller.RootVolume.Size instead")
-	return c.Controller.RootVolume.Size
-}
-
-func (c ControllerSettings) ControllerTenancy() string {
-	fmt.Println("WARN: ControllerTenancy is deprecated and will be removed in v0.9.7. Please use Controller.Tenancy instead")
-	return c.Controller.Tenancy
+	model.Controller `yaml:"controller,omitempty"`
 }
 
 // Part of configuration which is specific to etcd nodes
 type EtcdSettings struct {
-	model.Etcd                        `yaml:"etcd,omitempty"`
-	DeprecatedEtcdCount               *int    `yaml:"etcdCount"`
-	DeprecatedEtcdInstanceType        *string `yaml:"etcdInstanceType,omitempty"`
-	DeprecatedEtcdRootVolumeSize      *int    `yaml:"etcdRootVolumeSize,omitempty"`
-	DeprecatedEtcdRootVolumeType      *string `yaml:"etcdRootVolumeType,omitempty"`
-	DeprecatedEtcdRootVolumeIOPS      *int    `yaml:"etcdRootVolumeIOPS,omitempty"`
-	DeprecatedEtcdDataVolumeSize      *int    `yaml:"etcdDataVolumeSize,omitempty"`
-	DeprecatedEtcdDataVolumeType      *string `yaml:"etcdDataVolumeType,omitempty"`
-	DeprecatedEtcdDataVolumeIOPS      *int    `yaml:"etcdDataVolumeIOPS,omitempty"`
-	DeprecatedEtcdDataVolumeEphemeral *bool   `yaml:"etcdDataVolumeEphemeral,omitempty"`
-	DeprecatedEtcdDataVolumeEncrypted *bool   `yaml:"etcdDataVolumeEncrypted,omitempty"`
-	DeprecatedEtcdTenancy             *string `yaml:"etcdTenancy,omitempty"`
-}
-
-func (e EtcdSettings) EtcdCount() int {
-	fmt.Println("WARN: EtcdCount is deprecated and will be removed in v0.9.7. Please use Etcd.Count instead")
-	return e.Etcd.Count
-}
-
-func (e EtcdSettings) EtcdInstanceType() string {
-	fmt.Println("WARN: EtcdInstanceType is deprecated and will be removed in v0.9.7. Please use Etcd.InstanceType instead")
-	return e.Etcd.InstanceType
-}
-
-func (e EtcdSettings) EtcdRootVolumeSize() int {
-	fmt.Println("WARN: EtcdRootVolumeSize is deprecated and will be removed in v0.9.7. Please use Etcd.RootVolume.Size instead")
-	return e.Etcd.RootVolume.Size
-}
-
-func (e EtcdSettings) EtcdRootVolumeType() string {
-	fmt.Println("WARN: EtcdRootVolumeType is deprecated and will be removed in v0.9.7. Please use Etcd.RootVolume.Type instead")
-	return e.Etcd.RootVolume.Type
-}
-
-func (e EtcdSettings) EtcdRootVolumeIOPS() int {
-	fmt.Println("WARN: EtcdRootVolumeIOPS is deprecated and will be removed in v0.9.7. Please use Etcd.RootVolume.IOPS instead")
-	return e.Etcd.RootVolume.IOPS
-}
-
-func (e EtcdSettings) EtcdDataVolumeSize() int {
-	fmt.Println("WARN: EtcdDataVolumeSize is deprecated and will be removed in v0.9.7. Please use Etcd.DataVolume.Size instead")
-	return e.Etcd.DataVolume.Size
-}
-
-func (e EtcdSettings) EtcdDataVolumeType() string {
-	fmt.Println("WARN: EtcdDataVolumeType is deprecated and will be removed in v0.9.7. Please use Etcd.DataVolume.Type instead")
-	return e.Etcd.DataVolume.Type
-}
-
-func (e EtcdSettings) EtcdDataVolumeIOPS() int {
-	fmt.Println("WARN: EtcdDataVolumeIOPS is deprecated and will be removed in v0.9.7. Please use Etcd.DataVolume.IOPS instead")
-	return e.Etcd.DataVolume.IOPS
-}
-
-func (e EtcdSettings) EtcdDataVolumeEphemeral() bool {
-	fmt.Println("WARN: EtcdDataVolumeEphemeral is deprecated and will be removed in v0.9.7. Please use Etcd.DataVolume.Ephemeral instead")
-	return e.Etcd.DataVolume.Ephemeral
-}
-
-func (e EtcdSettings) EtcdDataVolumeEncrypted() bool {
-	fmt.Println("WARN: EtcdDataVolumeEncrypted is deprecated and will be removed in v0.9.7. Please use Etcd.DataVolume.Encrypted instead")
-	return e.Etcd.DataVolume.Encrypted
-}
-
-func (e EtcdSettings) EtcdTenancy() string {
-	fmt.Println("WARN: EtcdTenancy is deprecated and will be removed in v0.9.7. Please use Etcd.Tenancy instead")
-	return e.Etcd.Tenancy
+	model.Etcd `yaml:"etcd,omitempty"`
 }
 
 // Part of configuration which is specific to flanneld

--- a/core/controlplane/config/config_cluster_size_test.go
+++ b/core/controlplane/config/config_cluster_size_test.go
@@ -90,38 +90,23 @@ subnets:
 
 func checkControllerASGs(configuredCount *int, configuredMin *int, configuredMax *int, configuredMinInstances *int,
 	expectedMin int, expectedMax int, expectedMinInstances int, expectedError string, t *testing.T) {
-	// Use deprecated keys
 	checkControllerASG(configuredCount, configuredMin, configuredMax, configuredMinInstances,
-		expectedMin, expectedMax, expectedMinInstances, expectedError, true, t)
-	// Don't use deprecated keys
-	checkControllerASG(configuredCount, configuredMin, configuredMax, configuredMinInstances,
-		expectedMin, expectedMax, expectedMinInstances, expectedError, false, t)
+		expectedMin, expectedMax, expectedMinInstances, expectedError, t)
 }
 
 func checkControllerASG(configuredCount *int, configuredMin *int, configuredMax *int, configuredMinInstances *int,
-	expectedMin int, expectedMax int, expectedMinInstances int, expectedError string, useDeprecatedKey bool, t *testing.T) {
+	expectedMin int, expectedMax int, expectedMinInstances int, expectedError string, t *testing.T) {
 	config := testConfig
 
-	if useDeprecatedKey {
-		if configuredCount != nil {
-			config += fmt.Sprintf("controllerCount: %d\n", *configuredCount)
-		}
-		asgConfig := buildASGConfig(configuredMin, configuredMax, configuredMinInstances)
-		if asgConfig != "" {
-			// empty `controller` traps go-yaml to override the whole Controller with a zero-value, which is not what we expect
-			config += "controller:\n" + asgConfig
-		}
-	} else {
-		countConfig := ""
-		if configuredCount != nil {
-			countConfig = fmt.Sprintf("  count: %d\n", *configuredCount)
-		}
-		asgConfig := buildASGConfig(configuredMin, configuredMax, configuredMinInstances)
-		concatConfig := countConfig + asgConfig
-		if concatConfig != "" {
-			// empty `controller` traps go-yaml to override the whole Controller with a zero-value, which is not what we expect
-			config += "controller:\n" + concatConfig
-		}
+	countConfig := ""
+	if configuredCount != nil {
+		countConfig = fmt.Sprintf("  count: %d\n", *configuredCount)
+	}
+	asgConfig := buildASGConfig(configuredMin, configuredMax, configuredMinInstances)
+	concatConfig := countConfig + asgConfig
+	if concatConfig != "" {
+		// empty `controller` traps go-yaml to override the whole Controller with a zero-value, which is not what we expect
+		config += "controller:\n" + concatConfig
 	}
 
 	cluster, err := ClusterFromBytes([]byte(config))

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -525,63 +525,42 @@ controller:
 			volumeType: "io1",
 			iops:       2000,
 		},
-		// TODO Remove test cases for deprecated keys in v0.9.7
-		{
-			conf: `
-controllerRootVolumeType: gp2
-`,
-			volumeType: "gp2",
-			iops:       0,
-		},
-		{
-			conf: `
-controllerRootVolumeType: standard
-`,
-			volumeType: "standard",
-			iops:       0,
-		},
-		{
-			conf: `
-controllerRootVolumeType: io1
-controllerRootVolumeIOPS: 100
-`,
-			volumeType: "io1",
-			iops:       100,
-		},
-		{
-			conf: `
-controllerRootVolumeType: io1
-controllerRootVolumeIOPS: 2000
-`,
-			volumeType: "io1",
-			iops:       2000,
-		},
 	}
 
 	invalidConfigs := []string{
 		`
 # There's no volume type 'default'
-controllerRootVolumeType: default
+controller:
+  rootVolume:
+    type: default
 `,
 		`
 # IOPS must be zero for volume types != 'io1'
-controllerRootVolumeType: standard
-controllerRootVolumeIOPS: 100
+controller:
+  rootVolume:
+    type: standard
+    iops: 100
 `,
 		`
 # IOPS must be zero for volume types != 'io1'
-controllerRootVolumeType: gp2
-controllerRootVolumeIOPS: 2000
+controller:
+  rootVolume:
+    type: gp2
+    iops: 2000
 `,
 		`
 # IOPS smaller than the minimum (100)
-controllerRootVolumeType: io1
-controllerRootVolumeIOPS: 99
+controller:
+  rootVolume:
+    type: io1
+    iops: 99
 `,
 		`
 # IOPS greater than the maximum (2000)
-controllerRootVolumeType: io1
-controllerRootVolumeIOPS: 2001
+controller:
+  rootVolume:
+    type: io1
+    iops: 2001
 `,
 	}
 

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -3,9 +3,6 @@
 # name must not conflict with an existing cluster.
 clusterName: {{.ClusterName}}
 
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use apiEndpoints[].dnsName instead
-#externalDNSName:
-
 # CoreOS release channel to use. Currently supported options: alpha, beta, stable
 # See coreos.com/releases for more information
 #releaseChannel: stable
@@ -13,15 +10,6 @@ clusterName: {{.ClusterName}}
 # The AMI ID of CoreOS.
 # If omitted, the latest AMI for the releaseChannel is used.
 #amiId: ""
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use apiEndpoints[].loadBalancer.createRecordSet instead
-#createRecordSet:
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use apiEndpoints[].loadBalancer.recordSetTTL instead
-#recordSetTTL:
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use apiEndpoints[].loadBalancer.hostedZone.id instead
-#hostedZoneId:
 
 # The ID of hosted zone to add the externalDNSName to.
 # Either specify hostedZoneId or hostedZone, but not both
@@ -143,9 +131,6 @@ availabilityZone: {{.AvailabilityZone}}
 # ARN of the KMS key used to encrypt TLS assets.
 kmsKeyArn: "{{.KMSKeyARN}}"
 
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use controller.count instead
-#controllerCount: 1
-
 #controller:
 #  # Number of controller nodes to create, for more control use `controller.autoScalingGroup` and do not use this setting
 #  count: 1
@@ -162,7 +147,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    size: 30
 #    # Disk type for controller node (one of standard, io1, or gp2)
 #    type: gp2
-#    # Number of I/O operations per second (IOPS) that the controller node disk supports. Leave blank if controllerRootVolumeType is not io1
+#    # Number of I/O operations per second (IOPS) that the controller node disk supports. Leave blank if controller.rootVolume.type is not io1
 #    iops: 0
 #
 #  # Existing security groups attached to controller nodes which are typically used to
@@ -210,21 +195,6 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    # References subnets defined under the top-level `subnets` key by their names
 #    - name: ManagedPublicSubnet1
 #    - name: ManagedPublicSubnet2
-#  # CAUTION: Deprecated and will be removed in v0.9.7. Please use apiEndpoints[].loadBalancer instead
-#  loadBalancer:
-#    # kube-aws creates the ELB for the k8s API endpoint as `Schema=internet-facing` by default and
-#    # only public subnets defined under the top-level `subnets` key are used for the ELB
-#    private: false
-#    # If you like specific public subnets to be used by the internet-facing ELB:
-#    #subnets:
-#    #  - name: ManagedPublicSubnet0
-#
-#    # When explicitly set to true, the ELB for the k8s API endpoint becomes `Schema=internal` rather than default `Schema=internet-facing` one and
-#    # only private subnets defined under the top-level `subnets` key are used for the ELB
-#    private: true
-#    # If you like specific private subnets to be used by the internal ELB:
-#    # subnets:
-#    #   - name: ManagedPrivateSubnet0
 #
 #   # Kubernetes node labels to be added to controller nodes
 #   nodeLabels:
@@ -247,21 +217,6 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #        Description=Example Custom Service
 #        [Service]
 #        ExecStart=/bin/rkt run --set-env TAGS=Controller ...
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use controller.createTimeout instead
-#controllerCreateTimeout: PT15M
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use controller.instanceType instead
-#controllerInstanceType: t2.medium
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use controller.rootVolume.size instead
-#controllerRootVolumeSize: 30
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use controller.rootVolume.type instead
-#controllerRootVolumeType: gp2
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use controller.rootVolume.iops instead
-#controllerRootVolumeIOPS: 0
 
 # Default number of worker nodes per node pool to create, for more control use `worker.nodePools[].count` and/or `worker.autoScalingGroup` and do not use this setting
 #workerCount: 1
@@ -372,17 +327,8 @@ worker:
 #        size: 30
 #        # Disk type for worker node (one of standard, io1, or gp2)
 #        type: gp2
-#        # Number of I/O operations per second (IOPS) that the worker node disk supports. Leave blank if workerRootVolumeType is not io1
+#        # Number of I/O operations per second (IOPS) that the worker node disk supports. Leave blank if worker.rootVolume.type is not io1
 #        iops: 0
-#
-#      # CAUTION: Deprecated and will be removed in v0.9.7. Please use rootVolume.size instead
-#      rootVolumeSize: 30
-#
-#      # CAUTION: Deprecated and will be removed in v0.9.7. Please use rootVolume.type instead
-#      rootVolumeType: gp2
-#
-#      # CAUTION: Deprecated and will be removed in v0.9.7. Please use rootVolume.iops instead
-#      rootVolumeIOPS: 0
 #
 #      # Maximum time to wait for worker creation
 #      createTimeout: PT15M
@@ -468,15 +414,6 @@ worker:
 #            # Must be within the range between 100 and 2000
 #            # Defaults to worker.spotFleet.unitRootVolumeIOPS * weightedCapacity if omitted
 #            iops:
-#
-#          # CAUTION: Deprecated and will be removed in v0.9.7. Please use rootVolume.type instead
-#          #rootVolumeType:
-#
-#          # CAUTION: Deprecated and will be removed in v0.9.7. Please use rootVolume.size instead
-#          #rootVolumeSize:
-#
-#          # CAUTION: Deprecated and will be removed in v0.9.7. Please use rootVolume.iops instead
-#          #rootVolumeIOPS:
 #
 #        - weightedCapacity: 2
 #          instanceType: c4.xlarge
@@ -601,9 +538,6 @@ worker:
 ## WARNING: Any changes to etcd parameters after the cluster is first created will not be applied
 ## during a cluster upgrade, due to concerns over data loss.
 ## This situation is being rectified with work towards automated management of etcd clusters
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.count instead
-# etcdCount: 1
 
 #etcd:
 #  # Number of etcd nodes
@@ -739,36 +673,6 @@ worker:
 #        Description=Example Custom Service
 #        [Service]
 #        ExecStart=/bin/rkt run --set-env TAGS=Controller ...
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.instanceType instead
-# etcdInstanceType: t2.medium
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.rootVolume.size instead
-# etcdRootVolumeSize: 30
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.rootVolume.type instead
-# etcdRootVolumeType: gp2
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.rootVolume.iops instead
-# etcdRootVolumeIOPS: 0
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.ephemeral instead
-# etcdDataVolumeEphemeral: false
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.size instead
-# etcdDataVolumeSize: 30
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.type instead
-# etcdDataVolumeType: gp2
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.iops instead
-# etcdDataVolumeIOPS: 0
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.dataVolume.encrypted instead
-# etcdDataVolumeEncrypted: false
-
-# CAUTION: Deprecated and will be removed in v0.9.7. Please use etcd.tenancy instead
-# etcdTenancy: default
 
 ## Networking config
 

--- a/core/nodepool/cluster/cluster_test.go
+++ b/core/nodepool/cluster/cluster_test.go
@@ -153,39 +153,6 @@ availabilityZone: dummy-az-0
 				VolumeType: aws.String("standard"),
 			},
 			clusterYaml: `
-rootVolumeType: standard
-`,
-		},
-		{
-			expectedRootVolume: &ec2.CreateVolumeInput{
-				Iops:       aws.Int64(0),
-				Size:       aws.Int64(50),
-				VolumeType: aws.String("gp2"),
-			},
-			clusterYaml: `
-rootVolumeType: gp2
-rootVolumeSize: 50
-`,
-		},
-		{
-			expectedRootVolume: &ec2.CreateVolumeInput{
-				Iops:       aws.Int64(2000),
-				Size:       aws.Int64(100),
-				VolumeType: aws.String("io1"),
-			},
-			clusterYaml: `
-rootVolumeType: io1
-rootVolumeSize: 100
-rootVolumeIOPS: 2000
-`,
-		},
-		{
-			expectedRootVolume: &ec2.CreateVolumeInput{
-				Iops:       aws.Int64(0),
-				Size:       aws.Int64(30),
-				VolumeType: aws.String("standard"),
-			},
-			clusterYaml: `
 rootVolume:
   type: standard
 `,

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -143,25 +143,6 @@ func (c *ProvidedConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	}
 	*c = ProvidedConfig(work)
 
-	// TODO Remove deprecated keys in v0.9.7
-	if c.DeprecatedRootVolumeIOPS != nil {
-		fmt.Println("WARN: worker.nodePools[].rootVolumeIOPS is deprecated and will be removed in v0.9.7. Please use worker.nodePools[].rootVolume.iops instead")
-		c.RootVolume.IOPS = *c.DeprecatedRootVolumeIOPS
-	}
-
-	if c.WorkerNodePoolConfig.DeprecatedNodePoolManagedIamRoleName != "" {
-		fmt.Println("WARN: worker.nodePools[].managedIamRoleName is deprecated and will be removed in v0.9.7. Please use worker.nodePools[].iam.managedRoleName instead")
-		c.IAMConfig.Role.Name = c.WorkerNodePoolConfig.DeprecatedNodePoolManagedIamRoleName
-	}
-	if c.DeprecatedRootVolumeSize != nil {
-		fmt.Println("WARN: worker.nodePools[].rootVolumeSize is deprecated and will be removed in v0.9.7. Please use worker.nodePools[].rootVolume.size instead")
-		c.RootVolume.Size = *c.DeprecatedRootVolumeSize
-	}
-	if c.DeprecatedRootVolumeType != nil {
-		fmt.Println("WARN: worker.nodePools[].rootVolumeType is deprecated and will be removed in v0.9.7. Please use worker.nodePools[].rootVolume.type instead")
-		c.RootVolume.Type = *c.DeprecatedRootVolumeType
-	}
-
 	return nil
 }
 

--- a/model/controller.go
+++ b/model/controller.go
@@ -7,18 +7,17 @@ import (
 
 // TODO Merge this with NodePoolConfig
 type Controller struct {
-	AutoScalingGroup                       AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
-	Autoscaling                            Autoscaling      `yaml:"autoscaling,omitempty"`
-	EC2Instance                            `yaml:",inline"`
-	LoadBalancer                           ControllerElb       `yaml:"loadBalancer,omitempty"`
-	IAMConfig                              IAMConfig           `yaml:"iam,omitempty"`
-	DeprecatedControllerManagedIamRoleName string              `yaml:"managedIamRoleName,omitempty"`
-	SecurityGroupIds                       []string            `yaml:"securityGroupIds"`
-	Subnets                                []Subnet            `yaml:"subnets,omitempty"`
-	CustomFiles                            []CustomFile        `yaml:"customFiles,omitempty"`
-	CustomSystemdUnits                     []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
-	NodeSettings                           `yaml:",inline"`
-	UnknownKeys                            `yaml:",inline"`
+	AutoScalingGroup   AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
+	Autoscaling        Autoscaling      `yaml:"autoscaling,omitempty"`
+	EC2Instance        `yaml:",inline"`
+	LoadBalancer       ControllerElb       `yaml:"loadBalancer,omitempty"`
+	IAMConfig          IAMConfig           `yaml:"iam,omitempty"`
+	SecurityGroupIds   []string            `yaml:"securityGroupIds"`
+	Subnets            []Subnet            `yaml:"subnets,omitempty"`
+	CustomFiles        []CustomFile        `yaml:"customFiles,omitempty"`
+	CustomSystemdUnits []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
+	NodeSettings       `yaml:",inline"`
+	UnknownKeys        `yaml:",inline"`
 }
 
 const DefaultControllerCount = 1
@@ -72,7 +71,7 @@ func (c Controller) Validate() error {
 			"allowing so for a group of controller nodes spreading over 2 or more availability zones " +
 			"results in unreliability while scaling nodes out.")
 	}
-	if c.IAMConfig.InstanceProfile.Arn != "" && (c.IAMConfig.Role.Name != "" || c.DeprecatedControllerManagedIamRoleName != "") {
+	if c.IAMConfig.InstanceProfile.Arn != "" && c.IAMConfig.Role.Name != "" {
 		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
 	}
 	if c.IAMConfig.InstanceProfile.Arn != "" && len(c.IAMConfig.Role.ManagedPolicies) > 0 {

--- a/model/deprecated_root_volume.go
+++ b/model/deprecated_root_volume.go
@@ -1,7 +1,0 @@
-package model
-
-type DeprecatedRootVolume struct {
-	DeprecatedRootVolumeType *string `yaml:"rootVolumeType,omitempty"`
-	DeprecatedRootVolumeIOPS *int    `yaml:"rootVolumeIOPS,omitempty"`
-	DeprecatedRootVolumeSize *int    `yaml:"rootVolumeSize,omitempty"`
-}

--- a/model/lauch_specification.go
+++ b/model/lauch_specification.go
@@ -5,11 +5,10 @@ import (
 )
 
 type LaunchSpecification struct {
-	WeightedCapacity     int    `yaml:"weightedCapacity,omitempty"`
-	InstanceType         string `yaml:"instanceType,omitempty"`
-	SpotPrice            string `yaml:"spotPrice,omitempty"`
-	DeprecatedRootVolume `yaml:",inline"`
-	RootVolume           `yaml:"rootVolume,omitempty"`
+	WeightedCapacity int    `yaml:"weightedCapacity,omitempty"`
+	InstanceType     string `yaml:"instanceType,omitempty"`
+	SpotPrice        string `yaml:"spotPrice,omitempty"`
+	RootVolume       `yaml:"rootVolume,omitempty"`
 }
 
 func NewLaunchSpecification(weightedCapacity int, instanceType string) LaunchSpecification {
@@ -26,20 +25,6 @@ func (s *LaunchSpecification) UnmarshalYAML(unmarshal func(interface{}) error) e
 		return fmt.Errorf("failed to parse node pool config: %v", err)
 	}
 	*s = LaunchSpecification(work)
-
-	// TODO Remove deprecated keys in v0.9.7
-	if s.DeprecatedRootVolumeIOPS != nil {
-		fmt.Println("WARN: launchSpecifications[].rootVolumeIOPS is deprecated and will be removed in v0.9.7. Please use launchSpecifications[].rootVolume.iops instead")
-		s.RootVolume.IOPS = *s.DeprecatedRootVolumeIOPS
-	}
-	if s.DeprecatedRootVolumeSize != nil {
-		fmt.Println("WARN: launchSpecifications[].rootVolumeSize is deprecated and will be removed in v0.9.7. Please use launchSpecifications[].rootVolume.size instead")
-		s.RootVolume.Size = *s.DeprecatedRootVolumeSize
-	}
-	if s.DeprecatedRootVolumeType != nil {
-		fmt.Println("WARN: launchSpecifications[].rootVolumeType is deprecated and will be removed in v0.9.7. Please use launchSpecifications[].rootVolume.type instead")
-		s.RootVolume.Type = *s.DeprecatedRootVolumeType
-	}
 
 	return nil
 }

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -6,23 +6,21 @@ import (
 )
 
 type NodePoolConfig struct {
-	Autoscaling                          Autoscaling      `yaml:"autoscaling,omitempty"`
-	AutoScalingGroup                     AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
-	SpotFleet                            SpotFleet        `yaml:"spotFleet,omitempty"`
-	EC2Instance                          `yaml:",inline"`
-	IAMConfig                            IAMConfig `yaml:"iam,omitempty"`
-	DeprecatedNodePoolManagedIamRoleName string    `yaml:"managedIamRoleName,omitempty"`
-	DeprecatedRootVolume                 `yaml:",inline"`
-	SpotPrice                            string                 `yaml:"spotPrice,omitempty"`
-	SecurityGroupIds                     []string               `yaml:"securityGroupIds,omitempty"`
-	CustomSettings                       map[string]interface{} `yaml:"customSettings,omitempty"`
-	VolumeMounts                         []VolumeMount          `yaml:"volumeMounts,omitempty"`
-	UnknownKeys                          `yaml:",inline"`
-	NodeSettings                         `yaml:",inline"`
-	NodeStatusUpdateFrequency            string              `yaml:"nodeStatusUpdateFrequency"`
-	CustomFiles                          []CustomFile        `yaml:"customFiles,omitempty"`
-	CustomSystemdUnits                   []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
-	Gpu                                  Gpu                 `yaml:"gpu"`
+	Autoscaling               Autoscaling      `yaml:"autoscaling,omitempty"`
+	AutoScalingGroup          AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
+	SpotFleet                 SpotFleet        `yaml:"spotFleet,omitempty"`
+	EC2Instance               `yaml:",inline"`
+	IAMConfig                 IAMConfig              `yaml:"iam,omitempty"`
+	SpotPrice                 string                 `yaml:"spotPrice,omitempty"`
+	SecurityGroupIds          []string               `yaml:"securityGroupIds,omitempty"`
+	CustomSettings            map[string]interface{} `yaml:"customSettings,omitempty"`
+	VolumeMounts              []VolumeMount          `yaml:"volumeMounts,omitempty"`
+	UnknownKeys               `yaml:",inline"`
+	NodeSettings              `yaml:",inline"`
+	NodeStatusUpdateFrequency string              `yaml:"nodeStatusUpdateFrequency"`
+	CustomFiles               []CustomFile        `yaml:"customFiles,omitempty"`
+	CustomSystemdUnits        []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
+	Gpu                       Gpu                 `yaml:"gpu"`
 }
 
 type ClusterAutoscaler struct {
@@ -103,7 +101,7 @@ func (c NodePoolConfig) Valid() error {
 		fmt.Println(`WARNING: instance types "t2.nano" and "t2.micro" are not recommended. See https://github.com/kubernetes-incubator/kube-aws/issues/258 for more information`)
 	}
 
-	if c.IAMConfig.InstanceProfile.Arn != "" && (c.IAMConfig.Role.Name != "" || c.DeprecatedNodePoolManagedIamRoleName != "") {
+	if c.IAMConfig.InstanceProfile.Arn != "" && c.IAMConfig.Role.Name != "" {
 		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
 	}
 	if c.IAMConfig.InstanceProfile.Arn != "" && len(c.IAMConfig.Role.ManagedPolicies) > 0 {

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3211,167 +3211,6 @@ controller:
 			},
 		},
 		{
-			context: "WithControllerNodesWithLegacyKeys",
-			configYaml: minimalValidConfigYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
-routeTableId: rtb-1a2b3c4d
-controllerCount: 2
-controllerCreateTimeout: PT10M
-controllerInstanceType: t2.large
-controllerRootVolumeSize: 101
-controllerRootVolumeType: io1
-controllerRootVolumeIOPS: 102
-controllerTenancy: dedicated
-`,
-			assertConfig: []ConfigTester{
-				hasDefaultExperimentalFeatures,
-				func(c *config.Config, t *testing.T) {
-					expected := model.EC2Instance{
-						Count:         2,
-						InstanceType:  "t2.large",
-						CreateTimeout: "PT10M",
-						RootVolume: model.RootVolume{
-							Size: 101,
-							Type: "io1",
-							IOPS: 102,
-						},
-						Tenancy: "dedicated",
-					}
-
-					actual := c.Controller.EC2Instance
-					if !reflect.DeepEqual(expected, actual) {
-						t.Errorf(
-							"Controller didn't match: expected=%v actual=%v",
-							expected,
-							actual,
-						)
-					}
-
-					if c.ControllerInstanceType() != "t2.large" {
-						t.Errorf("unexpected controller instance type: expected=t2.large, actual=%s", c.ControllerInstanceType())
-					}
-					if c.ControllerCreateTimeout() != "PT10M" {
-						t.Errorf("unexpected controller create timeout: expected=PT10M, actual=%s", c.ControllerCreateTimeout())
-					}
-					if c.ControllerCount() != 2 {
-						t.Errorf("unexpected controller count: expected=2, actual=%d", c.ControllerCount())
-					}
-					if c.ControllerRootVolumeSize() != 101 {
-						t.Errorf("unexpected controller root volume size: expected=101, actual=%d", c.ControllerRootVolumeSize())
-					}
-					if c.ControllerRootVolumeType() != "io1" {
-						t.Errorf("unexpected controller root volume type: expected=io1, actual=%s", c.ControllerRootVolumeType())
-					}
-					if c.ControllerRootVolumeIOPS() != 102 {
-						t.Errorf("unexpected controller root volume iops: expected=102, actual=%d", c.ControllerRootVolumeIOPS())
-					}
-					if c.ControllerTenancy() != "dedicated" {
-						t.Errorf("unexpected controller tenancy: expected=dedicated, actual=%s", c.ControllerTenancy())
-					}
-				},
-			},
-		},
-		{
-			context: "WithEtcdNodesWithLegacyKeys",
-			configYaml: minimalValidConfigYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
-routeTableId: rtb-1a2b3c4d
-etcdCount: 2
-etcdTenancy: dedicated
-etcdInstanceType: t2.large
-etcdRootVolumeSize: 101
-etcdRootVolumeType: io1
-etcdRootVolumeIOPS: 102
-etcdDataVolumeSize: 103
-etcdDataVolumeType: io1
-etcdDataVolumeIOPS: 104
-etcdDataVolumeEncrypted: true
-`,
-			assertConfig: []ConfigTester{
-				hasDefaultExperimentalFeatures,
-				func(c *config.Config, t *testing.T) {
-					//intp := func(v int) *int {
-					//	return &v
-					//}
-					//boolp := func(v bool) *bool {
-					//	return &v
-					//}
-					//strp := func(v string) *string {
-					//	return &v
-					//}
-					subnet1 := model.NewPublicSubnetWithPreconfiguredRouteTable("us-west-1c", "10.0.0.0/24", "rtb-1a2b3c4d")
-					subnet1.Name = "Subnet0"
-					subnets := []model.Subnet{
-						subnet1,
-					}
-					expected := model.Etcd{
-						EC2Instance: model.EC2Instance{
-							Count:        2,
-							InstanceType: "t2.large",
-							RootVolume: model.RootVolume{
-								Size: 101,
-								Type: "io1",
-								IOPS: 102,
-							},
-							Tenancy: "dedicated",
-						},
-						DataVolume: model.DataVolume{
-							Size:      103,
-							Type:      "io1",
-							IOPS:      104,
-							Ephemeral: false,
-							Encrypted: true,
-						},
-						Subnets: subnets,
-					}
-
-					actual := c.EtcdSettings.Etcd
-					if !reflect.DeepEqual(expected, actual) {
-						t.Errorf(
-							"EtcdSettings didn't match: expected=%v actual=%v",
-							expected,
-							actual,
-						)
-					}
-					if c.EtcdInstanceType() != "t2.large" {
-						t.Errorf("unexpected etcd instance type: expected=t2.large, actual=%s", c.EtcdInstanceType())
-					}
-					//if c.EtcdCreateTimeout() != "PT10M" {
-					//	t.Errorf("unexpected etcd create timeout: expected=PT10M, actual=%s", c.EtcdCreateTimeout())
-					//}
-					if c.EtcdCount() != 2 {
-						t.Errorf("unexpected etcd count: expected=2, actual=%d", c.EtcdCount())
-					}
-					if c.EtcdRootVolumeSize() != 101 {
-						t.Errorf("unexpected etcd root volume size: expected=101, actual=%d", c.EtcdRootVolumeSize())
-					}
-					if c.EtcdRootVolumeType() != "io1" {
-						t.Errorf("unexpected etcd root volume type: expected=io1, actual=%s", c.EtcdRootVolumeType())
-					}
-					if c.EtcdRootVolumeIOPS() != 102 {
-						t.Errorf("unexpected etcd root volume iops: expected=102, actual=%d", c.EtcdRootVolumeIOPS())
-					}
-					if c.EtcdDataVolumeSize() != 103 {
-						t.Errorf("unexpected etcd data volume size: expected=103, actual=%d", c.EtcdDataVolumeSize())
-					}
-					if c.EtcdDataVolumeType() != "io1" {
-						t.Errorf("unexpected etcd data volume type: expected=io1, actual=%s", c.EtcdDataVolumeType())
-					}
-					if c.EtcdDataVolumeIOPS() != 104 {
-						t.Errorf("unexpected etcd data volume iops: expected=104, actual=%d", c.EtcdDataVolumeIOPS())
-					}
-					if !c.EtcdDataVolumeEncrypted() {
-						t.Errorf("unexpected etcd data volume encrypted: expected=true, actual=%v", c.EtcdDataVolumeEncrypted())
-					}
-					if c.EtcdTenancy() != "dedicated" {
-						t.Errorf("unexpected etcd tenancy: expected=dedicated, actual=%s", c.EtcdTenancy())
-					}
-				},
-			},
-		},
-		{
 			context: "WithSSHAccessAllowedSourceCIDRsSpecified",
 			configYaml: minimalValidConfigYaml + `
 sshAccessAllowedSourceCIDRs:
@@ -3700,7 +3539,41 @@ worker:
 `,
 			expectedErrorMessage: "invalid taint effect: UnknownEffect",
 		},
-
+		{
+			context: "WithLegacyControllerSettingKeys",
+			configYaml: minimalValidConfigYaml + `
+vpcId: vpc-1a2b3c4d
+internetGatewayId: igw-1a2b3c4d
+routeTableId: rtb-1a2b3c4d
+controllerCount: 2
+controllerCreateTimeout: PT10M
+controllerInstanceType: t2.large
+controllerRootVolumeSize: 101
+controllerRootVolumeType: io1
+controllerRootVolumeIOPS: 102
+controllerTenancy: dedicated
+`,
+			expectedErrorMessage: "unknown keys found: controllerCount, controllerCreateTimeout, controllerInstanceType, controllerRootVolumeIOPS, controllerRootVolumeSize, controllerRootVolumeType, controllerTenancy",
+		},
+		{
+			context: "WithLegacyEtcdSettingKeys",
+			configYaml: minimalValidConfigYaml + `
+vpcId: vpc-1a2b3c4d
+internetGatewayId: igw-1a2b3c4d
+routeTableId: rtb-1a2b3c4d
+etcdCount: 2
+etcdTenancy: dedicated
+etcdInstanceType: t2.large
+etcdRootVolumeSize: 101
+etcdRootVolumeType: io1
+etcdRootVolumeIOPS: 102
+etcdDataVolumeSize: 103
+etcdDataVolumeType: io1
+etcdDataVolumeIOPS: 104
+etcdDataVolumeEncrypted: true
+`,
+			expectedErrorMessage: "unknown keys found: etcdCount, etcdDataVolumeEncrypted, etcdDataVolumeIOPS, etcdDataVolumeSize, etcdDataVolumeType, etcdInstanceType, etcdRootVolumeIOPS, etcdRootVolumeSize, etcdRootVolumeType, etcdTenancy",
+		},
 		{
 			context: "WithAwsNodeLabelEnabledForTooLongClusterNameAndPoolName",
 			configYaml: minimalValidConfigYaml + `


### PR DESCRIPTION
Except `externalDNSName`, `createRecordSet`, `recordSetTTL`, `hostedZoneId`, `controller.loadBalancer` as per https://github.com/kubernetes-incubator/kube-aws/issues/753#issuecomment-314357384
Ref #753 

This is verified manually by running E2E