### PR TITLE
Tidy contributor/developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ Destroy:
 $ kube-aws destroy
 ```
 
-## Development
-
-Details of how to contribute to kube-aws are in our [Contributor Guide](https://kubernetes-incubator.github.io/kube-aws/guides/contributor-guide.html)
-
 ## Other Resources
 
 Extra or advanced topics in for kube-aws:
@@ -113,4 +109,5 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 ## Contributing
 
 Submit a PR to this repository, following the [contributors guide](CONTRIBUTING.md).
-The documentation is published from [this source](Documentation/kubernetes-on-aws.md).
+
+Details of how to develop kube-aws are in our [Developer Guide](https://kubernetes-incubator.github.io/kube-aws/guides/developer-guide.html).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,8 +17,8 @@
   * [Cluster Resource Backup to AWS S3](add-ons/cluster-resource-backup-to-s3.md)
   * [Journald Logging to AWS CloudWatch](add-ons/journald-logging-to-cloudwatch.md)
 * [Guides](guides/README.md)
+  * [Developer Guide](guides/developer-guide.md)
   * [Operator Guide](guides/operator-guide.md)
-  * [Contributor Guide](guides/contributor-guide.md)
 * [Advanced Topics](advanced-topics/README.md)
   * [etcd Backup & Restore](advanced-topics/etcd-backup-and-restore.md)
   * [CloudFormation Updates in CLI](advanced-topics/cloudformation-updates-in-cli.md)
@@ -27,4 +27,3 @@
   * [Known Limitations](troubleshooting/known-limitations.md)
   * [Common Problems](troubleshooting/common-problems.md)
 * [Quick Start \(WIP\)](tutorials/quick-start.md)
-

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,4 +1,4 @@
 # Guides
 
 * [Operator Guide](operator-guide.md) for those performing day to day operations on a kube-aws generated cluster
-* [Contributor Guide](contributor-guide.md) for those wishing to join us in improving kube-aws
+* [Developer Guide](developer-guide.md) for those wishing to join us in improving kube-aws

--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -1,16 +1,12 @@
-# Contributor Guide
+# Developer Guide
 
 If you would like to contribute towards the goals of kube-aws, the easiest way to get started is to submit a pull request to the [kube-aws repository](https://github.com/kubernetes-incubator/kube-aws/), following the [contributors guide](https://github.com/kubernetes-incubator/kube-aws/blob/master/CONTRIBUTING.md). If you need some help getting started with a contribution let us know and we can point you in the right direction.
 
-## Code of conduct
+# Code of conduct
 
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](https://github.com/kubernetes-incubator/kube-aws/blob/master/code-of-conduct.md).
 
-Submit a PR to the [kube-aws repository](https://github.com/kubernetes-incubator/kube-aws/), following the [contributors guide](https://github.com/kubernetes-incubator/kube-aws/blob/master/CONTRIBUTING.md).
-
-# Developing kube-aws
-
-## Build
+# Build
 
 Clone the [kube-aws repository](https://github.com/kubernetes-incubator/kube-aws) to the appropriate path under the GOPATH.
 
@@ -27,13 +23,13 @@ This depends on having:
 
 The compiled binary will be available at `bin/kube-aws`.
 
-## Run Unit Tests
+# Run Unit Tests
 
 ```bash
 make test
 ```
 
-## Run e2e Tests
+# Run e2e Tests
 
 To run the e2e tests, you will need at least these environment variables setup with any missing values filled in with values from your AWS account:
 
@@ -68,13 +64,13 @@ The `FOCUS` environment variable can be used if you wish to target a particular 
 export FOCUS=.*Rescheduler.*
 ```
 
-## Reformat Code
+# Reformat Code
 
 ```bash
 make format
 ```
 
-## Modifying Templates
+# Modifying Templates
 
 The various templates are located in the `core/controlplane/config/templates/` and the `core/nodepool/config/templates/` directory of the source repo. `go generate` is used to pack these templates into the source code. In order for changes to templates to be reflected in the source code:
 
@@ -82,7 +78,7 @@ The various templates are located in the `core/controlplane/config/templates/` a
 make build
 ```
 
-## Documentation
+# Documentation
 
 Documentation source lives inside the `docs` directory of the `master` branch. Generally we aim to add documentation in the same PR as any features/updates so it can be reviewed together. To update the documentation, create/update markdown files inside the `docs` directory and use the following command to generate the full documentation site locally:
 


### PR DESCRIPTION
Since we need to keep `CONTRIBUTING.md` as the contributors guide,
renamed the documentation version to Developer Guide.