### PR TITLE
Remove redundant step

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ Clone this repository to the appropriate path under the GOPATH.
 
 ```
 $ export GOPATH=$HOME/go
-$ mkdir -p $GOPATH/src/github.com/kubernetes-incubator/
 $ git clone git@github.com:kubernetes-incubator/kube-aws.git $GOPATH/src/github.com/kubernetes-incubator/kube-aws
 ```
 


### PR DESCRIPTION
git clone can make the directory automatically which is specified as the last argument