### PR TITLE
More flexible IAM configuration for etcd nodes

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1306,6 +1306,10 @@ func (e EtcdSettings) Valid() error {
 		return errors.New("`etcd.kmsKeyArn` can only be specified when `etcdDataVolumeEncrypted` is enabled")
 	}
 
+	if err := e.IAMConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid etcd settings: %v", err)
+	}
+
 	if e.Etcd.Version().Is3() {
 		if e.Etcd.DisasterRecovery.Automated && !e.Etcd.Snapshot.Automated {
 			return errors.New("`etcd.disasterRecovery.automated` is set to true but `etcd.snapshot.automated` is not - automated disaster recovery requires snapshot to be also automated")

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -478,20 +478,21 @@ type FlannelSettings struct {
 }
 
 type Cluster struct {
-	KubeClusterSettings    `yaml:",inline"`
-	DeploymentSettings     `yaml:",inline"`
-	DefaultWorkerSettings  `yaml:",inline"`
-	ControllerSettings     `yaml:",inline"`
-	EtcdSettings           `yaml:",inline"`
-	FlannelSettings        `yaml:",inline"`
-	AdminAPIEndpointName   string `yaml:"adminAPIEndpointName,omitempty"`
-	ServiceCIDR            string `yaml:"serviceCIDR,omitempty"`
-	CreateRecordSet        bool   `yaml:"createRecordSet,omitempty"`
-	RecordSetTTL           int    `yaml:"recordSetTTL,omitempty"`
-	TLSCADurationDays      int    `yaml:"tlsCADurationDays,omitempty"`
-	TLSCertDurationDays    int    `yaml:"tlsCertDurationDays,omitempty"`
-	HostedZoneID           string `yaml:"hostedZoneId,omitempty"`
-	ProvidedEncryptService EncryptService
+	AutoscalingNotification model.AutoscalingNotification `yaml:"autoscalingNotification,omitempty"`
+	KubeClusterSettings     `yaml:",inline"`
+	DeploymentSettings      `yaml:",inline"`
+	DefaultWorkerSettings   `yaml:",inline"`
+	ControllerSettings      `yaml:",inline"`
+	EtcdSettings            `yaml:",inline"`
+	FlannelSettings         `yaml:",inline"`
+	AdminAPIEndpointName    string `yaml:"adminAPIEndpointName,omitempty"`
+	ServiceCIDR             string `yaml:"serviceCIDR,omitempty"`
+	CreateRecordSet         bool   `yaml:"createRecordSet,omitempty"`
+	RecordSetTTL            int    `yaml:"recordSetTTL,omitempty"`
+	TLSCADurationDays       int    `yaml:"tlsCADurationDays,omitempty"`
+	TLSCertDurationDays     int    `yaml:"tlsCertDurationDays,omitempty"`
+	HostedZoneID            string `yaml:"hostedZoneId,omitempty"`
+	ProvidedEncryptService  EncryptService
 	// SSHAccessAllowedSourceCIDRs is network ranges of sources you'd like SSH accesses to be allowed from, in CIDR notation
 	SSHAccessAllowedSourceCIDRs model.CIDRRanges       `yaml:"sshAccessAllowedSourceCIDRs,omitempty"`
 	CustomSettings              map[string]interface{} `yaml:"customSettings,omitempty"`

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1202,6 +1202,14 @@ addons:
 #  Name: "Kubernetes"
 #  Environment: "Production"
 
+# Autoscaling lifecycle notifications are used by the kube-aws node drainer
+# in order to pend termination of an EC2 instance while gracefully stopping pods running on it
+#autoscalingNotification:
+#  iam:
+#    role:
+#      # When specified, kube-aws reuses an existing IAM role as the notification role of a autoscaling lifecycle hook
+#      arn: "arn:aws:iam::YOURACCOUNTID:role/ROLENAME"
+
 # User-provided YAML map available in control-plane's stack-template.json
 #customSettings:
 #  key1: [ 1, 2, 3 ]

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -167,7 +167,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #  # to follow the recommendation in AWS documentation  http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
 #  # This is also intended to be used in combination with .experimental.kube2IamSupport. See #297 for more information.
 #  #
-#  # ATTENTION: Consider limiting number of characters in clusterName and managedIamRoleName to avoid the resulting IAM
+#  # ATTENTION: Consider limiting number of characters in clusterName and iam.role.name to avoid the resulting IAM
 #  # role name's length from exceeding the AWS limit: 64
 #  # See https://github.com/kubernetes-incubator/kube-aws/issues/347
 #  # if you omit this block kube-aws would create an IAM Role and a customer managed policy with a random name.
@@ -587,6 +587,20 @@ worker:
 #  securityGroupIds:
 #    - sg-1234abcd
 #    - sg-5678efab
+#
+#  # If you omit this block kube-aws would create an IAM Role and a managed policy for etcd nodes with a random name.
+#  iam:
+#    role:
+#      # If you set managedPolicies here they will be attached to the role in addition to the managed policy.
+#      # CAUTION: if you attach a more restrictive policy in some resources (i.e ec2:* Deny) you can make kube-aws fail.
+#      managedPolicies:
+#      - arn: "arn:aws:iam::aws:policy/AdministratorAccess"
+#      - arn: "arn:aws:iam::YOURACCOUNTID:policy/YOURPOLICYNAME"
+#    # If you set an InstanceProfile kube-aws will NOT create any IAM Role and will use the existing instance profile.
+#    # CAUTION: you must ensure that the IAM role linked to the existing instance profile has enough permissions to ensure etcd nodes to run.
+#    # If you dont know which permissions are required, it is recommended to go ahead with a managed instance profile.
+#    instanceProfile:
+#      arn: "arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME"
 #
 #  # The version of etcd to be used. Set to e.g. "3.2.1" to use etcd3
 #  version: 3.2.1

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -159,19 +159,6 @@
       },
       "Type": "AWS::IAM::InstanceProfile"
     },
-    {{end}}
-    "IAMInstanceProfileEtcd": {
-      "Properties": {
-        "Path": "/",
-        "Roles": [
-          {
-            "Ref": "IAMRoleEtcd"
-          }
-        ]
-      },
-      "Type": "AWS::IAM::InstanceProfile"
-    },
-    {{ if not .Controller.IAMConfig.InstanceProfile.Arn }}
     "IAMManagedPolicyController" : {
       "Type" : "AWS::IAM::ManagedPolicy",
       "Properties" : {
@@ -344,6 +331,158 @@
       "Type": "AWS::IAM::Role"
     },
     {{end}}
+    {{ if not .Etcd.IAMConfig.InstanceProfile.Arn }}
+    "IAMInstanceProfileEtcd": {
+      "Properties": {
+        "Path": "/",
+        "Roles": [
+          {
+            "Ref": "IAMRoleEtcd"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::InstanceProfile"
+    },
+    "IAMManagedPolicyEtcd" : {
+      "Type" : "AWS::IAM::ManagedPolicy",
+      "Properties" : {
+        "Description" : "Policy for managing kube-aws k8s etcd nodes",
+        "Path" : "/",
+        "PolicyDocument" :   {
+          "Version":"2012-10-17",
+          "Statement": [
+            {{if .AssetsEncryptionEnabled}}
+            {
+              "Action" : "kms:Decrypt",
+              "Effect" : "Allow",
+              "Resource" : "{{.KMSKeyARN}}"
+            },
+            {{end}}
+            {{if $.Etcd.KMSKeyARN -}}
+            {{/* Required for mounting encrypted data volume */}}
+            {
+            "Action": [
+              "kms:CreateGrant",
+              "kms:Decrypt",
+              "kms:Describe*",
+              "kms:Encrypt",
+              "kms:GenerateDataKey*",
+              "kms:ReEncrypt*"
+            ],
+            "Effect": "Allow",
+            "Resource": "{{ $.Etcd.KMSKeyARN }}"
+            },
+            {{end -}}
+            {
+              "Action": "ec2:DescribeTags",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {{/* Required for cfn-etcd-environment.service to discover the volume */}}
+            {
+              "Action": "ec2:DescribeVolumes",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {{/* Required for cfn-etcd-environment.service to start attaching the volume */}}
+            {
+              "Action": "ec2:AttachVolume",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {{/* Required for cfn-etcd-environment.service to wait until the volume is attached */}}
+            {
+              "Action": "ec2:DescribeVolumeStatus",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {{if $.Etcd.NodeShouldHaveEIP -}}
+            {{/* Required for cfn-etcd-environment.service to associate an EIP */}}
+            {
+              "Action": "ec2:AssociateAddress",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {{end -}}
+            {{if $.Etcd.NodeShouldHaveSecondaryENI -}}
+            {{/* Required for cfn-etcd-environment.service to associate a network interface */}}
+            {
+              "Action": "ec2:AttachNetworkInterface",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {
+              "Action": "ec2:DescribeNetworkInterfaces",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {
+              "Action": "ec2:DescribeNetworkInterfaceAttribute",
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {{end -}}
+            {{- if $.UserDataEtcd.Parts.s3 }}
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:GetObject"
+              ],
+              "Resource": "arn:{{.Region.Partition}}:s3:::{{ $.UserDataEtcd.Parts.s3.Asset.S3Prefix }}*"
+            },
+            {{- end }}
+            {{/* Required for `etcdadm reconfigure` to check existence of an etcd snapshot in S3 */}}
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:ListBucket"
+              ],
+              "Resource": "arn:{{.Region.Partition}}:s3:::{{$.EtcdSnapshotsS3Bucket}}"
+            },
+            {{if .CloudWatchLogging.Enabled}}
+            {
+              "Effect": "Allow",
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams"
+              ],
+              "Resource": [
+                { "Ref": "CloudWatchLogGroupARN" },
+                { "Fn::Join" : [ "", [{ "Ref": "CloudWatchLogGroupARN" }, ":log-stream:*"]] }
+              ]
+            },{{ end }}
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:List*",
+                "s3:GetObject*"
+              ],
+              "Resource": "arn:{{.Region.Partition}}:s3:::{{$.EtcdSnapshotsS3Bucket}}",
+              "Condition": {
+                "StringLike": {
+                  "s3:prefix": { "Fn::Join" : [ "", [{{$.EtcdSnapshotsS3PrefixRef}}, "/*" ]]}
+                }
+              }
+            },
+            {{/* Required for `etcdadm save` to save etcd snapshots in S3 */}}
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:*"
+              ],
+              "Resource": { "Fn::Join" : [ "", ["arn:{{.Region.Partition}}:s3:::", {{$.EtcdSnapshotsS3PathRef}}, "/*" ]]}
+            },
+            {{/* Required for `etcdadm reconfigure` to determine the number of active etcd nodes */}}
+            {
+              "Action": "ec2:DescribeInstances",
+              "Resource": "*",
+              "Effect": "Allow"
+            }
+          ]
+        }
+      }
+    },
     "IAMRoleEtcd": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -363,146 +502,16 @@
           "Version": "2012-10-17"
         },
         "Path": "/",
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [{{if .AssetsEncryptionEnabled}}
-                {
-                  "Action" : "kms:Decrypt",
-                  "Effect" : "Allow",
-                  "Resource" : "{{.KMSKeyARN}}"
-                },{{end}}
-                {{if $.Etcd.KMSKeyARN -}}
-                {{/* Required for mounting encrypted data volume */}}
-                {
-                "Action": [
-                  "kms:CreateGrant",
-                  "kms:Decrypt",
-                  "kms:Describe*",
-                  "kms:Encrypt",
-                  "kms:GenerateDataKey*",
-                  "kms:ReEncrypt*"
-                ],
-                "Effect": "Allow",
-                "Resource": "{{ $.Etcd.KMSKeyARN }}"
-                },
-                {{end -}}
-                {
-                  "Action": "ec2:DescribeTags",
-                  "Effect": "Allow",
-                  "Resource": "*"
-                },
-                {{/* Required for cfn-etcd-environment.service to discover the volume */}}
-                {
-                  "Action": "ec2:DescribeVolumes",
-                  "Effect": "Allow",
-                  "Resource": "*"
-                },
-                {{/* Required for cfn-etcd-environment.service to start attaching the volume */}}
-                {
-                  "Action": "ec2:AttachVolume",
-                  "Effect": "Allow",
-                  "Resource": "*"
-                },
-                {{/* Required for cfn-etcd-environment.service to wait until the volume is attached */}}
-                {
-                  "Action": "ec2:DescribeVolumeStatus",
-                  "Effect": "Allow",
-                  "Resource": "*"
-                },
-                {{if $.Etcd.NodeShouldHaveEIP -}}
-                {{/* Required for cfn-etcd-environment.service to associate an EIP */}}
-                {
-                  "Action": "ec2:AssociateAddress",
-                  "Effect": "Allow",
-                  "Resource": "*"
-                },
-                {{end -}}
-                {{if $.Etcd.NodeShouldHaveSecondaryENI -}}
-                {{/* Required for cfn-etcd-environment.service to associate a network interface */}}
-                {
-                  "Action": "ec2:AttachNetworkInterface",
-                  "Effect": "Allow",
-                  "Resource": "*"
-                },
-                {
-                  "Action": "ec2:DescribeNetworkInterfaces",
-                  "Effect": "Allow",
-                  "Resource": "*"
-                },
-                {
-                  "Action": "ec2:DescribeNetworkInterfaceAttribute",
-                  "Effect": "Allow",
-                  "Resource": "*"
-                },
-                {{end -}}
-                {{- if $.UserDataEtcd.Parts.s3 }}
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "s3:GetObject"
-                  ],
-                  "Resource": "arn:{{.Region.Partition}}:s3:::{{ $.UserDataEtcd.Parts.s3.Asset.S3Prefix }}*"
-                },
-                {{- end }}
-                {{/* Required for `etcdadm reconfigure` to check existence of an etcd snapshot in S3 */}}
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "s3:ListBucket"
-                  ],
-                  "Resource": "arn:{{.Region.Partition}}:s3:::{{$.EtcdSnapshotsS3Bucket}}"
-                },
-                {{if .CloudWatchLogging.Enabled}}
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
-                    "logs:DescribeLogStreams"
-                  ],
-                  "Resource": [
-                    { "Ref": "CloudWatchLogGroupARN" },
-                    { "Fn::Join" : [ "", [{ "Ref": "CloudWatchLogGroupARN" }, ":log-stream:*"]] }
-                  ]
-                },{{ end }}
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "s3:List*",
-                    "s3:GetObject*"
-                  ],
-                  "Resource": "arn:{{.Region.Partition}}:s3:::{{$.EtcdSnapshotsS3Bucket}}",
-                  "Condition": {
-                    "StringLike": {
-                      "s3:prefix": { "Fn::Join" : [ "", [{{$.EtcdSnapshotsS3PrefixRef}}, "/*" ]]}
-                    }
-                  }
-                },
-                {{/* Required for `etcdadm save` to save etcd snapshots in S3 */}}
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "s3:*"
-                  ],
-                  "Resource": { "Fn::Join" : [ "", ["arn:{{.Region.Partition}}:s3:::", {{$.EtcdSnapshotsS3PathRef}}, "/*" ]]}
-                },
-                {{/* Required for `etcdadm reconfigure` to determine the number of active etcd nodes */}}
-                {
-                  "Action": "ec2:DescribeInstances",
-                  "Resource": "*",
-                  "Effect": "Allow"
-                }
-              ],
-              "Version": "2012-10-17"
-            },
-            "PolicyName": "root"
-          }
+        "ManagedPolicyArns": [
+          {{range $policyIndex, $policyArn := .Etcd.IAMConfig.Role.ManagedPolicies }}
+            "{{$policyArn.Arn}}",
+          {{end}}
+          {"Ref": "IAMManagedPolicyEtcd"}
         ]
       },
