### PR TITLE
Add support for Node Authorizer + Node Restriction admission controller

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -69,6 +69,9 @@ func NewDefaultCluster() *Cluster {
 		TLSBootstrap: TLSBootstrap{
 			Enabled: false,
 		},
+		NodeAuthorizer: NodeAuthorizer{
+			Enabled: false,
+		},
 		EphemeralImageStorage: EphemeralImageStorage{
 			Enabled:    false,
 			Disk:       "xvdb",
@@ -526,6 +529,7 @@ type Experimental struct {
 	// a node label and IAM permissions to run cluster-autoscaler
 	ClusterAutoscalerSupport    model.ClusterAutoscalerSupport `yaml:"clusterAutoscalerSupport"`
 	TLSBootstrap                TLSBootstrap                   `yaml:"tlsBootstrap"`
+	NodeAuthorizer              NodeAuthorizer                 `yaml:"nodeAuthorizer"`
 	EphemeralImageStorage       EphemeralImageStorage          `yaml:"ephemeralImageStorage"`
 	Kube2IamSupport             Kube2IamSupport                `yaml:"kube2IamSupport,omitempty"`
 	KubeletOpts                 string                         `yaml:"kubeletOpts,omitempty"`
@@ -578,6 +582,10 @@ type AwsNodeLabels struct {
 }
 
 type TLSBootstrap struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type NodeAuthorizer struct {
 	Enabled bool `yaml:"enabled"`
 }
 
@@ -1078,6 +1086,10 @@ func (c Cluster) validate() error {
 		if e := cfnresource.ValidateUnstableRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
 			return e
 		}
+	}
+
+	if c.Experimental.NodeAuthorizer.Enabled && !c.Experimental.TLSBootstrap.Enabled {
+		return fmt.Errorf("TLS bootstrap is required in order to enable the node authorizer")
 	}
 
 	return nil

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1450,6 +1450,7 @@ write_files:
             - daemonsets
             verbs:
             - get
+          # Can be removed if node authorizer is enabled
           - apiGroups: [""]
             resources:
             - nodes
@@ -1762,15 +1763,16 @@ write_files:
           - --audit-log-maxbackup=1
           {{ end }}
           {{if .Experimental.Plugins.Rbac.Enabled}}
-          - --authorization-mode=RBAC
-          - --authorization-rbac-super-user=kube-admin
+          - --authorization-mode={{if .Experimental.NodeAuthorizer.Enabled}}Node,{{end}}RBAC
+          {{ else if .Experimental.NodeAuthorizer.Enabled }}
+          - --authorization-mode=Node
           {{ end }}
           {{if .Experimental.Authentication.Webhook.Enabled}}
           - --authentication-token-webhook-config-file=/etc/kubernetes/webhooks/authentication.yaml
           - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
           {{ end }}
           - --advertise-address=$private_ipv4
-          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }},ResourceQuota,{{if .Experimental.Admission.DenyEscalatingExec.Enabled}}DenyEscalatingExec{{end}}
+          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }}{{if .Experimental.NodeAuthorizer.Enabled}},NodeRestriction{{end}},ResourceQuota,{{if .Experimental.Admission.DenyEscalatingExec.Enabled}}DenyEscalatingExec{{end}}
           - --anonymous-auth=false
           {{if .Experimental.Oidc.Enabled}}
           - --oidc-issuer-url={{.Experimental.Oidc.IssuerUrl}}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1167,6 +1167,10 @@ addons:
 #   # The bootstrap token is automatically generated in ./credentials/kubelet-tls-bootstrap-token.
 #   tlsBootstrap:
 #     enabled: true
+#   # Enables the Node authorization + node restriction admission controller (requires Kubernetes 1.7.4+)
+#   # Requires TLS bootstrapping to be enabled as well
+#   nodeAuthorizer:
+#     enabled: true
 #   # This option has not yet been tested with rkt as container runtime
 #   ephemeralImageStorage:
 #     enabled: true


### PR DESCRIPTION
After https://github.com/kubernetes/kubernetes/pull/48707, we can now add support for the node authorizer + node restriction admission controller to kube-aws without breaking our node drainer implementation.

In order to use this, Kubelets must use certificates that conform with the username/group restrictions documented [here](https://kubernetes.io/docs/admin/authorization/node/), which makes TLS bootstrapping a prerequisite.

Also, as noted in `cluster.yaml`, this feature can only be used in Kubernetes 1.7.4+. (See #853)