### PR TITLE
Support cross-stack references of VPC, IGW

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -676,11 +676,25 @@ worker:
 
 ## Networking config
 
-# ID of existing VPC to create subnet in. Leave blank to create a new VPC
+# CAUTION: Deprecated and will be removed in v0.9.9. Please use vpc.id instead
 # vpcId:
 
-# ID of existing Internet Gateway to associate subnet with. Leave blank to create a new Internet Gateway
+#vpc:
+#  # ID of existing VPC to create subnet in. Leave blank to create a new VPC
+#  id:
+#  # Exported output's name from another stack
+#  # Only specify either id or idFromStackOutput but not both
+#  #idFromStackOutput: myinfra-Vpc
+
+# CAUTION: Deprecated and will be removed in v0.9.9. Please use internetGateway.id instead
 # internetGatewayId:
+
+#internetGateway:
+#  # ID of existing Internet Gateway to associate subnet with. Leave blank to create a new Internet Gateway
+#  id:
+#  # Exported output's name from another stack
+#  # Only specify either id or idFromStackOutput but not both
+#  #idFromStackOutput: myinfra-igw
 
 # Advanced: ID of existing route table in existing VPC to attach subnet to.
 # Leave blank to use the VPC's main route table.

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1484,7 +1484,7 @@
     {{end}}
     {{end}}
 