-
       "Type": "AWS::IAM::Role"
     },
+    {{end}}
     {{if $.Etcd.HostedZoneManaged}}
     "{{$.Etcd.HostedZoneLogicalName}}": {
       "Type": "AWS::Route53::HostedZone",
@@ -771,9 +780,13 @@
           }
           {{end}}
         ],
+        {{if $.Etcd.IAMConfig.InstanceProfile.Arn }}
+        "IamInstanceProfile": "{{$.Etcd.IAMConfig.InstanceProfile.Arn}}",
+        {{else}}
         "IamInstanceProfile": {
           "Ref": "IAMInstanceProfileEtcd"
         },
+        {{end}}
         "ImageId": "{{$.AMI}}",
         "InstanceType": "{{$.Etcd.InstanceType}}",
         {{if $.KeyName}}"KeyName": "{{$.KeyName}}",{{end}}

--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -6,7 +6,8 @@
     "ASGNotificationTarget": {
       "Type": "AWS::SQS::Queue"
     },
-    "ASGNotificationRole": {
+    {{if .ControlPlane.AutoscalingNotification.RoleManaged}}
+    "{{.ControlPlane.AutoscalingNotification.RoleLogicalName}}": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [ {
@@ -35,6 +36,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
+    {{end}}
       {{if .CloudWatchLogging.Enabled}}
       "CloudWatchLogGroup": {
       "Type" : "AWS::Logs::LogGroup",
@@ -48,7 +50,7 @@
       "Properties" : {
         "Parameters": {
           "NotificationTargetARN": { "Fn::GetAtt": [ "ASGNotificationTarget", "Arn" ] },
-          "NotificationRoleARN": { "Fn::GetAtt": [ "ASGNotificationRole", "Arn" ] }
+          "NotificationRoleARN": {{.ControlPlane.AutoscalingNotification.RoleArn}}
           {{if .CloudWatchLogging.Enabled}}
           ,
           "CloudWatchLogGroupARN": { "Fn::GetAtt": [ "CloudWatchLogGroup", "Arn" ] }
@@ -73,7 +75,7 @@
         "Parameters": {
           "ControlPlaneStackName": {"Fn::GetAtt" : [ "{{$.ControlPlane.Name}}" , "Outputs.StackName" ]},
           "NotificationTargetARN": { "Fn::GetAtt": [ "ASGNotificationTarget", "Arn" ] },
-          "NotificationRoleARN": { "Fn::GetAtt": [ "ASGNotificationRole", "Arn" ] }
+          "NotificationRoleARN": {{$.ControlPlane.AutoscalingNotification.RoleArn}}
           {{if .CloudWatchLogging.Enabled}}
           ,
           "CloudWatchLogGroupARN": { "Fn::GetAtt": [ "CloudWatchLogGroup", "Arn" ] }

--- a/core/root/template_params.go
+++ b/core/root/template_params.go
@@ -6,6 +6,7 @@ import (
 	controlplane "github.com/kubernetes-incubator/kube-aws/core/controlplane/cluster"
 	config "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	nodepool "github.com/kubernetes-incubator/kube-aws/core/nodepool/cluster"
+	"github.com/kubernetes-incubator/kube-aws/model"
 )
 
 type TemplateParams struct {
@@ -39,6 +40,10 @@ type NestedStack interface {
 
 type controlPlane struct {
 	controlPlane *controlplane.Cluster
+}
+
+func (p controlPlane) AutoscalingNotification() model.AutoscalingNotification {
+	return p.controlPlane.AutoscalingNotification
 }
 
 func (p controlPlane) Name() string {
@@ -97,7 +102,7 @@ func (p nodePool) NeedToExportIAMroles() bool {
 	return p.nodePool.IAMConfig.InstanceProfile.Arn == ""
 }
 
-func (c TemplateParams) ControlPlane() NestedStack {
+func (c TemplateParams) ControlPlane() controlPlane {
 	return controlPlane{
 		controlPlane: c.cluster.controlPlane,
 	}

--- a/model/arn.go
+++ b/model/arn.go
@@ -1,0 +1,69 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ARN struct {
+	Arn                string `yaml:"arn,omitempty"`
+	ArnFromStackOutput string `yaml:"arnFromStackOutput,omitempty"`
+	ArnFromFn          string `yaml:"arnFromFn,omitempty"`
+}
+
+// HasArn returns true when the id of a resource i.e. either `arn` or `arnFromStackOutput` is specified
+func (i ARN) HasArn() bool {
+	return i.Arn != "" || i.ArnFromStackOutput != ""
+}
+
+func (i ARN) Validate() error {
+	if i.ArnFromFn != "" {
+		var jsonHolder map[string]interface{}
+		if err := json.Unmarshal([]byte(i.ArnFromFn), &jsonHolder); err != nil {
+			return fmt.Errorf("arnFromFn must be a valid json expression but was not: %s", i.ArnFromFn)
+		}
+	}
+	return nil
+}
+
+func (i ARN) OrGetAttArn(logicalNameProvider func() (string, error)) (string, error) {
+	return i.OrExpr(func() (string, error) {
+		logicalName, err := logicalNameProvider()
+		if err != nil {
+			// So that kube-aws can print a more useful error message with
+			// the line number for the stack-template.json when there's an error
+			return "", fmt.Errorf("failed to get arn: %v", err)
+		}
+		return fmt.Sprintf(`{ "Fn::GetAtt": [ %q, "Arn" ] }`, logicalName), nil
+	})
+}
+
+func (i ARN) OrRef(logicalNameProvider func() (string, error)) (string, error) {
+	return i.OrExpr(func() (string, error) {
+		logicalName, err := logicalNameProvider()
+		if err != nil {
+			// So that kube-aws can print a more useful error message with
+			// the line number for the stack-template.json when there's an error
+			return "", fmt.Errorf("failed to get arn: %v", err)
+		}
+		return fmt.Sprintf(`{ "Ref": %q }`, logicalName), nil
+	})
+}
+
+func (i ARN) OrExpr(exprProvider func() (string, error)) (string, error) {
+	if i.ArnFromStackOutput != "" {
+		return fmt.Sprintf(`{ "Fn::ImportValue" : %q }`, i.ArnFromStackOutput), nil
+	} else if i.Arn != "" {
+		return fmt.Sprintf(`"%s"`, i.Arn), nil
+	} else if i.ArnFromFn != "" {
+		return i.ArnFromFn, nil
+	} else {
+		expr, err := exprProvider()
+		if err != nil {
+			// So that kube-aws can print a more useful error message with
+			// the line number for the stack-template.json when there's an error
+			return "", fmt.Errorf("failed to get arn: %v", err)
+		}
+		return expr, nil
+	}
+}

--- a/model/autoscaling_notification.go
+++ b/model/autoscaling_notification.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"errors"
+)
+
+type AutoscalingNotification struct {
+	IAMConfig `yaml:"iam,omitempty"`
+}
+
+func (n AutoscalingNotification) RoleLogicalName() (string, error) {
+	if !n.RoleManaged() {
+		return "", errors.New("[BUG] RoleLogicalName should not be called when an existing autoscaling notification role was specified")
+	}
+	return "ASGNotificationRole", nil
+}
+
+func (n AutoscalingNotification) RoleArn() (string, error) {
+	return n.IAMConfig.Role.ARN.OrGetAttArn(func() (string, error) { return n.RoleLogicalName() })
+}
+
+func (n AutoscalingNotification) RoleManaged() bool {
+	return !n.IAMConfig.Role.HasArn()
+}

--- a/model/controller.go
+++ b/model/controller.go
@@ -71,12 +71,6 @@ func (c Controller) Validate() error {
 			"allowing so for a group of controller nodes spreading over 2 or more availability zones " +
 			"results in unreliability while scaling nodes out.")
 	}
-	if c.IAMConfig.InstanceProfile.Arn != "" && c.IAMConfig.Role.Name != "" {
-		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
-	}
-	if c.IAMConfig.InstanceProfile.Arn != "" && len(c.IAMConfig.Role.ManagedPolicies) > 0 {
-		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
-	}
 	if err := c.IAMConfig.Validate(); err != nil {
 		return err
 	}

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -8,15 +8,16 @@ import (
 
 type Etcd struct {
 	Cluster            EtcdCluster          `yaml:",inline"`
+	CustomFiles        []CustomFile         `yaml:"customFiles,omitempty"`
+	CustomSystemdUnits []CustomSystemdUnit  `yaml:"customSystemdUnits,omitempty"`
 	DataVolume         DataVolume           `yaml:"dataVolume,omitempty"`
 	DisasterRecovery   EtcdDisasterRecovery `yaml:"disasterRecovery,omitempty"`
-	Snapshot           EtcdSnapshot         `yaml:"snapshot,omitempty"`
 	EC2Instance        `yaml:",inline"`
-	Nodes              []EtcdNode          `yaml:"nodes,omitempty"`
-	SecurityGroupIds   []string            `yaml:"securityGroupIds"`
-	Subnets            []Subnet            `yaml:"subnets,omitempty"`
-	CustomFiles        []CustomFile        `yaml:"customFiles,omitempty"`
-	CustomSystemdUnits []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
+	IAMConfig          IAMConfig    `yaml:"iam,omitempty"`
+	Nodes              []EtcdNode   `yaml:"nodes,omitempty"`
+	SecurityGroupIds   []string     `yaml:"securityGroupIds"`
+	Snapshot           EtcdSnapshot `yaml:"snapshot,omitempty"`
+	Subnets            []Subnet     `yaml:"subnets,omitempty"`
 	UnknownKeys        `yaml:",inline"`
 }
 

--- a/model/iamconfig.go
+++ b/model/iamconfig.go
@@ -13,16 +13,17 @@ type IAMConfig struct {
 }
 
 type IAMRole struct {
+	ARN             `yaml:",inline"`
 	Name            string             `yaml:"name,omitempty"`
 	ManagedPolicies []IAMManagedPolicy `yaml:"managedPolicies,omitempty"`
 }
 
 type IAMManagedPolicy struct {
-	Arn string `yaml:"arn,omitempty"`
+	ARN `yaml:",inline"`
 }
 
 type IAMInstanceProfile struct {
-	Arn string `yaml:"arn,omitempty"`
+	ARN `yaml:",inline"`
 }
 
 func (c IAMConfig) Validate() error {

--- a/model/iamconfig.go
+++ b/model/iamconfig.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 )
@@ -25,6 +26,12 @@ type IAMInstanceProfile struct {
 }
 
 func (c IAMConfig) Validate() error {
+	if c.InstanceProfile.Arn != "" && c.Role.Name != "" {
+		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
+	}
+	if c.InstanceProfile.Arn != "" && len(c.Role.ManagedPolicies) > 0 {
+		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
+	}
 
 	managedPolicyRegexp := regexp.MustCompile(`arn:aws:iam::((\d{12})|aws):policy/([a-zA-Z0-9-=,\\.@_]{1,128})`)
 	instanceProfileRegexp := regexp.MustCompile(`arn:aws:iam::(\d{12}):instance-profile/([a-zA-Z0-9-=,\\.@_]{1,128})`)

--- a/model/identifier.go
+++ b/model/identifier.go
@@ -20,7 +20,7 @@ func (i Identifier) Validate() error {
 	if i.IDFromFn != "" {
 		var jsonHolder map[string]interface{}
 		if err := json.Unmarshal([]byte(i.IDFromFn), &jsonHolder); err != nil {
-			return fmt.Errorf("idFromRef must be a valid json expression but was not: %s", i.IDFromFn)
+			return fmt.Errorf("idFromFn must be a valid json expression but was not: %s", i.IDFromFn)
 		}
 	}
 	return nil

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -101,12 +100,6 @@ func (c NodePoolConfig) Valid() error {
 		fmt.Println(`WARNING: instance types "t2.nano" and "t2.micro" are not recommended. See https://github.com/kubernetes-incubator/kube-aws/issues/258 for more information`)
 	}
 
-	if c.IAMConfig.InstanceProfile.Arn != "" && c.IAMConfig.Role.Name != "" {
-		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
-	}
-	if c.IAMConfig.InstanceProfile.Arn != "" && len(c.IAMConfig.Role.ManagedPolicies) > 0 {
-		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
-	}
 	if err := c.IAMConfig.Validate(); err != nil {
 		return err
 	}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -4248,7 +4248,28 @@ worker:
 			expectedErrorMessage: "IAM role name(=kubeaws-it-main-Pool1-PRK1CVQNY7XZ-ap-northeast-1-foobarbazbaraaa) will be 65 characters long. It exceeds the AWS limit of 64 characters: cluster name(=kubeaws-it-main) + nested stack name(=Pool1) + managed iam role name(=foobarbazbaraaa) should be less than or equal to 34",
 		},
 		{
-			context: "WithInvalidInstanceProfileArn",
+			context: "WithInvalidEtcdInstanceProfileArn",
+			configYaml: minimalValidConfigYaml + `
+etcd:
+  iam:
+    instanceProfile:
+      arn: "badArn"
+`,
+			expectedErrorMessage: "invalid etcd settings: invalid instance profile, your instance profile must match (=arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME), provided (badArn)",
+		},
+		{
+			context: "WithInvalidEtcdManagedPolicyArn",
+			configYaml: minimalValidConfigYaml + `
+etcd:
+  iam:
+    role:
+      managedPolicies:
+      - arn: "badArn"
+`,
+			expectedErrorMessage: "invalid etcd settings: invalid managed policy arn, your managed policy must match this (=arn:aws:iam::(YOURACCOUNTID|aws):policy/POLICYNAME), provided this (badArn)",
+		},
+		{
+			context: "WithInvalidWorkerInstanceProfileArn",
 			configYaml: minimalValidConfigYaml + `
 worker:
   nodePools:
@@ -4260,7 +4281,7 @@ worker:
 			expectedErrorMessage: "invalid instance profile, your instance profile must match (=arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME), provided (badArn)",
 		},
 		{
-			context: "WithInvalidManagedPolicyArn",
+			context: "WithInvalidWorkerManagedPolicyArn",
 			configYaml: minimalValidConfigYaml + `
 worker:
   nodePools:


### PR DESCRIPTION
* Add `etcd.iam.role.managedPolicies[].arn` for specifying additional managed policies associated to the kube-aws managed etcd IAM role
* Add `etcd.iam.instanceProfile.arn` for specifying an existing IAM instance profile used instead of kube-aws managed one. In other words, when it is specified, kube-aws doesn't create an instance profile for you
* Unlike `controller.iam` and `worker.iam`, `etcd.iam.role.name` isn't supported yet. The reason is that I'm still unsure what is the exact use-case for it

This is tested manually by running E2E WITHOUT custom IAM config. Testing with custom IAM configs is delegated to whom requested this feature due to that I'm short on time to set up an instance profile used for testing.

Resolves #747 