### PR TITLE
doc: Fix the link from the getting-started/addons page to the next

### DIFF
--- a/docs/getting-started/step-6-configure-add-ons.md
+++ b/docs/getting-started/step-6-configure-add-ons.md
@@ -120,10 +120,10 @@ Resources:
 
 When you are done with your cluster, [destroy your cluster][getting-started-step-7]
 
-[getting-started-step-1]: kubernetes-on-aws.md
-[getting-started-step-2]: kubernetes-on-aws-render.md
-[getting-started-step-3]: kubernetes-on-aws-launch.md
-[getting-started-step-4]: kube-aws-cluster-updates.md
-[getting-started-step-5]: kubernetes-on-aws-node-pool.md
-[getting-started-step-6]: kubernetes-on-aws-add-ons.md
-[getting-started-step-7]: kubernetes-on-aws-destroy.md
+[getting-started-step-1]: step-1-configure.md
+[getting-started-step-2]: step-2-render.md
+[getting-started-step-3]: step-3-launch.md
+[getting-started-step-4]: step-4-update.md
+[getting-started-step-5]: step-5-add-node-pool.md
+[getting-started-step-6]: step-6-configure-add-ons.md
+[getting-started-step-7]: step-7-destroy.md


### PR DESCRIPTION
The "destroy your cluster" link doesn't work in https://kubernetes-incubator.github.io/kube-aws/getting-started/step-6-configure-add-ons.html

@c-knowles Merging this would result in the doc site automatically updated by #859 