### PR TITLE
Issue #796 - cluster.yaml missing dnsMasqMetricsImage.repo key

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -976,7 +976,7 @@ worker:
 
 # DNS Masq metrics image repository to use.
 #dnsMasqMetricsImage:
-#  gcr.io/google_containers/k8s-dns-sidecar-amd64
+#  repo: gcr.io/google_containers/k8s-dns-sidecar-amd64
 #  tag: 1.14.4
 #  rktPullDocker: false
 


### PR DESCRIPTION
core/controlplane/config/templates/cluster.yaml: dnsMasqMetricsImage.repo

The `repo:` key for `dnsMasqMetricsImage` was missing

Fixes #796 