### PR TITLE
CloudFormation events stream to stdout during kube-aws up/update

### DIFF
--- a/Documentation/kubernetes-on-aws-cloudformation-streaming.md
+++ b/Documentation/kubernetes-on-aws-cloudformation-streaming.md
@@ -1,0 +1,19 @@
+# CloudFormation Streaming
+
+CouldFormation stack events can be streamed to the console (stdout) during a `kube-aws up` or `kube-aws update` operation.
+The format of the messages are:
+```
+TimePassed   StackName   ResourceStatus    LogicalResourceId   StatusReason
+```
+For example:
+```
++00:02:45	Nodepoolb	CREATE_IN_PROGRESS      		WorkersLC             	"Resource creation Initiated"
++00:02:45	Nodepoolb	CREATE_COMPLETE         		WorkersLC
++00:02:48	Nodepoolb	CREATE_IN_PROGRESS      		Workers
+```
+
+This feature is enabled by default and configurable in cluster.yaml:
+
+```
+cloudFormationStreaming: true
+```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Check out our getting started tutorial on launching your first Kubernetes cluste
   * [Restore Kubernetes resources](/contrib/cluster-backup/README.md)
   * [Journald logging to AWS CloudWatch](/Documentation/kubernetes-on-aws-journald-cloudwatch-logs.md)
     * [kube-aws up/update feedback](/Documentation/kubernetes-on-aws-journald-cloudwatch-logs.md)
+  * [CloudFormation Streaming](/Documentation/kubernetes-on-aws-cloudformation-streaming.md)
 
 ## Examples
 

