### PR TITLE
Ability to propagate custom options to kubelet

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -73,6 +73,7 @@ func NewDefaultCluster() *Cluster {
 		Kube2IamSupport: Kube2IamSupport{
 			Enabled: false,
 		},
+		KubeletOpts: "",
 		LoadBalancer: LoadBalancer{
 			Enabled: false,
 		},
@@ -513,6 +514,7 @@ type Experimental struct {
 	TLSBootstrap                TLSBootstrap                   `yaml:"tlsBootstrap"`
 	EphemeralImageStorage       EphemeralImageStorage          `yaml:"ephemeralImageStorage"`
 	Kube2IamSupport             Kube2IamSupport                `yaml:"kube2IamSupport,omitempty"`
+	KubeletOpts                 string                         `yaml:"kubeletOpts,omitempty"`
 	LoadBalancer                LoadBalancer                   `yaml:"loadBalancer"`
 	TargetGroup                 TargetGroup                    `yaml:"targetGroup"`
 	NodeDrainer                 model.NodeDrainer              `yaml:"nodeDrainer"`

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -242,7 +242,8 @@ coreos:
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster-dns={{.DNSServiceIP}} \
         --cluster-domain=cluster.local \
-        --cloud-provider=aws
+        --cloud-provider=aws \
+        $KUBELET_OPTS
         Restart=always
         RestartSec=10
 
@@ -586,6 +587,12 @@ write_files:
           '
 
       rkt rm --uuid-file=/var/run/coreos/cfn-etcd-environment.uuid || :
+
+  - path: /etc/default/kubelet
+    permissions: 0755
+    owner: root:root
+    content: |
+      KUBELET_OPTS="{{.Experimental.KubeletOpts}}"
 
   - path: /opt/bin/install-kube-system
     permissions: 0700

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -622,7 +622,7 @@ write_files:
     permissions: 0755
     owner: root:root
     content: |
-      KUBELET_OPTS=""
+      KUBELET_OPTS="{{.Experimental.KubeletOpts}}"
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -468,6 +468,12 @@ worker:
 #      kube2IamSupport:
 #        enabled: true
 #
+#      # Propagate custom CLI options to kubelet
+#      # Provided example enables docker image garbage collection as in https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/
+#      # Anything from https://kubernetes.io/docs/admin/kubelet/ can be used as a value
+#
+#      kubeletOpts: --image-gc-low-threshold=50 --image-gc-high-threshold=65
+#
 #      # Kubernetes node labels to be added to worker nodes
 #      nodeLabels:
 #        kube-aws.coreos.com/role: worker

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -469,7 +469,8 @@ worker:
 #        enabled: true
 #
 #      # Propagate custom CLI options to kubelet
-#      # Provided example enables docker image garbage collection as in https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/
+#      # Provided example overrides default docker image garbage collection limits
+#      # as in https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/
 #      # Anything from https://kubernetes.io/docs/admin/kubelet/ can be used as a value
 #
 #      kubeletOpts: --image-gc-low-threshold=50 --image-gc-high-threshold=65

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1154,6 +1154,7 @@ experimental:
     enabled: true
   kube2IamSupport:
     enabled: true
+  kubeletOpts: '--image-gc-low-threshold 60 --image-gc-high-threshold 70'
   loadBalancer:
     enabled: true
     names:
@@ -1252,6 +1253,7 @@ worker:
 						Kube2IamSupport: controlplane_config.Kube2IamSupport{
 							Enabled: true,
 						},
+						KubeletOpts: "--image-gc-low-threshold 60 --image-gc-high-threshold 70",
 						LoadBalancer: controlplane_config.LoadBalancer{
 							Enabled:          true,
 							Names:            []string{"manuallymanagedlb"},


### PR DESCRIPTION
Main motivation for us is to utilize
https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/

Anything from https://kubernetes.io/docs/admin/kubelet/
can be potentially used as a value