-    {{if not .VPCID}}
+    {{if .VPCManaged}}
     ,
     "{{.InternetGatewayLogicalName}}": {
       "Properties": {
@@ -1528,7 +1528,7 @@
   },
 
   "Outputs": {
-    {{if not .VPCID}}
+    {{if .VPCManaged}}
     "VPC" : {
       "Description" : "The VPC managed by this stack",
       "Value" :  { "Ref" : "{{.VPCLogicalName}}" },

--- a/core/nodepool/config/deployment.go
+++ b/core/nodepool/config/deployment.go
@@ -10,18 +10,18 @@ func (c DeploymentSettings) ValidateInputs() error {
 	// By design, kube-aws doesn't allow customizing the following settings among node pools.
 	//
 	// Every node pool imports subnets from the main stack and therefore there's no need for setting:
-	// * VPCID
-	// * InternetGatewayID
+	// * VPC.ID(FromStackOutput)
+	// * InternetGateway.ID(FromStackOutput)
 	// * RouteTableID
 	// * VPCCIDR
 	// * InstanceCIDR
 	// * MapPublicIPs
 	// * ElasticFileSystemID
-	if c.VPCID != "" {
-		return fmt.Errorf("although you can't customize `vpcId` per node pool but you did specify \"%s\" in your cluster.yaml", c.VPCID)
+	if c.VPC.HasIdentifier() {
+		return fmt.Errorf("although you can't customize VPC per node pool but you did specify \"%v\" in your cluster.yaml", c.VPC)
 	}
-	if c.InternetGatewayID != "" {
-		return fmt.Errorf("although you can't customize `internetGatewayId` per node pool but you did specify \"%s\" in your cluster.yaml", c.InternetGatewayID)
+	if c.InternetGateway.HasIdentifier() {
+		return fmt.Errorf("although you can't customize internet gateway per node pool but you did specify \"%v\" in your cluster.yaml", c.InternetGateway)
 	}
 	if c.RouteTableID != "" {
 		return fmt.Errorf("although you can't customize `routeTableId` per node pool but you did specify \"%s\" in your cluster.yaml", c.RouteTableID)

--- a/e2e/run
+++ b/e2e/run
@@ -149,8 +149,8 @@ customize_cluster_yaml() {
   echo Writing to $(pwd)/cluster.yaml
 
   if [ "${KUBE_AWS_DEPLOY_TO_EXISTING_VPC}" != "" ]; then
-    echo "vpcId: $(testinfra_vpc)" >> cluster.yaml
-    echo "routeTableId: $(testinfra_public_routetable)" >> cluster.yaml
+    echo -e "vpc:\n  id: $(testinfra_vpc)" >> cluster.yaml
+    echo -e "routeTableId: $(testinfra_public_routetable)" >> cluster.yaml
     echo -e "workerSecurityGroupIds:\n- $(testinfra_glue_sg)" >> cluster.yaml
   fi
 

--- a/model/vpc.go
+++ b/model/vpc.go
@@ -1,0 +1,12 @@
+package model
+
+// kube-aws manages at most one VPC per cluster
+// If ID or IDFromStackOutput is non-zero, kube-aws doesn't manage the VPC but its users' responsibility to
+// provide properly configured one to be reused by kube-aws.
+// More concretely:
+// * If an user is going to reuse an existing VPC, it must have an internet gateway attached and
+// * A valid internet gateway ID must be provided via `internetGateway.id` or `internetGateway.idFromStackOutput`.
+//   In other words, kube-aws doesn't create an internet gateway in an existing VPC.
+type VPC struct {
+	Identifier `yaml:",inline"`
+}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1622,8 +1622,10 @@ worker:
 		{
 			context: "WithMultiAPIEndpoints",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: privateSubnet1
@@ -1810,7 +1812,8 @@ apiEndpoints:
 		{
 			context: "WithNetworkTopologyAllPreconfiguredPrivateDeprecated",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
 # This, in combination with mapPublicIPs=false, implies that the route table contains a route to a preconfigured NAT gateway
 # See https://github.com/kubernetes-incubator/kube-aws/pull/284#issuecomment-276008202
 routeTableId: rtb-1a2b3c4d
@@ -1881,14 +1884,16 @@ subnets:
 		{
 			context: "WithNetworkTopologyAllPreconfiguredPublicDeprecated",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
 # This, in combination with mapPublicIPs=true, implies that the route table contains a route to a preconfigured internet gateway
 # See https://github.com/kubernetes-incubator/kube-aws/pull/284#issuecomment-276008202
 routeTableId: rtb-1a2b3c4d
 # This means that all the subnets created by kube-aws should be public
 mapPublicIPs: true
-# internetGatewayId should be omitted as we assume that the route table specified by routeTableId already contain a route to one
-#internetGatewayId:
+# internetGateway.id should be omitted as we assume that the route table specified by routeTableId already contain a route to one
+#internetGateway:
+#  id:
 subnets:
 - availabilityZone: us-west-1a
   instanceCIDR: "10.0.1.0/24"
@@ -1954,8 +1959,10 @@ subnets:
 		{
 			context: "WithNetworkTopologyExplicitSubnets",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 # routeTableId must be omitted
 # See https://github.com/kubernetes-incubator/kube-aws/pull/284#issuecomment-275962332
 # routeTableId: rtb-1a2b3c4d
@@ -2064,8 +2071,10 @@ worker:
 		{
 			context: "WithNetworkTopologyImplicitSubnets",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 # routeTableId must be omitted
 # See https://github.com/kubernetes-incubator/kube-aws/pull/284#issuecomment-275962332
 # routeTableId: rtb-1a2b3c4d
@@ -2142,8 +2151,10 @@ subnets:
 		{
 			context: "WithNetworkTopologyControllerPrivateLB",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 # routeTableId must be omitted
 # See https://github.com/kubernetes-incubator/kube-aws/pull/284#issuecomment-275962332
 # routeTableId: rtb-1a2b3c4d
@@ -2244,8 +2255,10 @@ worker:
 		{
 			context: "WithNetworkTopologyControllerPublicLB",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 # routeTableId must be omitted
 # See https://github.com/kubernetes-incubator/kube-aws/pull/284#issuecomment-275962332
 # routeTableId: rtb-1a2b3c4d
@@ -2346,7 +2359,8 @@ worker:
 		{
 			context: "WithNetworkTopologyExistingVaryingSubnets",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
 subnets:
 - name: private1
   availabilityZone: us-west-1a
@@ -2439,7 +2453,8 @@ worker:
 		{
 			context: "WithNetworkTopologyAllExistingPrivateSubnets",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
 subnets:
 - name: private1
   availabilityZone: us-west-1a
@@ -2471,7 +2486,8 @@ worker:
 		{
 			context: "WithNetworkTopologyAllExistingPublicSubnets",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
 subnets:
 - name: public1
   availabilityZone: us-west-1a
@@ -2501,8 +2517,10 @@ worker:
 		{
 			context: "WithNetworkTopologyExistingNATGateways",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 subnets:
 - name: private1
   availabilityZone: us-west-1a
@@ -2600,8 +2618,10 @@ worker:
 		{
 			context: "WithNetworkTopologyExistingNATGatewayEIPs",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 subnets:
 - name: private1
   availabilityZone: us-west-1a
@@ -2690,10 +2710,12 @@ worker:
 		{
 			context: "WithNetworkTopologyVaryingPublicSubnets",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
 #required only for the managed subnet "public1"
 # "public2" is assumed to have an existing route table and an igw already associated to it
-internetGatewayId: igw-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 subnets:
 - name: public1
   availabilityZone: us-west-1a
@@ -2899,19 +2921,54 @@ worker:
 		{
 			context: "WithVpcIdSpecified",
 			configYaml: minimalValidConfigYaml + `
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
+`,
+			assertConfig: []ConfigTester{
+				hasDefaultEtcdSettings,
+				hasDefaultExperimentalFeatures,
+				func(c *config.Config, t *testing.T) {
+					vpcId := "vpc-1a2b3c4d"
+					if c.VPC.ID != vpcId {
+						t.Errorf("vpc id didn't match: expected=%v actual=%v", vpcId, c.VPC.ID)
+					}
+					igwId := "igw-1a2b3c4d"
+					if c.InternetGateway.ID != igwId {
+						t.Errorf("internet gateway id didn't match: expected=%v actual=%v", igwId, c.InternetGateway.ID)
+					}
+				},
+			},
+		},
+		{
+			context: "WithLegacyVpcAndIGWIdSpecified",
+			configYaml: minimalValidConfigYaml + `
 vpcId: vpc-1a2b3c4d
 internetGatewayId: igw-1a2b3c4d
 `,
 			assertConfig: []ConfigTester{
 				hasDefaultEtcdSettings,
 				hasDefaultExperimentalFeatures,
+				func(c *config.Config, t *testing.T) {
+					vpcId := "vpc-1a2b3c4d"
+					if c.VPC.ID != vpcId {
+						t.Errorf("vpc id didn't match: expected=%v actual=%v", vpcId, c.VPC.ID)
+					}
+					igwId := "igw-1a2b3c4d"
+					if c.InternetGateway.ID != igwId {
+						t.Errorf("internet gateway id didn't match: expected=%v actual=%v", igwId, c.InternetGateway.ID)
+					}
+				},
 			},
 		},
 		{
 			context: "WithVpcIdAndRouteTableIdSpecified",
 			configYaml: minimalValidConfigYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 routeTableId: rtb-1a2b3c4d
 `,
 			assertConfig: []ConfigTester{
@@ -3542,8 +3599,10 @@ worker:
 		{
 			context: "WithLegacyControllerSettingKeys",
 			configYaml: minimalValidConfigYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 routeTableId: rtb-1a2b3c4d
 controllerCount: 2
 controllerCreateTimeout: PT10M
@@ -3558,8 +3617,10 @@ controllerTenancy: dedicated
 		{
 			context: "WithLegacyEtcdSettingKeys",
 			configYaml: minimalValidConfigYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 routeTableId: rtb-1a2b3c4d
 etcdCount: 2
 etcdTenancy: dedicated
@@ -3605,8 +3666,10 @@ experimental:
 		{
 			context: "WithMultiAPIEndpointsInvalidLB",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: publicSubnet1
@@ -3632,8 +3695,10 @@ apiEndpoints:
 		{
 			context: "WithMultiAPIEndpointsInvalidWorkerAPIEndpointName",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: publicSubnet1
@@ -3667,8 +3732,10 @@ apiEndpoints:
 		{
 			context: "WithMultiAPIEndpointsInvalidWorkerNodePoolAPIEndpointName",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: publicSubnet1
@@ -3706,8 +3773,10 @@ apiEndpoints:
 		{
 			context: "WithMultiAPIEndpointsMissingDNSName",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: publicSubnet1
@@ -3723,8 +3792,10 @@ apiEndpoints:
 		{
 			context: "WithMultiAPIEndpointsMissingGlobalAPIEndpointName",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: publicSubnet1
@@ -3762,8 +3833,10 @@ apiEndpoints:
 		{
 			context: "WithMultiAPIEndpointsRecordSetImpliedBySubnetsMissingHostedZoneID",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: publicSubnet1
@@ -3788,8 +3861,10 @@ apiEndpoints:
 		{
 			context: "WithMultiAPIEndpointsRecordSetImpliedByExplicitPublicMissingHostedZoneID",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: publicSubnet1
@@ -3813,8 +3888,10 @@ apiEndpoints:
 		{
 			context: "WithMultiAPIEndpointsRecordSetImpliedByExplicitPrivateMissingHostedZoneID",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: publicSubnet1
@@ -3841,8 +3918,10 @@ apiEndpoints:
 		{
 			context: "WithMultiAPIEndpointsExplicitRecordSetMissingHostedZoneID",
 			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 
 subnets:
 - name: publicSubnet1
@@ -3866,8 +3945,10 @@ apiEndpoints:
 		{
 			context: "WithNetworkTopologyAllExistingPrivateSubnetsRejectingExistingIGW",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 subnets:
 - name: private1
   availabilityZone: us-west-1a
@@ -3885,13 +3966,15 @@ worker:
     subnets:
     - name: private1
 `,
-			expectedErrorMessage: `internetGatewayId can't be spcified when all the subnets are existing private subnets`,
+			expectedErrorMessage: `internet gateway id can't be specified when all the subnets are existing private subnets`,
 		},
 		{
 			context: "WithNetworkTopologyAllExistingPublicSubnetsRejectingExistingIGW",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 subnets:
 - name: public1
   availabilityZone: us-west-1a
@@ -3908,13 +3991,15 @@ worker:
     subnets:
     - name: public1
 `,
-			expectedErrorMessage: `internetGatewayId can't be specified when all the public subnets have existing route tables associated. kube-aws doesn't try to modify an exisinting route table to include a route to the internet gateway`,
+			expectedErrorMessage: `internet gateway id can't be specified when all the public subnets have existing route tables associated. kube-aws doesn't try to modify an exisinting route table to include a route to the internet gateway`,
 		},
 		{
 			context: "WithNetworkTopologyAllManagedPublicSubnetsWithExistingRouteTableRejectingExistingIGW",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 subnets:
 - name: public1
   availabilityZone: us-west-1a
@@ -3933,14 +4018,16 @@ worker:
     subnets:
     - name: public1
 `,
-			expectedErrorMessage: `internetGatewayId can't be specified when all the public subnets have existing route tables associated. kube-aws doesn't try to modify an exisinting route table to include a route to the internet gateway`,
+			expectedErrorMessage: `internet gateway id can't be specified when all the public subnets have existing route tables associated. kube-aws doesn't try to modify an exisinting route table to include a route to the internet gateway`,
 		},
 		{
 			context: "WithNetworkTopologyAllManagedPublicSubnetsMissingExistingIGW",
 			configYaml: mainClusterYaml + `
-vpcId: vpc-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
 #misses this
-#internetGatewayId: igw-1a2b3c4d
+#internetGateway:
+#  id: igw-1a2b3c4d
 subnets:
 - name: public1
   availabilityZone: us-west-1a
@@ -3957,7 +4044,7 @@ worker:
     subnets:
     - name: public1
 `,
-			expectedErrorMessage: `internetGatewayId can't be omitted when there're one or more managed public subnets in an existing VPC`,
+			expectedErrorMessage: `internet gateway id can't be omitted when there're one or more managed public subnets in an existing VPC`,
 		},
 		{
 			context: "WithNonZeroWorkerCount",
@@ -3969,8 +4056,10 @@ workerCount: 1
 		{
 			context: "WithVpcIdAndVPCCIDRSpecified",
 			configYaml: minimalValidConfigYaml + `
-vpcId: vpc-1a2b3c4d
-internetGatewayId: igw-1a2b3c4d
+vpc:
+  id: vpc-1a2b3c4d
+internetGateway:
+  id: igw-1a2b3c4d
 # vpcCIDR (10.1.0.0/16) does not contain instanceCIDR (10.0.1.0/24)
 vpcCIDR: "10.1.0.0/16"
 `,
@@ -3978,7 +4067,7 @@ vpcCIDR: "10.1.0.0/16"
 		{
 			context: "WithRouteTableIdSpecified",
 			configYaml: minimalValidConfigYaml + `
-# vpcId must be specified if routeTableId is specified
+# vpc.id must be specified if routeTableId is specified
 routeTableId: rtb-1a2b3c4d
 `,
 		},


### PR DESCRIPTION
* Add `vpc.id` and deprecate `vpcId` instead
  * kube-aws emits a warning message when `vpcId` is specified in `cluster.yaml`
  * kube-aws emits a warning message when `.VPCID` is called in a control-plane stack template
* Add `vpc.idFromStackOutput` for cross-stack referencing vpc id
* Add `internetGateway.id` and deprecate `internetGatewayId` instead
  * kube-aws emits a warning message when `internetGatewayId` is specified in `cluster.yaml`
* Add `internetGateway.idFromStackOutput` for cross-stack referencing internet gateway id

This is verified manually by running E2E in 2 ways:
1. Deployment to a managed VPC: `ETCD_DISASTER_RECOVERY_AUTOMATED=1 ETCD_SNAPSHOT_AUTOMATED=1 ETCD_COUNT=1 CONTROLLER_COUNT=1 KUBE_AWS_CLUSTER_NAME=vpcid1 bash -c './run all`
2. Deployment to an existing VPC: `KUBE_AWS_DEPLOY_TO_EXISTING_VPC=1 ETCD_DISASTER_RECOVERY_AUTOMATED=1 ETCD_SNAPSHOT_AUTOMATED=1 ETCD_COUNT=1 CONTROLLER_COUNT=1 KUBE_AWS_CLUSTER_NAME=vpcid2 bash -c './run all'` 

Resolves #643

