### PR TITLE
Fix potential YAML parsing error

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -239,7 +239,7 @@ worker:
 #      # If omitted, public subnets are created by kube-aws and used for worker nodes
 #      subnets:
 #      - # References subnets defined under the top-level `subnets` key by their names
-#        name: ManagedPublicSubnet1
+#        - name: ManagedPublicSubnet1
 #
 #      # Existing "glue" security groups attached to worker nodes which are typically used to allow
 #      # access from worker nodes to services running on an existing infrastructure


### PR DESCRIPTION
Fixed the name subnet name parameter in nodePools section so that YAML can parse. When you uncomment the name, a - is needed for successfully parsing YAML