### PR TITLE
Fix managed role name validation

### DIFF
--- a/cfnresource/naming.go
+++ b/cfnresource/naming.go
@@ -12,3 +12,12 @@ func ValidateRoleNameLength(clusterName string, nestedStackLogicalName string, m
 	}
 	return nil
 }
+
+func ValidateManagedRoleNameLength(managedIAMRoleName string, region string) error {
+	name := fmt.Sprintf("%s-%s", region, managedIAMRoleName)
+	if len(name) > 64 {
+		limit := 64 - len(name) + len(managedIAMRoleName)
+		return fmt.Errorf("IAM role name(=%s) will be %d characters long. It exceeds the AWS limit of 64 characters: region name(=%s) + managed iam role name(=%s) should be less than or equal to %d", name, len(name), region, managedIAMRoleName, limit)
+	}
+	return nil
+}

--- a/cfnresource/naming.go
+++ b/cfnresource/naming.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func ValidateRoleNameLength(clusterName string, nestedStackLogicalName string, managedIAMRoleName string, region string) error {
+func ValidateUnstableRoleNameLength(clusterName string, nestedStackLogicalName string, managedIAMRoleName string, region string) error {
 	name := fmt.Sprintf("%s-%s-PRK1CVQNY7XZ-%s-%s", clusterName, nestedStackLogicalName, region, managedIAMRoleName)
 	if len(name) > 64 {
 		limit := 64 - len(name) + len(clusterName) + len(nestedStackLogicalName) + len(managedIAMRoleName)
@@ -13,7 +13,7 @@ func ValidateRoleNameLength(clusterName string, nestedStackLogicalName string, m
 	return nil
 }
 
-func ValidateManagedRoleNameLength(managedIAMRoleName string, region string) error {
+func ValidateStableRoleNameLength(managedIAMRoleName string, region string) error {
 	name := fmt.Sprintf("%s-%s", region, managedIAMRoleName)
 	if len(name) > 64 {
 		limit := 64 - len(name) + len(managedIAMRoleName)

--- a/cfnresource/naming_test.go
+++ b/cfnresource/naming_test.go
@@ -14,3 +14,16 @@ func TestValidateRoleNameLength(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateManagedRoleNameLength(t *testing.T) {
+	t.Run("WhenMax", func(t *testing.T) {
+		if e := ValidateManagedRoleNameLength("prod-workers", "ap-southeast-1"); e != nil {
+			t.Errorf("expected validation to succeed but failed: %v", e)
+		}
+	})
+	t.Run("WhenTooLong", func(t *testing.T) {
+		if e := ValidateManagedRoleNameLength("prod-workers-role-with-very-very-very-very-very-long-name", "ap-southeast-1"); e == nil {
+			t.Error("expected validation to fail but succeeded")
+		}
+	})
+}

--- a/cfnresource/naming_test.go
+++ b/cfnresource/naming_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 func TestValidateRoleNameLength(t *testing.T) {
 	t.Run("WhenMax", func(t *testing.T) {
-		if e := ValidateRoleNameLength("my-firstcluster", "prodWorkerks", "prod-workers", "us-east-1"); e != nil {
+		if e := ValidateUnstableRoleNameLength("my-firstcluster", "prodWorkerks", "prod-workers", "us-east-1"); e != nil {
 			t.Errorf("expected validation to succeed but failed: %v", e)
 		}
 	})
 	t.Run("WhenTooLong", func(t *testing.T) {
-		if e := ValidateRoleNameLength("my-secondcluster", "prodWorkerks", "prod-workers", "us-east-1"); e == nil {
+		if e := ValidateUnstableRoleNameLength("my-secondcluster", "prodWorkerks", "prod-workers", "us-east-1"); e == nil {
 			t.Error("expected validation to fail but succeeded")
 		}
 	})
@@ -17,12 +17,12 @@ func TestValidateRoleNameLength(t *testing.T) {
 
 func TestValidateManagedRoleNameLength(t *testing.T) {
 	t.Run("WhenMax", func(t *testing.T) {
-		if e := ValidateManagedRoleNameLength("prod-workers", "ap-southeast-1"); e != nil {
+		if e := ValidateStableRoleNameLength("prod-workers", "ap-southeast-1"); e != nil {
 			t.Errorf("expected validation to succeed but failed: %v", e)
 		}
 	})
 	t.Run("WhenTooLong", func(t *testing.T) {
-		if e := ValidateManagedRoleNameLength("prod-workers-role-with-very-very-very-very-very-long-name", "ap-southeast-1"); e == nil {
+		if e := ValidateStableRoleNameLength("prod-workers-role-with-very-very-very-very-very-long-name", "ap-southeast-1"); e == nil {
 			t.Error("expected validation to fail but succeeded")
 		}
 	})

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1023,8 +1023,14 @@ func (c Cluster) validate() error {
 		fmt.Println(`WARNING: instance types "t2.nano" and "t2.micro" are not recommended. See https://github.com/kubernetes-incubator/kube-aws/issues/258 for more information`)
 	}
 
-	if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
-		return e
+	if len(c.Controller.IAMConfig.Role.Name) > 0 {
+		if e := cfnresource.ValidateManagedRoleNameLength(c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
+			return e
+		}
+	} else {
+		if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
+			return e
+		}
 	}
 
 	return nil

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1024,11 +1024,11 @@ func (c Cluster) validate() error {
 	}
 
 	if len(c.Controller.IAMConfig.Role.Name) > 0 {
-		if e := cfnresource.ValidateManagedRoleNameLength(c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
+		if e := cfnresource.ValidateStableRoleNameLength(c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
 			return e
 		}
 	} else {
-		if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
+		if e := cfnresource.ValidateUnstableRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
 			return e
 		}
 	}

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -334,8 +334,14 @@ func (c ProvidedConfig) validate() error {
 		return fmt.Errorf("awsNodeLabels can't be enabled for node pool because the total number of characters in clusterName(=\"%s\") + node pool's name(=\"%s\") exceeds the limit of %d", c.ClusterName, c.NodePoolName, limit)
 	}
 
-	if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
-		return e
+	if len(c.WorkerNodePoolConfig.IAMConfig.Role.Name) > 0 {
+		if e := cfnresource.ValidateManagedRoleNameLength(c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
+			return e
+		}
+	} else {
+		if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
+			return e
+		}
 	}
 
 	return nil

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -335,11 +335,11 @@ func (c ProvidedConfig) validate() error {
 	}
 
 	if len(c.WorkerNodePoolConfig.IAMConfig.Role.Name) > 0 {
-		if e := cfnresource.ValidateManagedRoleNameLength(c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
+		if e := cfnresource.ValidateStableRoleNameLength(c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
 			return e
 		}
 	} else {
-		if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
+		if e := cfnresource.ValidateUnstableRoleNameLength(c.ClusterName, c.NestedStackName(), c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
 			return e
 		}
 	}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3050,7 +3050,7 @@ worker:
   - name: pool1
     iam:
       role:
-        managedPolicies: 
+        managedPolicies:
          - arn: "arn:aws:iam::aws:policy/AdministratorAccess"
          - arn: "arn:aws:iam::000000000000:policy/myManagedPolicy"
 `,
@@ -4242,9 +4242,9 @@ addons:
 controller:
   iam:
     role:
-      name: foobarba
+      name: foobarba-foobarba-foobarba-foobarba-foobarba-foobarba
 `,
-			expectedErrorMessage: "IAM role name(=kubeaws-it-main-Controlplane-PRK1CVQNY7XZ-ap-northeast-1-foobarba) will be 65 characters long. It exceeds the AWS limit of 64 characters: cluster name(=kubeaws-it-main) + nested stack name(=Controlplane) + managed iam role name(=foobarba) should be less than or equal to 34",
+			expectedErrorMessage: "IAM role name(=ap-northeast-1-foobarba-foobarba-foobarba-foobarba-foobarba-foobarba) will be 68 characters long. It exceeds the AWS limit of 64 characters: region name(=ap-northeast-1) + managed iam role name(=foobarba-foobarba-foobarba-foobarba-foobarba-foobarba) should be less than or equal to 49",
 		},
 		{
 			context: "WithTooLongWorkerIAMRoleName",
@@ -4254,9 +4254,9 @@ worker:
   - name: pool1
     iam:
       role:
-        name: foobarbazbaraaa
+        name: foobarba-foobarba-foobarba-foobarba-foobarba-foobarbazzz
 `,
-			expectedErrorMessage: "IAM role name(=kubeaws-it-main-Pool1-PRK1CVQNY7XZ-ap-northeast-1-foobarbazbaraaa) will be 65 characters long. It exceeds the AWS limit of 64 characters: cluster name(=kubeaws-it-main) + nested stack name(=Pool1) + managed iam role name(=foobarbazbaraaa) should be less than or equal to 34",
+			expectedErrorMessage: "IAM role name(=ap-northeast-1-foobarba-foobarba-foobarba-foobarba-foobarba-foobarbazzz) will be 71 characters long. It exceeds the AWS limit of 64 characters: region name(=ap-northeast-1) + managed iam role name(=foobarba-foobarba-foobarba-foobarba-foobarba-foobarbazzz) should be less than or equal to 49",
 		},
 		{
 			context: "WithInvalidEtcdInstanceProfileArn",


### PR DESCRIPTION
When creating iam roles for the controller or node pools, validation checks for the whole string consisting of `<cluster_name>-<nested_stack_name>-<12_characters_random_alphanumeric_characters>-<region>-<iam_role_name>`. The validation works as intended if `iam.role.name` is not specified and auto-generated.

However when `iam.role.name` is specified, kube-aws is actually creating `<region_name>-<managed_role_name>` so for the following config it'll actually create a role named `<region>-myrole` so a new validation is needed.

```
      iam:
        role:
          name: "myrole"
```

This allows for a little bit more leeway to have a more meaningful name for the fixed role.