### PR TITLE
Fix --ami-id

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -9,8 +9,11 @@ clusterName: {{.ClusterName}}
 
 # The AMI ID of CoreOS.
 # If omitted, the latest AMI for the releaseChannel is used.
+{{if .AmiId -}}
+amiId: "{{.AmiId}}"
+{{else -}}
 #amiId: ""
-
+{{- end}}
 # The ID of hosted zone to add the externalDNSName to.
 # Either specify hostedZoneId or hostedZone, but not both
 #hostedZoneId: ""

--- a/e2e/run
+++ b/e2e/run
@@ -136,6 +136,7 @@ configure() {
 }
 
 kube-aws() {
+  mkdir -p ${WORK_DIR}
   cd ${WORK_DIR}
   ${KUBE_AWS_CMD} "$@"
 }


### PR DESCRIPTION
Values passed via the flag had been completely ignored, surprisingly.
Resolves #764