### PR TITLE
Allow OIDC config without Dex

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -89,6 +89,14 @@ func NewDefaultCluster() *Cluster {
 				Enabled: false,
 			},
 		},
+		OIDC: model.OIDC{
+			Enabled:       false,
+			IssuerURL:     "https://accounts.google.com",
+			ClientID:      "YOUR_CLIENT_ID.apps.googleusercontent.com",
+			UsernameClaim: "email",
+			GroupsClaim:   "",
+			SelfSignedCa:  false,
+		},
 		Dex: model.Dex{
 			Enabled:         false,
 			Url:             "https://dex.example.com",
@@ -531,6 +539,7 @@ type Experimental struct {
 	TargetGroup                 TargetGroup                    `yaml:"targetGroup"`
 	NodeDrainer                 model.NodeDrainer              `yaml:"nodeDrainer"`
 	Plugins                     Plugins                        `yaml:"plugins"`
+	OIDC                        model.OIDC                     `yaml:"oidc"`
 	Dex                         model.Dex                      `yaml:"dex"`
 	DisableSecurityGroupIngress bool                           `yaml:"disableSecurityGroupIngress"`
 	NodeMonitorGracePeriod      string                         `yaml:"nodeMonitorGracePeriod"`

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1721,6 +1721,17 @@ write_files:
           - --advertise-address=$private_ipv4
           - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }},ResourceQuota,{{if .Experimental.Admission.DenyEscalatingExec.Enabled}}DenyEscalatingExec{{end}}
           - --anonymous-auth=false
+          {{- if .Experimental.OIDC.Enabled }}
+          - --oidc-issuer-url={{.Experimental.OIDC.IssuerURL}}
+          - --oidc-client-id={{.Experimental.OIDC.ClientID}}
+          - --oidc-username-claim={{.Experimental.OIDC.UsernameClaim}}
+          {{- if .Experimental.OIDC.GroupsClaim }}
+          - --oidc-groups-claim={{.Experimental.OIDC.GroupsClaim}}
+          {{- end }}
+          {{- if .Experimental.OIDC.SelfSignedCa }}
+          - --oidc-ca-file=/etc/kubernetes/ssl/ca.pem
+          {{- end }}
+          {{ end }}
           {{if .Experimental.Dex.Enabled}}
           - --oidc-issuer-url={{.Experimental.Dex.Url}}
           - --oidc-client-id={{.Experimental.Dex.ClientId}}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1174,7 +1174,18 @@ addons:
 #     enabled: true
 #     # Maximum time to wait, in minutes, for the node to be completely drained. Must be an integer between 1 and 60.
 #     drainTimeout: 5
-#   # Enable dex  integration - https://github.com/coreos/dex
+#
+#   # Configure OpenID Connect (OIDC) in the Kubernetes API server without Dex
+#   # If you want to use Dex please enable via the `dex` config section
+#   oidc:
+#     enabled: true
+#     issuerUrl: https://accounts.google.com
+#     clientId: YOUR_CLIENT_ID.apps.googleusercontent.com
+#     usernameClaim: email
+#     groupsClaim: ""
+#     selfSignedCa: false
+#
+#   # Enable dex integration - https://github.com/coreos/dex
 #   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
 #   # Notice: always use "https" for the "url", otherwise the Kubernetes API server will not start correctly.
 #   # Please set selfSignedCa to false if you plan to expose dex service using a LoadBalancer or Ingress with certificates signed by a trusted CA.

--- a/model/oidc.go
+++ b/model/oidc.go
@@ -1,0 +1,10 @@
+package model
+
+type OIDC struct {
+	Enabled       bool   `yaml:"enabled"`
+	IssuerURL     string `yaml:"issuerUrl"`
+	ClientID      string `yaml:"clientId"`
+	UsernameClaim string `yaml:"usernameClaim"`
+	GroupsClaim   string `yaml:"groupsClaim,omitempty"`
+	SelfSignedCa  bool   `yaml:"selfSignedCa"`
+}


### PR DESCRIPTION
If using a single OIDC provider, Dex is not needed.