--- a/cfnstack/provisioner.go
+++ b/cfnstack/provisioner.go
@@ -248,7 +248,7 @@ func (c *Provisioner) StreamEventsNested(q chan struct{}, f *cloudformation.Clou
 				&cloudformation.DescribeStackEventsInput{StackName: &stackId},
 				func(page *cloudformation.DescribeStackEventsOutput, lastPage bool) bool {
 					for _, e := range page.StackEvents {
-						if (*e.Timestamp).Before(t) {
+						if (e.Timestamp).Before(t) {
 							return false
 						}
 						if *e.EventId == lastSeenEventId {

--- a/cfnstack/provisioner.go
+++ b/cfnstack/provisioner.go
@@ -232,7 +232,7 @@ func (c *Destroyer) Destroy() error {
 	return err
 }
 
-func (c *Provisioner) StreamCloudFormationNested(q chan struct{}, f *cloudformation.CloudFormation, stackId string, headStackName string, t time.Time) error {
+func (c *Provisioner) StreamEventsNested(q chan struct{}, f *cloudformation.CloudFormation, stackId string, headStackName string, t time.Time) error {
 	nestedStacks := make(map[string]bool)
 	nestedQuit := make(chan struct{}, 1)
 	var lastSeenEventId string
@@ -263,7 +263,7 @@ func (c *Provisioner) StreamCloudFormationNested(q chan struct{}, f *cloudformat
 				e := events[i]
 				if *e.ResourceType == "AWS::CloudFormation::Stack" && *e.PhysicalResourceId != *e.StackId && !nestedStacks[*e.PhysicalResourceId] {
 					nestedStacks[*e.PhysicalResourceId] = true
-					go c.StreamCloudFormationNested(nestedQuit, f, *e.PhysicalResourceId, headStackName, t)
+					go c.StreamEventsNested(nestedQuit, f, *e.PhysicalResourceId, headStackName, t)
 				}
 				eventPrettyPrint(e, headStackName, t)
 				lastSeenEventId = *e.EventId

--- a/cfnstack/provisioner.go
+++ b/cfnstack/provisioner.go
@@ -231,3 +231,67 @@ func (c *Destroyer) Destroy() error {
 	_, err := cfSvc.DeleteStack(dreq)
 	return err
 }
+
+func (c *Provisioner) StreamCloudFormationNested(q chan struct{}, f *cloudformation.CloudFormation, stackId string, headStackName string, t time.Time) error {
+	nestedStacks := make(map[string]bool)
+	nestedQuit := make(chan struct{}, 1)
+	var lastSeenEventId string
+	defer func() { nestedQuit <- struct{}{} }()
+	for {
+		select {
+		case <-q:
+			return nil
+		case <-time.After(1 * time.Second):
+			events := make([]cloudformation.StackEvent, 0)
+
+			_ = f.DescribeStackEventsPages(
+				&cloudformation.DescribeStackEventsInput{StackName: &stackId},
+				func(page *cloudformation.DescribeStackEventsOutput, lastPage bool) bool {
+					for _, e := range page.StackEvents {
+						if (*e.Timestamp).Before(t) {
+							return false
+						}
+						if *e.EventId == lastSeenEventId {
+							return false
+						}
+						events = append(events, *e)
+					}
+					return true
+				})
+
+			for i := len(events) - 1; i >= 0; i-- {
+				e := events[i]
+				if *e.ResourceType == "AWS::CloudFormation::Stack" && *e.PhysicalResourceId != *e.StackId && !nestedStacks[*e.PhysicalResourceId] {
+					nestedStacks[*e.PhysicalResourceId] = true
+					go c.StreamCloudFormationNested(nestedQuit, f, *e.PhysicalResourceId, headStackName, t)
+				}
+				eventPrettyPrint(e, headStackName, t)
+				lastSeenEventId = *e.EventId
+			}
+		}
+	}
+}
+
+func eventPrettyPrint(e cloudformation.StackEvent, n string, t time.Time) {
+	ns := strings.Split(strings.TrimLeft(*e.StackName, n), "-")
+	if len(ns) > 2 {
+		n = "\t" + ns[len(ns)-2]
+	} else {
+		n = ""
+	}
+
+	s := int((*e.Timestamp).Sub(t).Seconds())
+	d := fmt.Sprintf("+%.2d:%.2d:%.2d", s/3600, (s/60)%60, s%60)
+	if e.ResourceStatusReason != nil {
+		fmt.Printf("%s%s\t%s\t\t%s\t\"%s\"\n", d, n, resize(*e.ResourceStatus, 24), resize(*e.LogicalResourceId, 22), *e.ResourceStatusReason)
+	} else {
+		fmt.Printf("%s%s\t%s\t\t%s\n", d, n, resize(*e.ResourceStatus, 24), resize(*e.LogicalResourceId, 22))
+	}
+}
+
+func resize(s string, i int) string {
+	if len(s) < i {
+		s += strings.Repeat(" ", i-len(s))
+	}
+	return s
+}

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -127,6 +127,7 @@ func NewDefaultCluster() *Cluster {
 					interval: 60,
 				},
 			},
+			CloudFormationStreaming:            true,
 			HyperkubeImage:                     model.Image{Repo: "quay.io/coreos/hyperkube", Tag: k8sVer, RktPullDocker: false},
 			AWSCliImage:                        model.Image{Repo: "quay.io/coreos/awscli", Tag: "master", RktPullDocker: false},
 			CalicoNodeImage:                    model.Image{Repo: "quay.io/calico/node", Tag: "v1.2.1", RktPullDocker: false},
@@ -415,24 +416,25 @@ type DeploymentSettings struct {
 	InternetGateway             model.InternetGateway `yaml:"internetGateway,omitempty"`
 	RouteTableID                string                `yaml:"routeTableId,omitempty"`
 	// Required for validations like e.g. if instance cidr is contained in vpc cidr
-	VPCCIDR                string            `yaml:"vpcCIDR,omitempty"`
-	InstanceCIDR           string            `yaml:"instanceCIDR,omitempty"`
-	K8sVer                 string            `yaml:"kubernetesVersion,omitempty"`
-	ContainerRuntime       string            `yaml:"containerRuntime,omitempty"`
-	KMSKeyARN              string            `yaml:"kmsKeyArn,omitempty"`
-	StackTags              map[string]string `yaml:"stackTags,omitempty"`
-	Subnets                []model.Subnet    `yaml:"subnets,omitempty"`
-	EIPAllocationIDs       []string          `yaml:"eipAllocationIDs,omitempty"`
-	MapPublicIPs           bool              `yaml:"mapPublicIPs,omitempty"`
-	ElasticFileSystemID    string            `yaml:"elasticFileSystemId,omitempty"`
-	SharedPersistentVolume bool              `yaml:"sharedPersistentVolume,omitempty"`
-	SSHAuthorizedKeys      []string          `yaml:"sshAuthorizedKeys,omitempty"`
-	Addons                 model.Addons      `yaml:"addons"`
-	Experimental           Experimental      `yaml:"experimental"`
-	ManageCertificates     bool              `yaml:"manageCertificates,omitempty"`
-	WaitSignal             WaitSignal        `yaml:"waitSignal"`
-	CloudWatchLogging      `yaml:"cloudWatchLogging,omitempty"`
-	AmazonSsmAgent         `yaml:"amazonSsmAgent,omitempty"`
+	VPCCIDR                 string            `yaml:"vpcCIDR,omitempty"`
+	InstanceCIDR            string            `yaml:"instanceCIDR,omitempty"`
+	K8sVer                  string            `yaml:"kubernetesVersion,omitempty"`
+	ContainerRuntime        string            `yaml:"containerRuntime,omitempty"`
+	KMSKeyARN               string            `yaml:"kmsKeyArn,omitempty"`
+	StackTags               map[string]string `yaml:"stackTags,omitempty"`
+	Subnets                 []model.Subnet    `yaml:"subnets,omitempty"`
+	EIPAllocationIDs        []string          `yaml:"eipAllocationIDs,omitempty"`
+	MapPublicIPs            bool              `yaml:"mapPublicIPs,omitempty"`
+	ElasticFileSystemID     string            `yaml:"elasticFileSystemId,omitempty"`
+	SharedPersistentVolume  bool              `yaml:"sharedPersistentVolume,omitempty"`
+	SSHAuthorizedKeys       []string          `yaml:"sshAuthorizedKeys,omitempty"`
+	Addons                  model.Addons      `yaml:"addons"`
+	Experimental            Experimental      `yaml:"experimental"`
+	ManageCertificates      bool              `yaml:"manageCertificates,omitempty"`
+	WaitSignal              WaitSignal        `yaml:"waitSignal"`
+	CloudWatchLogging       `yaml:"cloudWatchLogging,omitempty"`
+	AmazonSsmAgent          `yaml:"amazonSsmAgent,omitempty"`
+	CloudFormationStreaming bool `yaml:"cloudFormationStreaming,omitempty"`
 
 	// Images repository
 	HyperkubeImage                     model.Image `yaml:"hyperkubeImage,omitempty"`

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1095,7 +1095,7 @@ worker:
 #  downloadUrl: https://github.com/DailyHotel/amazon-ssm-agent/releases/download/v2.0.805.1/ssm.linux-amd64.tar.gz
 #  sha1sum: a6fff8f9839d5905934e7e3df3123b54020a1f5e
 
-# When enabled, CloudFormation events will stream to stdout during kube-aws 'apply | up'.
+# When enabled, CloudFormation events will stream to stdout during kube-aws 'update | up'.
 # It is enabled by default.
 #cloudFormationStreaming: true
 

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1095,6 +1095,9 @@ worker:
 #  downloadUrl: https://github.com/DailyHotel/amazon-ssm-agent/releases/download/v2.0.805.1/ssm.linux-amd64.tar.gz
 #  sha1sum: a6fff8f9839d5905934e7e3df3123b54020a1f5e
 
+# When enabled, CloudFormation events will stream to stdout during kube-aws 'apply | up'.
+# It is enabled by default.
+#cloudFormationStreaming: true
 
 # Addon features
 addons:

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -194,7 +194,7 @@ func (c clusterImpl) Create() error {
 	}
 
 	if c.controlPlane.CloudFormationStreaming {
-		go streamCloudFormation(c, cfSvc, q)
+		go streamStackEvents(c, cfSvc, q)
 	}
 
 	return c.stackProvisioner().CreateStackAtURLAndWait(cfSvc, stackTemplateURL)
@@ -319,7 +319,7 @@ func (c clusterImpl) Update() (string, error) {
 	}
 
 	if c.controlPlane.CloudFormationStreaming {
-		go streamCloudFormation(c, cfSvc, q)
+		go streamStackEvents(c, cfSvc, q)
 	}
 
 	return c.stackProvisioner().UpdateStackAtURLAndWait(cfSvc, templateUrl)
@@ -417,7 +417,8 @@ func streamJournaldLogs(c clusterImpl, q chan struct{}) error {
 	}
 }
 
-func streamCloudFormation(c clusterImpl, cfSvc *cloudformation.CloudFormation, q chan struct{}) error {
+func streamStackEvents(c clusterImpl, cfSvc *cloudformation.CloudFormation, q chan struct{}) error {
 	fmt.Printf("Streaming CloudFormation events for the cluster '%s'...\n", c.controlPlane.ClusterName)
-	return c.stackProvisioner().StreamCloudFormationNested(q, cfSvc, c.controlPlane.ClusterName, c.controlPlane.ClusterName, time.Now())
+	// StreamEventsNested streams all the events from the root, the contorl-plane, and worker node pool stacks
+	return c.stackProvisioner().StreamEventsNested(q, cfSvc, c.controlPlane.ClusterName, c.controlPlane.ClusterName, time.Now())
 }

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -417,8 +417,8 @@ func streamJournaldLogs(c clusterImpl, q chan struct{}) error {
 	}
 }
 
+// streamStackEvents streams all the events from the root, the control-plane, and worker node pool stacks using StreamEventsNested
 func streamStackEvents(c clusterImpl, cfSvc *cloudformation.CloudFormation, q chan struct{}) error {
 	fmt.Printf("Streaming CloudFormation events for the cluster '%s'...\n", c.controlPlane.ClusterName)
-	// StreamEventsNested streams all the events from the root, the contorl-plane, and worker node pool stacks
 	return c.stackProvisioner().StreamEventsNested(q, cfSvc, c.controlPlane.ClusterName, c.controlPlane.ClusterName, time.Now())
 }


### PR DESCRIPTION
This feature will allow CouldFormation stack events to be streamed to the console (stdout) during a `kube-aws up` or `kube-aws update` operation.
The format of the messages are:
```
TimePassed   StackName   ResourceStatus    LogicalResourceId   StatusReason
```
For example:
```
+00:02:45	Nodepoolb	CREATE_IN_PROGRESS      		WorkersLC             	"Resource creation Initiated"
+00:02:45	Nodepoolb	CREATE_COMPLETE         		WorkersLC
+00:02:48	Nodepoolb	CREATE_IN_PROGRESS      		Workers
```
