### PR TITLE
WIP: An attempt to refactor UserData assets management

### DIFF
--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -239,8 +239,9 @@ func (c clusterImpl) Assets() (cfnstack.Assets, error) {
 		c.controlPlane.ClusterName,
 	)
 
-	assetsBuilder := cfnstack.NewAssetsBuilder(c.stackName(), s3URI, c.controlPlane.Region)
-	assetsBuilder.Add(REMOTE_STACK_TEMPLATE_FILENAME, stackTemplate)
+	assetFactory := cfnstack.NewAssetFactory(c.stackName(), s3URI, c.controlPlane.Region)
+	assetsBuilder := cfnstack.NewAssetsBuilder(assetFactory)
+	assetsBuilder.AddNew(REMOTE_STACK_TEMPLATE_FILENAME, stackTemplate)
 	assets := assetsBuilder.Build()
 
 	cpAssets := c.controlPlane.Assets()

--- a/model/assets.go
+++ b/model/assets.go
@@ -24,6 +24,10 @@ type AssetLocation struct {
 	Region Region
 }
 
+type AssetFactory interface {
+	Create(filename string, content string) (Asset, error)
+}
+
 func NewAssetID(stack string, file string) AssetID {
 	return AssetID{
 		StackName: stack,

--- a/model/userdata.go
+++ b/model/userdata.go
@@ -3,17 +3,20 @@ package model
 import (
 	"github.com/coreos/coreos-cloudinit/config/validate"
 	"github.com/kubernetes-incubator/kube-aws/filereader/texttemplate"
+	"github.com/kubernetes-incubator/kube-aws/fingerprint"
 	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
 
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"path"
 	"strings"
 	"text/template"
 )
 
 // UserDataValidateFunc returns error if templated Part content doesn't pass validation
 type UserDataValidateFunc func(content []byte) error
+type UserDataTemplateExtraParams map[string]interface{}
 
 const (
 	USERDATA_S3       = "s3"
@@ -22,14 +25,13 @@ const (
 
 // UserData represents userdata which might be split across multiple storage types
 type UserData struct {
-	Parts map[string]*UserDataPart
+	Parts            map[string]*UserDataPart
+	templateFilePath string
 }
 
 type UserDataPart struct {
-	Asset    Asset
-	tmpl     *template.Template
-	tmplData interface{}
-	validate UserDataValidateFunc
+	Asset   Asset
+	Content string
 }
 
 type PartDesc struct {
@@ -41,23 +43,44 @@ var (
 	defaultParts = []PartDesc{{USERDATA_INSTANCE, validateNone}, {USERDATA_S3, validateCoreosCloudInit}}
 )
 
-type userDataOpt struct {
+type UserDataOpt struct {
+	Extra UserDataTemplateExtraParams
 	Parts []PartDesc // userdata Parts in template file
 }
 
-type UserDataOption func(*userDataOpt)
+type UserDataOption func(*UserDataOpt)
 
 // Parts to find in UserData template file
 func UserDataPartsOpt(Parts ...PartDesc) UserDataOption {
-	return func(o *userDataOpt) {
+	return func(o *UserDataOpt) {
 		o.Parts = Parts
 	}
 }
 
+func UserDataPartFromTemplate(name string, tmpl *template.Template, tmplData interface{}, validate UserDataValidateFunc, assetFactory AssetFactory, extra ...UserDataTemplateExtraParams) (*UserDataPart, error) {
+	content, err := renderUserdataFromTemplate(tmpl, tmplData, validate, extra...)
+	if err != nil {
+		return nil, err
+	}
+	nameWithHash := fmt.Sprintf("%s-%s", name, fingerprint.SHA256(content))
+	asset, err := assetFactory.Create(nameWithHash, content)
+	if err != nil {
+		return nil, err
+	}
+	p := &UserDataPart{
+		Content: content,
+		Asset:   asset,
+	}
+	return p, nil
+}
+
 // NewUserData creates userdata struct from template file.
 // Template file is expected to have defined subtemplates (Parts) which are of various part and storage types
-func NewUserData(templateFile string, context interface{}, opts ...UserDataOption) (UserData, error) {
-	v := UserData{make(map[string]*UserDataPart)}
+func NewUserDataFromTemplateFile(path string, context interface{}, assetFactory AssetFactory, opts ...UserDataOption) (UserData, error) {
+	v := UserData{
+		Parts:            make(map[string]*UserDataPart),
+		templateFilePath: path,
+	}
 
 	funcs := template.FuncMap{
 		"self": func() UserData { return v },
@@ -65,12 +88,12 @@ func NewUserData(templateFile string, context interface{}, opts ...UserDataOptio
 		"extra": func() (r string) { panic("[bug] Stub 'extra' was not replaced") },
 	}
 
-	tmpl, err := texttemplate.Parse(templateFile, funcs)
+	tmpl, err := texttemplate.Parse(path, funcs)
 	if err != nil {
 		return UserData{}, err
 	}
 
-	var o userDataOpt
+	var o UserDataOpt
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -83,25 +106,40 @@ func NewUserData(templateFile string, context interface{}, opts ...UserDataOptio
 		if p.validateFunc == nil {
 			return UserData{}, fmt.Errorf("ValidateFunc must not be nil. Use 'validateNone' if you don't require part validation")
 		}
+		// The template file `tmpl` is composed of multiple sub-templates.
+		// Each sub-template `t` is for a single `part` in the userdata
 		t := tmpl.Lookup(p.templateName)
 		if t == nil {
-			return UserData{}, fmt.Errorf("Can't find requested template %s in %s", p.templateName, templateFile)
+			return UserData{}, fmt.Errorf("Can't find requested template %s in %s", p.templateName, path)
 		}
 
-		v.Parts[p.templateName] = &UserDataPart{
-			tmpl:     t,
-			tmplData: context,
-			validate: p.validateFunc,
+		part, err := UserDataPartFromTemplate(p.templateName, t, context, p.validateFunc, assetFactory, o.Extra)
+		if err != nil {
+			return UserData{}, err
 		}
+		v.Parts[p.templateName] = part
 	}
 	return v, nil
 }
 
-func (self UserDataPart) Base64(compress bool, extra ...map[string]interface{}) (string, error) {
-	content, err := self.Template(extra...)
-	if err != nil {
-		return "", err
-	}
+func (self *UserData) templateFileBaseName() string {
+	return path.Base(self.templateFilePath)
+}
+
+func (self *UserData) s3Part() *UserDataPart {
+	return self.Parts[USERDATA_S3]
+}
+
+func (self *UserData) S3PartAsset() Asset {
+	return self.s3Part().Asset
+}
+
+func (self *UserData) S3PartContent() string {
+	return self.s3Part().Content
+}
+
+func (self UserDataPart) Base64(compress bool) (string, error) {
+	content := self.Content
 	if compress {
 		return gzipcompressor.CompressString(content)
 	} else {
@@ -109,7 +147,7 @@ func (self UserDataPart) Base64(compress bool, extra ...map[string]interface{}) 
 	}
 }
 
-func (self UserDataPart) Template(extra ...map[string]interface{}) (string, error) {
+func renderUserdataFromTemplate(tmpl *template.Template, tmplData interface{}, validate UserDataValidateFunc, extra ...UserDataTemplateExtraParams) (string, error) {
 	buf := bytes.Buffer{}
 	funcs := template.FuncMap{}
 	switch len(extra) {
@@ -120,13 +158,13 @@ func (self UserDataPart) Template(extra ...map[string]interface{}) (string, erro
 		return "", fmt.Errorf("Provide single extra context")
 	}
 
-	if err := self.tmpl.Funcs(funcs).Execute(&buf, self.tmplData); err != nil {
+	if err := tmpl.Funcs(funcs).Execute(&buf, tmplData); err != nil {
 		return "", err
 	}
 
 	// we validate userdata at render time, because we need to wait for
 	// optional extra context to produce final output
-	return buf.String(), self.validate(buf.Bytes())
+	return buf.String(), validate(buf.Bytes())
 }
 
 func validateCoreosCloudInit(content []byte) error {


### PR DESCRIPTION
I went for a ramble in the codebase and came up with a possible improvement like this for less coupling between the `cfnstack/assets` package and the `model` package, less fields in `UserDataPart`, etc.

The major difficulty preventing this work from being finished is that:

```
"UserData": {{ $.UserDataEtcd.Parts.instance.Base64 true (dict "etcdIndex" $etcdIndex) |
```

in the stack template doesn't work anymore due to that I changed UserDataPart to render the template on its creation hence the `Base64` func to not take the second argument.

Anyway, I'm submitting this so that anyone who is interested hopefully comes and leaves comments 😉 