### PR TITLE
relnote: Also consider changes under docs/ to be documentation updates

### DIFF
--- a/hack/relnote.go
+++ b/hack/relnote.go
@@ -102,7 +102,7 @@ func filesChangedInCommit(refName string) []string {
 func onlyDocsAreChanged(files []string) bool {
 	all := true
 	for _, file := range files {
-		all = all && strings.HasPrefix(file, "Documentation/")
+		all = all && (strings.HasPrefix(file, "Documentation/") || strings.HasPrefix(file, "docs/"))
 	}
 	return all
 }


### PR DESCRIPTION
So that relnote.go will not classify a commit which changes nothing but files under docs/ to be an "other change".