### PR TITLE
Additional permissions for heapster nanny

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -674,9 +674,10 @@ write_files:
       # Configmaps
       kubectl apply -f "${mfdir}/kube-dns-cm.yaml"
 
-      # Serviceaccounts
-      kubectl apply -f "${mfdir}/kube-dns-sa.yaml"
-      kubectl apply -f "${mfdir}/heapster-sa.yaml"
+      # Service Accounts
+      for manifest in {kube-dns,heapster}; do
+          kubectl apply -f "${mfdir}/$manifest-sa.yaml"
+      done
 
       # Install tiller by default
       kubectl apply -f "${mfdir}/tiller.yaml"
@@ -687,8 +688,8 @@ write_files:
       done
 
       # Services
-      for manifest in {kube-dns,heapster,kube-dashboard}-svc.yaml; do
-          kubectl apply -f "${mfdir}/$manifest"
+      for manifest in {kube-dns,heapster,kube-dashboard}; do
+          kubectl apply -f "${mfdir}/$manifest-svc.yaml"
       done
 
       {{- if .Addons.Rescheduler.Enabled }}
@@ -1492,6 +1493,7 @@ write_files:
         - kind: ServiceAccount
           name: heapster
           namespace: kube-system
+
   # Heapster's pod_nanny monitors the heapster deployment & its pod(s), and scales
   # the resources of the deployment if necessary.
   - path: /srv/kubernetes/rbac/roles/pod-nanny.yaml
@@ -1518,6 +1520,7 @@ write_files:
           verbs:
           - get
           - update
+
   # Allow heapster nanny access to the pod nanny role via its service account (same pod as heapster)
   - path: /srv/kubernetes/rbac/role-bindings/heapster-nanny.yaml
     content: |

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -682,15 +682,12 @@ write_files:
       kubectl apply -f "${mfdir}/tiller.yaml"
 
       # Deployments
-      for manifest in {kube-dns-de,kube-dns-autoscaler-de,{{ if .Addons.ClusterAutoscaler.Enabled }}cluster-autoscaler-de,{{ end }}heapster-de{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}.yaml; do
-          kubectl apply -f "${mfdir}/$manifest"
+      for manifest in {kube-dns-de,kube-dns-autoscaler-de,kube-dashboard-de,{{ if .Addons.ClusterAutoscaler.Enabled }}cluster-autoscaler-de,{{ end }}heapster-de{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}; do
+          kubectl apply -f "${mfdir}/$manifest.yaml"
       done
 
-      # Replicationcontrollers
-      kubectl apply -f "${mfdir}/kube-dashboard-de.yaml"
-
       # Services
-      for manifest in {kube-dns,heapster,kube-dashboard}-svc.yaml;do
+      for manifest in {kube-dns,heapster,kube-dashboard}-svc.yaml; do
           kubectl apply -f "${mfdir}/$manifest"
       done
 
@@ -701,10 +698,20 @@ write_files:
       {{if .Experimental.Plugins.Rbac.Enabled}}
       mfdir=/srv/kubernetes/rbac
 
-      kubectl apply -f "${mfdir}/cluster-roles/node-extensions.yaml"
-
+      # Cluster roles and bindings
+      for manifest in {node-extensions,}; do
+          kubectl apply -f "${mfdir}/cluster-roles/$manifest.yaml"
+      done
       for manifest in {kube-admin,system-worker,node,node-proxier,node-extensions,heapster}; do
           kubectl apply -f "${mfdir}/cluster-role-bindings/$manifest.yaml"
+      done
+
+      # Roles and bindings
+      for manifest in {pod-nanny,}; do
+          kubectl apply -f "${mfdir}/roles/$manifest.yaml"
+      done
+      for manifest in {heapster-nanny,}; do
+          kubectl apply -f "${mfdir}/role-bindings/$manifest.yaml"
       done
 
       {{ if .Experimental.TLSBootstrap.Enabled }}
@@ -1485,6 +1492,51 @@ write_files:
         - kind: ServiceAccount
           name: heapster
           namespace: kube-system
+  # Heapster's pod_nanny monitors the heapster deployment & its pod(s), and scales
+  # the resources of the deployment if necessary.
+  - path: /srv/kubernetes/rbac/roles/pod-nanny.yaml
+    content: |
+        apiVersion: rbac.authorization.k8s.io/v1beta1
+        kind: Role
+        metadata:
+          name: system:pod-nanny
+          namespace: kube-system
+          labels:
+            kubernetes.io/cluster-service: "true"
+            addonmanager.kubernetes.io/mode: Reconcile
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - "extensions"
+          resources:
+          - deployments
+          verbs:
+          - get
+          - update
+  # Allow heapster nanny access to the pod nanny role via its service account (same pod as heapster)
+  - path: /srv/kubernetes/rbac/role-bindings/heapster-nanny.yaml
+    content: |
+        kind: RoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1beta1
+        metadata:
+          name: heapster-nanny
+          namespace: kube-system
+          labels:
+            kubernetes.io/cluster-service: "true"
+            addonmanager.kubernetes.io/mode: Reconcile
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: Role
+          name: system:pod-nanny
+        subjects:
+        - kind: ServiceAccount
+          name: heapster
+          namespace: kube-system
 
 {{ if .Experimental.TLSBootstrap.Enabled }}
   # A ClusterRole which instructs the CSR approver to approve a user requesting
@@ -2097,7 +2149,7 @@ write_files:
         apiVersion: extensions/v1beta1
         kind: Deployment
         metadata:
-          name: heapster-v1.4.0
+          name: heapster
           namespace: kube-system
           labels:
             k8s-app: heapster
@@ -2165,7 +2217,7 @@ write_files:
                     - --extra-cpu=4m
                     - --memory=200Mi
                     - --extra-memory=4Mi
-                    - --deployment=heapster-v1.4.0
+                    - --deployment=heapster
                     - --container=heapster
                     - --poll-period=300000
 

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -683,8 +683,8 @@ write_files:
       kubectl apply -f "${mfdir}/tiller.yaml"
 
       # Deployments
-      for manifest in {kube-dns-de,kube-dns-autoscaler-de,kube-dashboard-de,{{ if .Addons.ClusterAutoscaler.Enabled }}cluster-autoscaler-de,{{ end }}heapster-de{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}; do
-          kubectl apply -f "${mfdir}/$manifest.yaml"
+      for manifest in {kube-dns,kube-dns-autoscaler,kube-dashboard,{{ if .Addons.ClusterAutoscaler.Enabled }}cluster-autoscaler,{{ end }}heapster{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}; do
+          kubectl apply -f "${mfdir}/$manifest-de.yaml"
       done
 
       # Services
@@ -980,7 +980,7 @@ write_files:
 
 {{ end }}
 {{ if .KubeResourcesAutosave.Enabled }}
-  - path: /srv/kubernetes/manifests/kube-resources-autosave.yaml
+  - path: /srv/kubernetes/manifests/kube-resources-autosave-de.yaml
     content: |
       ---
       apiVersion: extensions/v1beta1


### PR DESCRIPTION
For https://github.com/kubernetes-incubator/kube-aws/issues/685.

Permission set taken from upstream
https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/cluster-monitoring/heapster-rbac.yaml

Remove a few inconsistencies in kube setup such as heapster version in
the name and dashboard not being a replication controller any more.