### PR TITLE
Update tiller to v2.6.0

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -146,6 +146,7 @@ func NewDefaultCluster() *Cluster {
 			DnsMasqMetricsImage:                model.Image{Repo: "gcr.io/google_containers/k8s-dns-sidecar-amd64", Tag: "1.14.4", RktPullDocker: false},
 			ExecHealthzImage:                   model.Image{Repo: "gcr.io/google_containers/exechealthz-amd64", Tag: "1.2", RktPullDocker: false},
 			HelmImage:                          model.Image{Repo: "quay.io/kube-aws/helm", Tag: "v2.5.1", RktPullDocker: false},
+			TillerImage:                        model.Image{Repo: "gcr.io/kubernetes-helm/tiller", Tag: "v2.6.0", RktPullDocker: false},
 			HeapsterImage:                      model.Image{Repo: "gcr.io/google_containers/heapster", Tag: "v1.4.1", RktPullDocker: false},
 			AddonResizerImage:                  model.Image{Repo: "gcr.io/google_containers/addon-resizer", Tag: "2.0", RktPullDocker: false},
 			KubeDashboardImage:                 model.Image{Repo: "gcr.io/google_containers/kubernetes-dashboard-amd64", Tag: "v1.6.3", RktPullDocker: false},
@@ -456,6 +457,7 @@ type DeploymentSettings struct {
 	DnsMasqMetricsImage                model.Image `yaml:"dnsMasqMetricsImage,omitempty"`
 	ExecHealthzImage                   model.Image `yaml:"execHealthzImage,omitempty"`
 	HelmImage                          model.Image `yaml:"helmImage,omitempty"`
+	TillerImage                        model.Image `yaml:"tillerImage,omitempty"`
 	HeapsterImage                      model.Image `yaml:"heapsterImage,omitempty"`
 	AddonResizerImage                  model.Image `yaml:"addonResizerImage,omitempty"`
 	KubeDashboardImage                 model.Image `yaml:"kubeDashboardImage,omitempty"`

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -145,7 +145,7 @@ func NewDefaultCluster() *Cluster {
 			KubeReschedulerImage:               model.Image{Repo: "gcr.io/google-containers/rescheduler", Tag: "v0.3.1", RktPullDocker: false},
 			DnsMasqMetricsImage:                model.Image{Repo: "gcr.io/google_containers/k8s-dns-sidecar-amd64", Tag: "1.14.4", RktPullDocker: false},
 			ExecHealthzImage:                   model.Image{Repo: "gcr.io/google_containers/exechealthz-amd64", Tag: "1.2", RktPullDocker: false},
-			HelmImage:                          model.Image{Repo: "quay.io/kube-aws/helm", Tag: "v2.5.1", RktPullDocker: false},
+			HelmImage:                          model.Image{Repo: "quay.io/kube-aws/helm", Tag: "v2.6.0", RktPullDocker: false},
 			TillerImage:                        model.Image{Repo: "gcr.io/kubernetes-helm/tiller", Tag: "v2.6.0", RktPullDocker: false},
 			HeapsterImage:                      model.Image{Repo: "gcr.io/google_containers/heapster", Tag: "v1.4.1", RktPullDocker: false},
 			AddonResizerImage:                  model.Image{Repo: "gcr.io/google_containers/addon-resizer", Tag: "2.0", RktPullDocker: false},

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2586,7 +2586,7 @@ write_files:
               - env:
                 - name: TILLER_NAMESPACE
                   value: kube-system
-                image: gcr.io/kubernetes-helm/tiller:v2.5.1
+                image: {{.TillerImage.RepoWithTag}}
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -996,7 +996,7 @@ worker:
 # Helm image repository to use.
 #helmImage:
 #  repo: quay.io/kube-aws/helm
-#  tag: v2.5.1
+#  tag: v2.6.0
 #  rktPullDocker: false
 
 # Tiller (Helm backend) image repository to use.

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -999,6 +999,12 @@ worker:
 #  tag: v2.5.1
 #  rktPullDocker: false
 
+# Tiller (Helm backend) image repository to use.
+#tillerImage:
+#  repo: gcr.io/kubernetes-helm/tiller
+#  tag: v2.6.0
+#  rktPullDocker: false
+
 # Heapster image repository to use.
 #heapsterImage:
 #  repo: gcr.io/google_containers/heapster


### PR DESCRIPTION
This also adds an extension point in `cluster.yaml` so the user can specify a custom version of Tiller.

@mumoshu I noticed the plugin system uses Helm, but it's hosted in a dedicated quay.io repository. If you update it with the latest Helm version, I'll update the references to the Helm image as well.