### PR TITLE
Rescheduler logs now piped to docker

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -132,7 +132,7 @@ func NewDefaultCluster() *Cluster {
 			ClusterProportionalAutoscalerImage: model.Image{Repo: "gcr.io/google_containers/cluster-proportional-autoscaler-amd64", Tag: "1.1.2", RktPullDocker: false},
 			KubeDnsImage:                       model.Image{Repo: "gcr.io/google_containers/k8s-dns-kube-dns-amd64", Tag: "1.14.4", RktPullDocker: false},
 			KubeDnsMasqImage:                   model.Image{Repo: "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64", Tag: "1.14.4", RktPullDocker: false},
-			KubeReschedulerImage:               model.Image{Repo: "gcr.io/google-containers/rescheduler", Tag: "v0.3.0", RktPullDocker: false},
+			KubeReschedulerImage:               model.Image{Repo: "gcr.io/google-containers/rescheduler", Tag: "v0.3.1", RktPullDocker: false},
 			DnsMasqMetricsImage:                model.Image{Repo: "gcr.io/google_containers/k8s-dns-sidecar-amd64", Tag: "1.14.4", RktPullDocker: false},
 			ExecHealthzImage:                   model.Image{Repo: "gcr.io/google_containers/exechealthz-amd64", Tag: "1.2", RktPullDocker: false},
 			HeapsterImage:                      model.Image{Repo: "gcr.io/google_containers/heapster", Tag: "v1.4.0", RktPullDocker: false},

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -971,7 +971,7 @@ worker:
 # kube rescheduler image repository to use.
 #kubeReschedulerImage:
 #  repo: gcr.io/google-containers/rescheduler
-#  tag: v0.3.0
+#  tag: v0.3.1
 #  rktPullDocker: false
 
 # DNS Masq metrics image repository to use.


### PR DESCRIPTION
Rather than being stored inside the container instance. For https://github.com/kubernetes-incubator/kube-aws/issues/118.

v0.3.1 has the fix for https://github.com/kubernetes/contrib/issues/2518.

I've deployed this on a dev cluster and I can see rescheduler logs in the cluster logs again.