### PR TITLE
Fix the existing TLS CA support

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -836,7 +836,7 @@ func (c Cluster) StackConfig(opts StackTemplateOptions, extra ...[]*pluginmodel.
 	var compactAssets *CompactAssets
 
 	if c.AssetsEncryptionEnabled() {
-		compactAssets, err = ReadOrCreateCompactAssets(opts.AssetsDir, c.ManageCertificates, KMSConfig{
+		compactAssets, err = ReadOrCreateCompactAssets(opts.AssetsDir, c.ManageCertificates, c.Experimental.TLSBootstrap.Enabled, KMSConfig{
 			Region:         stackConfig.Config.Region,
 			KMSKeyARN:      c.KMSKeyARN,
 			EncryptService: c.ProvidedEncryptService,
@@ -847,7 +847,7 @@ func (c Cluster) StackConfig(opts StackTemplateOptions, extra ...[]*pluginmodel.
 
 		stackConfig.Config.AssetsConfig = compactAssets
 	} else {
-		rawAssets, err := ReadOrCreateUnencryptedCompactAssets(opts.AssetsDir, c.ManageCertificates)
+		rawAssets, err := ReadOrCreateUnencryptedCompactAssets(opts.AssetsDir, c.ManageCertificates, c.Experimental.TLSBootstrap.Enabled)
 		if err != nil {
 			return nil, err
 		}

--- a/core/controlplane/config/encrypted_assets.go
+++ b/core/controlplane/config/encrypted_assets.go
@@ -509,8 +509,18 @@ func (r *RawAssetsOnMemory) WriteToDir(dirname string, includeCAKey bool) error 
 		{"ca-key.pem", "worker-ca-key.pem"},
 	}
 
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Chdir(dirname); err != nil {
+		return err
+	}
+
 	for _, sl := range symlinks {
-		to := filepath.Join(dirname, sl.to)
+		from := sl.from
+		to := sl.to
 
 		if _, err := os.Lstat(to); err == nil {
 			if err := os.Remove(to); err != nil {
@@ -518,10 +528,15 @@ func (r *RawAssetsOnMemory) WriteToDir(dirname string, includeCAKey bool) error 
 			}
 		}
 
-		if err := os.Symlink(sl.from, to); err != nil {
+		if err := os.Symlink(from, to); err != nil {
 			return err
 		}
 	}
+
+	if err := os.Chdir(wd); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/core/controlplane/config/encrypted_assets.go
+++ b/core/controlplane/config/encrypted_assets.go
@@ -171,6 +171,7 @@ func (c *Cluster) NewAssetsOnDisk(dir string, renderCredentialsOpts CredentialsO
 		}
 	}
 
+	fmt.Println("-> Generating new assets")
 	assets, err := c.NewAssetsOnMemory(caKey, caCert)
 	if err != nil {
 		return nil, fmt.Errorf("Error generating default assets: %v", err)

--- a/core/controlplane/config/encrypted_assets.go
+++ b/core/controlplane/config/encrypted_assets.go
@@ -473,7 +473,7 @@ func (r *RawAssetsOnMemory) WriteToDir(dirname string, includeCAKey bool) error 
 			name      string
 			data      []byte
 			overwrite bool
-		}{"ca-key.pem", r.CACert, true})
+		}{"ca-key.pem", r.CAKey, true})
 	}
 
 	for _, asset := range assets {

--- a/core/controlplane/config/encrypted_assets_test.go
+++ b/core/controlplane/config/encrypted_assets_test.go
@@ -154,7 +154,7 @@ func TestReadOrCreateCompactAssets(t *testing.T) {
 			}
 
 			files := []string{
-				"ca-key.pem.enc", "admin-key.pem.enc", "worker-key.pem.enc", "apiserver-key.pem.enc",
+				"admin-key.pem.enc", "worker-key.pem.enc", "apiserver-key.pem.enc",
 				"etcd-key.pem.enc", "etcd-client-key.pem.enc", "worker-ca-key.pem.enc",
 			}
 
@@ -187,7 +187,7 @@ func TestReadOrCreateCompactAssets(t *testing.T) {
 
 			for _, v := range [][]string{
 				{"AdminKey", original.AdminKey, regenerated.AdminKey},
-				{"CAKey", original.CAKey, regenerated.CAKey},
+				{"WorkerCAKey", original.WorkerCAKey, regenerated.WorkerCAKey},
 				{"WorkerKey", original.WorkerKey, regenerated.WorkerKey},
 				{"APIServerKey", original.APIServerKey, regenerated.APIServerKey},
 				{"EtcdClientKey", original.EtcdClientKey, regenerated.EtcdClientKey},

--- a/core/controlplane/config/user_data_config_test.go
+++ b/core/controlplane/config/user_data_config_test.go
@@ -61,11 +61,6 @@ func TestCloudConfigTemplating(t *testing.T) {
 		t.Fatalf("Failed to create config: %v", err)
 	}
 
-	// TLS assets
-	caKey, caCert, err := cluster.NewTLSCA()
-	if err != nil {
-		t.Fatalf("failed generating tls ca: %v", err)
-	}
 	opts := CredentialsOptions{
 		GenerateCA: true,
 	}
@@ -77,12 +72,12 @@ func TestCloudConfigTemplating(t *testing.T) {
 	}
 
 	helper.WithTempDir(func(dir string) {
-		_, err = cluster.NewAssetsOnDisk(dir, opts, caKey, caCert)
+		_, err = cluster.NewAssetsOnDisk(dir, opts)
 		if err != nil {
 			t.Fatalf("Error generating default assets: %v", err)
 		}
 
-		encryptedAssets, err := ReadOrEncryptAssets(dir, true, cachedEncryptor)
+		encryptedAssets, err := ReadOrEncryptAssets(dir, true, true, cachedEncryptor)
 		if err != nil {
 			t.Fatalf("failed to compress assets: %v", err)
 		}

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -80,8 +80,9 @@ func (c ProvidedConfig) StackConfig(opts StackTemplateOptions) (*StackConfig, er
 		return nil, fmt.Errorf("failed to generate config : %v", err)
 	}
 
+	tlsBootstrappingEnabled := c.Experimental.TLSBootstrap.Enabled
 	if stackConfig.ComputedConfig.AssetsEncryptionEnabled() {
-		compactAssets, err := cfg.ReadOrCreateCompactAssets(opts.AssetsDir, c.ManageCertificates, cfg.KMSConfig{
+		compactAssets, err := cfg.ReadOrCreateCompactAssets(opts.AssetsDir, c.ManageCertificates, tlsBootstrappingEnabled, cfg.KMSConfig{
 			Region:         stackConfig.ComputedConfig.Region,
 			KMSKeyARN:      c.KMSKeyARN,
 			EncryptService: c.ProvidedEncryptService,
@@ -91,7 +92,7 @@ func (c ProvidedConfig) StackConfig(opts StackTemplateOptions) (*StackConfig, er
 		}
 		stackConfig.ComputedConfig.AssetsConfig = compactAssets
 	} else {
-		rawAssets, _ := cfg.ReadOrCreateUnencryptedCompactAssets(opts.AssetsDir, c.ManageCertificates)
+		rawAssets, _ := cfg.ReadOrCreateUnencryptedCompactAssets(opts.AssetsDir, c.ManageCertificates, tlsBootstrappingEnabled)
 		stackConfig.ComputedConfig.AssetsConfig = rawAssets
 	}
 

--- a/core/root/render/credentials.go
+++ b/core/root/render/credentials.go
@@ -1,13 +1,9 @@
 package render
 
 import (
-	"crypto/rsa"
-	"crypto/x509"
 	"fmt"
 	"github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	"github.com/kubernetes-incubator/kube-aws/core/root/defaults"
-	"github.com/kubernetes-incubator/kube-aws/tlsutil"
-	"io/ioutil"
 	"os"
 )
 
@@ -27,41 +23,13 @@ func NewCredentialsRenderer(c *config.Cluster) CredentialsRenderer {
 
 func (r credentialsRendererImpl) RenderCredentials(renderCredentialsOpts config.CredentialsOptions) error {
 	cluster := r.c
-	fmt.Println("Generating credentials...")
-	var caKey *rsa.PrivateKey
-	var caCert *x509.Certificate
-	if renderCredentialsOpts.GenerateCA {
-		var err error
-		caKey, caCert, err = cluster.NewTLSCA()
-		if err != nil {
-			return fmt.Errorf("failed generating cluster CA: %v", err)
-		}
-		fmt.Printf("-> Generating new TLS CA\n")
-	} else {
-		fmt.Printf("-> Parsing existing TLS CA\n")
-		if caKeyBytes, err := ioutil.ReadFile(renderCredentialsOpts.CaKeyPath); err != nil {
-			return fmt.Errorf("failed reading ca key file %s : %v", renderCredentialsOpts.CaKeyPath, err)
-		} else {
-			if caKey, err = tlsutil.DecodePrivateKeyPEM(caKeyBytes); err != nil {
-				return fmt.Errorf("failed parsing ca key: %v", err)
-			}
-		}
-		if caCertBytes, err := ioutil.ReadFile(renderCredentialsOpts.CaCertPath); err != nil {
-			return fmt.Errorf("failed reading ca cert file %s : %v", renderCredentialsOpts.CaCertPath, err)
-		} else {
-			if caCert, err = tlsutil.DecodeCertificatePEM(caCertBytes); err != nil {
-				return fmt.Errorf("failed parsing ca cert: %v", err)
-			}
-		}
-	}
-
 	dir := defaults.AssetsDir
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
 
 	fmt.Println("-> Generating new assets")
-	_, err := cluster.NewAssetsOnDisk(dir, renderCredentialsOpts, caKey, caCert)
+	_, err := cluster.NewAssetsOnDisk(dir, renderCredentialsOpts)
 	if err != nil {
 		return err
 	}

--- a/core/root/render/credentials.go
+++ b/core/root/render/credentials.go
@@ -1,7 +1,6 @@
 package render
 
 import (
-	"fmt"
 	"github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	"github.com/kubernetes-incubator/kube-aws/core/root/defaults"
 	"os"
@@ -28,7 +27,6 @@ func (r credentialsRendererImpl) RenderCredentials(renderCredentialsOpts config.
 		return err
 	}
 
-	fmt.Println("-> Generating new assets")
 	_, err := cluster.NewAssetsOnDisk(dir, renderCredentialsOpts)
 	if err != nil {
 		return err

--- a/e2e/run
+++ b/e2e/run
@@ -125,7 +125,15 @@ configure() {
 
   rm -rf ./kubeconfig ./credentials ./userdata ./stack-templates ./exported
 
-  ${KUBE_AWS_CMD} render
+  ${KUBE_AWS_CMD} render stack
+  ${KUBE_AWS_CMD} render credentials --generate-ca
+
+  if [ "${EXISTING_CA}" != "" ]; then
+    mv ./credentials/ca-key.pem my-ca-key.pem
+    mv ./credentials/ca.pem my-ca.pem
+    rm -rf ./credentials
+    ${KUBE_AWS_CMD} render credentials --ca-key-path=./my-ca-key.pem --ca-cert-path=./my-ca.pem
+  fi
 
   validate
 

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 )
 
 func WithTempDir(fn func(dir string)) {
@@ -55,17 +54,32 @@ func withDummyCredentials(alsoWriteCAKey bool, fn func(dir string)) {
 		}
 	}
 
-	symlinks := []struct {
+	type symlink struct {
 		from string
 		to   string
-	}{
+	}
+
+	symlinks := []symlink{
 		{"ca.pem", "worker-ca.pem"},
 		{"ca.pem", "etcd-trusted-ca.pem"},
-		{"ca-key.pem", "worker-ca-key.pem"},
+	}
+
+	if alsoWriteCAKey {
+		symlinks = append(symlinks, symlink{"ca-key.pem", "worker-ca-key.pem"})
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	if err := os.Chdir(dir); err != nil {
+		panic(err)
 	}
 
 	for _, sl := range symlinks {
-		to := filepath.Join(dir, sl.to)
+		from := sl.from
+		to := sl.to
 
 		if _, err := os.Lstat(to); err == nil {
 			if err := os.Remove(to); err != nil {
@@ -73,10 +87,14 @@ func withDummyCredentials(alsoWriteCAKey bool, fn func(dir string)) {
 			}
 		}
 
-		if err := os.Symlink(sl.from, to); err != nil {
+		if err := os.Symlink(from, to); err != nil {
 			panic(err)
 		}
 		defer os.Remove(to)
+	}
+
+	if err := os.Chdir(wd); err != nil {
+		panic(err)
 	}
 
 	fn(dir)

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -20,6 +20,14 @@ func WithTempDir(fn func(dir string)) {
 }
 
 func WithDummyCredentials(fn func(dir string)) {
+	withDummyCredentials(true, fn)
+}
+
+func WithDummyCredentialsButCAKey(fn func(dir string)) {
+	withDummyCredentials(false, fn)
+}
+
+func withDummyCredentials(alsoWriteCAKey bool, fn func(dir string)) {
 	dir, err := ioutil.TempDir("", "dummy-credentials")
 
 	if err != nil {
@@ -38,11 +46,13 @@ func WithDummyCredentials(fn func(dir string)) {
 		}
 		defer os.Remove(certFile)
 
-		keyFile := fmt.Sprintf("%s/%s-key.pem", dir, pairName)
-		if err := ioutil.WriteFile(keyFile, []byte("dummykey"), 0644); err != nil {
-			panic(err)
+		if pairName != "ca" || alsoWriteCAKey {
+			keyFile := fmt.Sprintf("%s/%s-key.pem", dir, pairName)
+			if err := ioutil.WriteFile(keyFile, []byte("dummykey"), 0644); err != nil {
+				panic(err)
+			}
+			defer os.Remove(keyFile)
 		}
-		defer os.Remove(keyFile)
 	}
 
 	symlinks := []struct {


### PR DESCRIPTION
It seems to have broken at some point.

This is verified to fix the problem by creating a cluster with a configuration which requires ca-key.pem to be deployed on controller nodes:

```
cd e2e && EXISTING_CA=1 RBAC=1 NODE_AUTHORIZER=1 KUBE_AWS_USE_CALICO=1 ETCD_DISASTER_RECOVERY_AUTOMATED=1 ETCD_SNAPSHOT_AUTOMATED=1 ETCD_COUNT=1 CONTROLLER_COUNT=1 KUBE_AWS_CLUSTER_NAME=clustername bash -c './run all'
```

and an another one which doesn't require ca-key.pem on controller nodes:

```
cd e2e && EXISTING_CA=1 ETCD_COUNT=1 CONTROLLER_COUNT=1 KUBE_AWS_CLUSTER_NAME=clustername bash -c './run all'
```

Fixes #839

cc @danielfm @kamatama41
