### PR TITLE
Refactor node drainer implementation

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -666,7 +666,9 @@ write_files:
       {{ end }}
 
       {{ if .Experimental.NodeDrainer.Enabled }}
-      kubectl apply -f "${mfdir}/kube-node-drainer-ds.yaml"
+      for manifest in {kube-node-drainer-ds,kube-node-drainer-asg-status-updater-de}; do
+          kubectl apply -f "${mfdir}/$manifest.yaml"
+      done
       {{ end }}
 
       # Configmaps
@@ -1129,22 +1131,99 @@ write_files:
 {{ end }}
 
 {{if .Experimental.NodeDrainer.Enabled}}
+  - path: /srv/kubernetes/manifests/kube-node-drainer-asg-status-updater-de.yaml
+    content: |
+        kind: Deployment
+        apiVersion: extensions/v1beta1
+        metadata:
+          name: kube-node-drainer-asg-status-updater
+          namespace: kube-system
+          labels:
+            k8s-app: kube-node-drainer-asg-status-updater
+        spec:
+          replicas: 1
+          template:
+            metadata:
+              labels:
+                k8s-app: kube-node-drainer-asg-status-updater
+              annotations:
+                scheduler.alpha.kubernetes.io/critical-pod: ''
+            spec:
+              initContainers:
+                - name: hyperkube
+                  image: {{.HyperkubeImage.RepoWithTag}}
+                  command:
+                  - /bin/cp
+                  - -f
+                  - /hyperkube
+                  - /workdir/hyperkube
+                  volumeMounts:
+                  - mountPath: /workdir
+                    name: workdir
+              containers:
+                - name: main
+                  image: {{.AWSCliImage.RepoWithTag}}
+                  env:
+                  - name: NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  command:
+                  - /bin/sh
+                  - -xec
+                  - |
+                    metadata() { wget -O - -q http://169.254.169.254/2016-09-02/"$1"; }
+                    asg()      { aws --region="${REGION}" autoscaling "$@"; }
+
+                    # Hyperkube binary is not statically linked, so we need to use
+                    # the musl interpreter to be able to run it in this image
+                    # See: https://github.com/kubernetes-incubator/kube-aws/pull/674#discussion_r118889687
+                    kubectl() { /lib/ld-musl-x86_64.so.1 /opt/bin/hyperkube kubectl "$@"; }
+
+                    REGION=$(metadata dynamic/instance-identity/document | jq -r .region)
+                    [ -n "${REGION}" ]
+
+                    # Not customizable, for now
+                    POLL_INTERVAL=30
+
+                    # Instance termination detection loop
+                    while sleep ${POLL_INTERVAL}; do
+
+                      # Fetch the list of instances being terminated by their respective ASGs
+                      instances_to_drain=$(asg describe-auto-scaling-groups | jq -r '.AutoScalingGroups[] | select(.Tags[].Key | contains("kube-aws")) | .Instances[] | select(.LifecycleState == "Terminating:Wait") | .InstanceId')
+
+                      # Mark each node with an annotation that's picked up by the node draining pod
+                      for instance in $instances_to_drain; do
+                        node=$(kubectl get nodes -o json | jq --arg instance "${instance}" -r '.items[] | select(.spec.externalID == $instance) | .metadata.name')
+
+                        if [ -n "${node}" ]; then
+                          kubectl annotate --overwrite node "${node}" kube-aws.coreos.com/node-termination-source=asg
+                        fi
+                      done
+                    done
+                  volumeMounts:
+                  - mountPath: /opt/bin
+                    name: workdir
+              volumes:
+                - name: workdir
+                  emptyDir: {}
+
   - path: /srv/kubernetes/manifests/kube-node-drainer-ds.yaml
     content: |
         kind: DaemonSet
         apiVersion: extensions/v1beta1
         metadata:
-          name: kube-node-drainer-sg-ds
+          name: kube-node-drainer-ds
           namespace: kube-system
           labels:
-            k8s-app: kube-node-drainer-sg-ds
+            k8s-app: kube-node-drainer-ds
         spec:
           updateStrategy:
             type: RollingUpdate
           template:
             metadata:
               labels:
-                k8s-app: kube-node-drainer-sg-ds
+                k8s-app: kube-node-drainer-ds
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
@@ -1190,19 +1269,14 @@ write_files:
                     REGION=$(metadata dynamic/instance-identity/document | jq -r .region)
                     [ -n "${REGION}" ]
 
-                    # Not customizable (for now)
-                    SPOT_POLL_INTERVAL=5
-                    SG_POLL_INTERVAL=30
+                    # Not customizable, for now
+                    POLL_INTERVAL=10
 
-                    # Used to control when to execute each termination check
-                    secs=0
-
-                    # Used to identify which was the source that requested the instance termination ('spot' or 'asg', for now)
+                    # Used to identify the source which requested the instance termination
                     termination_source=''
 
                     # Instance termination detection loop
-                    while sleep ${SPOT_POLL_INTERVAL}; do
-                      secs=$((secs + SPOT_POLL_INTERVAL))
+                    while sleep ${POLL_INTERVAL}; do
 
                       # Spot instance termination check
                       http_status=$(curl -o /dev/null -w '%{http_code}' -sL http://169.254.169.254/latest/meta-data/spot/termination-time)
@@ -1211,16 +1285,10 @@ write_files:
                         break
                       fi
 
-                      if [ $((secs % SG_POLL_INTERVAL)) -eq 0 ]; then
-                        # Reset counter to avoid overflow
-                        secs=0
-
-                        # AutoScalingGroup lifecycle check
-                        state=$(asg describe-auto-scaling-instances --region "${REGION}" --instance-ids "${INSTANCE_ID}" | jq -r '.AutoScalingInstances[].LifecycleState')
-                        if [ "${state}" = Terminating:Wait ]; then
-                          termination_source=asg
-                          break
-                        fi
+                      # Termination annotation check
+                      termination_source=$(kubectl get nodes "${NODE_NAME}" -o json | jq -r '.metadata.annotations["kube-aws.coreos.com/node-termination-source"]')
+                      if [ "${termination_source}" == asg ]; then
+                        break
                       fi
                     done
 
@@ -1232,13 +1300,12 @@ write_files:
                         echo Not all pods on this host can be evicted, will try again
                         continue
                       fi
+                      echo All evictable pods are gone
 
                       if [ "${termination_source}" == asg ]; then
-                        echo All evictable pods are gone, notifying AutoScalingGroup that instance ${INSTANCE_ID} can be shutdown
+                        echo Notifying AutoScalingGroup that instance ${INSTANCE_ID} can be shutdown
                         ASG_NAME=$(asg describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}" | jq -r '.AutoScalingInstances[].AutoScalingGroupName')
                         HOOK_NAME=$(asg describe-lifecycle-hooks --auto-scaling-group-name "${ASG_NAME}" | jq -r '.LifecycleHooks[].LifecycleHookName' | grep -i nodedrainer)
-
-                        echo Sending notification to ASG_NAME=${ASG_NAME} HOOK_NAME=${HOOK_NAME}
                         asg complete-lifecycle-action --lifecycle-action-result CONTINUE --instance-id "${INSTANCE_ID}" --lifecycle-hook-name "${HOOK_NAME}" --auto-scaling-group-name "${ASG_NAME}"
                       fi
 

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -666,7 +666,7 @@ write_files:
       {{ end }}
 
       {{ if .Experimental.NodeDrainer.Enabled }}
-      for manifest in {kube-node-drainer-ds,kube-node-drainer-asg-status-updater-de}; do
+      for manifest in {kube-node-drainer-status-cm,kube-node-drainer-ds,kube-node-drainer-asg-status-updater-de}; do
           kubectl apply -f "${mfdir}/$manifest.yaml"
       done
       {{ end }}
@@ -1131,6 +1131,15 @@ write_files:
 {{ end }}
 
 {{if .Experimental.NodeDrainer.Enabled}}
+  - path: /srv/kubernetes/manifests/kube-node-drainer-status-cm.yaml
+    content: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-node-drainer-status
+        namespace: kube-system
+      data: {}
+
   - path: /srv/kubernetes/manifests/kube-node-drainer-asg-status-updater-de.yaml
     content: |
         kind: Deployment
@@ -1192,12 +1201,13 @@ write_files:
                       # Fetch the list of instances being terminated by their respective ASGs
                       instances_to_drain=$(asg describe-auto-scaling-groups | jq -r '.AutoScalingGroups[] | select((.Tags[].Key | contains("kube-aws")) and (.Tags[].Key | contains("kubernetes.io/cluster/{{.ClusterName}}"))) | .Instances[] | select(.LifecycleState == "Terminating:Wait") | .InstanceId')
 
-                      # Mark each node with an annotation that's picked up by the node draining pod
+                      # Add nodes to be drained to the kube-node-drainer-status ConfigMap, which will be picked
+                      # up by the node drainer pod running in every node
+                      node_data=$(kubectl get nodes -o json)
                       for instance in $instances_to_drain; do
-                        node=$(kubectl get nodes -o json | jq --arg instance "${instance}" -r '.items[] | select(.spec.externalID == $instance) | .metadata.name')
-
+                        node=$(echo $node_data | jq --arg instance "${instance}" -r '.items[] | select(.spec.externalID == $instance) | .metadata.name')
                         if [ -n "${node}" ]; then
-                          kubectl annotate --overwrite node "${node}" kube-aws.coreos.com/node-termination-source=asg
+                          kubectl -n kube-system patch configmap kube-node-drainer-status -p "{\"data\": {\"${node}\": \"asg\"}}"
                         fi
                       done
                     done
@@ -1285,9 +1295,10 @@ write_files:
                         break
                       fi
 
-                      # Termination annotation check
-                      termination_source=$(kubectl get nodes "${NODE_NAME}" -o json | jq -r '.metadata.annotations["kube-aws.coreos.com/node-termination-source"]')
-                      if [ "${termination_source}" == asg ]; then
+                      # Termination ConfigMap check
+                      if [ -e "/etc/kube-node-drainer/${NODE_NAME}" ]; then
+                        termination_source=$(cat "/etc/kube-node-drainer/${NODE_NAME}")
+                        kubectl -n kube-system patch configmap kube-node-drainer-status --type=json -p '[{ "op": "remove", "path": "/data/${NODE_NAME}"}]'
                         break
                       fi
                     done
@@ -1315,9 +1326,17 @@ write_files:
                   volumeMounts:
                   - mountPath: /opt/bin
                     name: workdir
+                  - mountPath: /etc/kube-node-drainer
+                    name: kube-node-drainer-status
+                    readOnly: true
               volumes:
-                - name: workdir
-                  emptyDir: {}
+              - name: workdir
+                emptyDir: {}
+              - name: kube-node-drainer-status
+                projected:
+                  sources:
+                  - configMap:
+                      name: kube-node-drainer-status
 {{end}}
 
 {{if .Experimental.Plugins.Rbac.Enabled }}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1203,13 +1203,16 @@ write_files:
 
                       # Add nodes to be drained to the kube-node-drainer-status ConfigMap, which will be picked
                       # up by the node drainer pod running in every node
-                      node_data=$(kubectl get nodes -o json)
-                      for instance in $instances_to_drain; do
-                        node=$(echo $node_data | jq --arg instance "${instance}" -r '.items[] | select(.spec.externalID == $instance) | .metadata.name')
-                        if [ -n "${node}" ]; then
-                          kubectl -n kube-system patch configmap kube-node-drainer-status -p "{\"data\": {\"${node}\": \"asg\"}}"
-                        fi
-                      done
+                      if [ -n "${instances_to_drain}" ]; then
+                        node_data=$(kubectl get nodes -o json)
+
+                        for instance in $instances_to_drain; do
+                          node=$(echo $node_data | jq --arg instance "${instance}" -r '.items[] | select(.spec.externalID == $instance) | .metadata.name')
+                          if [ -n "${node}" ]; then
+                            kubectl -n kube-system patch configmap kube-node-drainer-status -p "{\"data\": {\"${node}\": \"asg\"}}"
+                          fi
+                        done
+                      fi
                     done
                   volumeMounts:
                   - mountPath: /opt/bin

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1190,7 +1190,7 @@ write_files:
                     while sleep ${POLL_INTERVAL}; do
 
                       # Fetch the list of instances being terminated by their respective ASGs
-                      instances_to_drain=$(asg describe-auto-scaling-groups | jq -r '.AutoScalingGroups[] | select(.Tags[].Key | contains("kube-aws")) | .Instances[] | select(.LifecycleState == "Terminating:Wait") | .InstanceId')
+                      instances_to_drain=$(asg describe-auto-scaling-groups | jq -r '.AutoScalingGroups[] | select((.Tags[].Key | contains("kube-aws")) and (.Tags[].Key | contains("kubernetes.io/cluster/{{.ClusterName}}"))) | .Instances[] | select(.LifecycleState == "Terminating:Wait") | .InstanceId')
 
                       # Mark each node with an annotation that's picked up by the node draining pod
                       for instance in $instances_to_drain; do

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -666,7 +666,7 @@ write_files:
       {{ end }}
 
       {{ if .Experimental.NodeDrainer.Enabled }}
-      for manifest in {kube-node-drainer-status-cm,kube-node-drainer-ds,kube-node-drainer-asg-status-updater-de}; do
+      for manifest in {kube-node-drainer-ds,kube-node-drainer-asg-status-updater-de}; do
           kubectl apply -f "${mfdir}/$manifest.yaml"
       done
       {{ end }}
@@ -1131,15 +1131,6 @@ write_files:
 {{ end }}
 
 {{if .Experimental.NodeDrainer.Enabled}}
-  - path: /srv/kubernetes/manifests/kube-node-drainer-status-cm.yaml
-    content: |
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: kube-node-drainer-status
-        namespace: kube-system
-      data: {}
-
   - path: /srv/kubernetes/manifests/kube-node-drainer-asg-status-updater-de.yaml
     content: |
         kind: Deployment
@@ -1193,26 +1184,26 @@ write_files:
                     [ -n "${REGION}" ]
 
                     # Not customizable, for now
-                    POLL_INTERVAL=30
+                    POLL_INTERVAL=10
+
+                    # Keeps a comma-separated list of instances that need to be drained. Sets '-'
+                    # to force the ConfigMap to be updated in the first iteration.
+                    instances_to_drain='-'
 
                     # Instance termination detection loop
                     while sleep ${POLL_INTERVAL}; do
 
                       # Fetch the list of instances being terminated by their respective ASGs
-                      instances_to_drain=$(asg describe-auto-scaling-groups | jq -r '.AutoScalingGroups[] | select((.Tags[].Key | contains("kube-aws")) and (.Tags[].Key | contains("kubernetes.io/cluster/{{.ClusterName}}"))) | .Instances[] | select(.LifecycleState == "Terminating:Wait") | .InstanceId')
+                      updated_instances_to_drain=$(asg describe-auto-scaling-groups | jq -r '[.AutoScalingGroups[] | select((.Tags[].Key | contains("kube-aws:")) and (.Tags[].Key | contains("kubernetes.io/cluster/{{.ClusterName}}"))) | .Instances[] | select(.LifecycleState == "Terminating:Wait") | .InstanceId] | sort | join(",")')
 
-                      # Add nodes to be drained to the kube-node-drainer-status ConfigMap, which will be picked
-                      # up by the node drainer pod running in every node
-                      if [ -n "${instances_to_drain}" ]; then
-                        node_data=$(kubectl get nodes -o json)
-
-                        for instance in $instances_to_drain; do
-                          node=$(echo $node_data | jq --arg instance "${instance}" -r '.items[] | select(.spec.externalID == $instance) | .metadata.name')
-                          if [ -n "${node}" ]; then
-                            kubectl -n kube-system patch configmap kube-node-drainer-status -p "{\"data\": {\"${node}\": \"asg\"}}"
-                          fi
-                        done
+                      # Have things changed since last iteration?
+                      if [ "${updated_instances_to_drain}" == "${instances_to_drain}" ]; then
+                        continue
                       fi
+                      instances_to_drain="${updated_instances_to_drain}"
+
+                      # Update ConfigMap to reflect current ASG state
+                      echo "{\"apiVersion\": \"v1\", \"kind\": \"ConfigMap\", \"metadata\": {\"name\": \"kube-node-drainer-status\"}, \"data\": {\"asg\": \"${instances_to_drain}\"}}" | kubectl -n kube-system apply -f -
                     done
                   volumeMounts:
                   - mountPath: /opt/bin
@@ -1299,9 +1290,8 @@ write_files:
                       fi
 
                       # Termination ConfigMap check
-                      if [ -e "/etc/kube-node-drainer/${NODE_NAME}" ]; then
-                        termination_source=$(cat "/etc/kube-node-drainer/${NODE_NAME}")
-                        kubectl -n kube-system patch configmap kube-node-drainer-status --type=json -p '[{ "op": "remove", "path": "/data/${NODE_NAME}"}]'
+                      if [ -e /etc/kube-node-drainer/asg ] && grep -q "${INSTANCE_ID}" /etc/kube-node-drainer/asg; then
+                        termination_source=asg
                         break
                       fi
                     done
@@ -1340,6 +1330,7 @@ write_files:
                   sources:
                   - configMap:
                       name: kube-node-drainer-status
+                      optional: true
 {{end}}
 
 {{if .Experimental.Plugins.Rbac.Enabled }}


### PR DESCRIPTION
This PR separates the node drainer into two components: the ASG watcher, and the node drainer itself.

The ASG watcher is the component (that runs as a Deployment) responsible for using the AWS AutoScaling API to check whether there are any instances waiting for termination; if anything is changed in the status of any ASG-controlled instances, the script updates the ASG status ConfigMap with the IDs of the instances being terminated. This ConfigMap is mounted in every node, and is used by the node drainer pods, which run as a DaemonSet.

The node drainer pods are responsible for checking whether the instance ID corresponding to the node they are running in are listed in the ASG status ConfigMap (it does that by mounting the ConfigMap as a volume in order to avoid hitting the API Server directly), and draining their own nodes if necessary.

This design allows us to significantly reduce both the API Server and the AutoScaling API usage -
 and reduce the risk of being throttled in the process - which is a good idea especially for large clusters.

Fixes: #782