### PR TITLE
Configure tolerations for kube2iam DaemonSet. Update ETCD version to 3.2.6.

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2798,6 +2798,13 @@ write_files:
             serviceAccountName: kube2iam
             {{- end}}
             hostNetwork: true
+            tolerations:
+            - operator: Exists
+              effect: NoSchedule
+            - operator: Exists
+              effect: NoExecute
+            - operator: Exists
+              key: CriticalAddonsOnly
             containers:
               - image: jtblin/kube2iam:latest
                 name: kube2iam

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -613,7 +613,7 @@ worker:
 #      arn: "arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME"
 #
 #  # The version of etcd to be used. Set to e.g. "3.2.1" to use etcd3
-#  version: 3.2.5
+#  version: 3.2.6
 #
 #  snapshot:
 #    # Set to true to periodically take an etcd snapshot

--- a/etcdadm/README.md
+++ b/etcdadm/README.md
@@ -14,7 +14,7 @@ AWS_SECRET_ACCESS_KEY=... \
 ETCDADM_AWSCLI_DOCKER_IMAGE=quay.io/coreos/awscli \
 # Required settings
 AWS_DEFAULT_REGION=ap-northeast-1 \
-ETCD_VERSION=3.2.5 \
+ETCD_VERSION=3.2.6 \
 ETCD_DATA_DIR=/var/lib/etcd \
 ETCD_INITIAL_CLUSTER=etcd0=http://127.0.0.1:3080,etcd1=http://127.0.0.1:3180,etcd2=http://127.0.0.1:3280 \
 ETCDCTL_ENDPOINTS=http://127.0.0.1:3079,etcd1=http://127.0.0.1:3179,etcd2=http://127.0.0.1:3279, \

--- a/etcdadm/etcdadm
+++ b/etcdadm/etcdadm
@@ -85,7 +85,7 @@ config_etcd_endpoints() {
   echo "${ETCD_ENDPOINTS}"
 }
 
-etcd_version=${ETCD_VERSION:-3.2.5}
+etcd_version=${ETCD_VERSION:-3.2.6}
 etcd_aci_url="https://github.com/coreos/etcd/releases/download/v$etcd_version/etcd-v$etcd_version-linux-amd64.aci"
 
 member_count="${ETCDADM_MEMBER_COUNT:?missing required env}"

--- a/etcdadm/test
+++ b/etcdadm/test
@@ -98,7 +98,7 @@ RestartSec=10s
 TimeoutStartSec=0
 LimitNOFILE=40000
 
-Environment="ETCD_IMAGE_TAG=v3.2.5"
+Environment="ETCD_IMAGE_TAG=v3.2.6"
 Environment="ETCD_NAME=%m"
 Environment="ETCD_USER=etcd"
 Environment="ETCD_DATA_DIR=/var/lib/etcd"

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -153,7 +153,7 @@ func (e Etcd) Version() EtcdVersion {
 	if e.Cluster.Version != "" {
 		return e.Cluster.Version
 	}
-	return "3.2.5"
+	return "3.2.6"
 }
 
 func (v EtcdVersion) Is3() bool {


### PR DESCRIPTION
1. Configure tolerations for kube2iam DaemonSet.

2. Update ETCD version to 3.2.6

etcd v3.2.6 (2017-08-21)
- fix watch restore from snapshot
- fix etcd_debugging_mvcc_keys_total inconsistency
- fix multiple URLs for '--listen-peer-urls' flag
- add 'enable-pprof' to etcd configuration file format