### PR TITLE
Dedicated worker CA and Etcd trusted CA bundle

### DIFF
--- a/core/controlplane/config/encrypted_assets.go
+++ b/core/controlplane/config/encrypted_assets.go
@@ -451,7 +451,6 @@ func (r *RawAssetsOnMemory) WriteToDir(dirname string, includeCAKey bool) error 
 	}
 
 	for _, sl := range symlinks {
-		from := filepath.Join(dirname, sl.from)
 		to := filepath.Join(dirname, sl.to)
 
 		if _, err := os.Lstat(to); err == nil {
@@ -460,7 +459,7 @@ func (r *RawAssetsOnMemory) WriteToDir(dirname string, includeCAKey bool) error 
 			}
 		}
 
-		if err := os.Symlink(from, to); err != nil {
+		if err := os.Symlink(sl.from, to); err != nil {
 			return err
 		}
 	}

--- a/core/controlplane/config/encrypted_assets_test.go
+++ b/core/controlplane/config/encrypted_assets_test.go
@@ -155,7 +155,7 @@ func TestReadOrCreateCompactAssets(t *testing.T) {
 
 			files := []string{
 				"ca-key.pem.enc", "admin-key.pem.enc", "worker-key.pem.enc", "apiserver-key.pem.enc",
-				"etcd-key.pem.enc", "etcd-client-key.pem.enc",
+				"etcd-key.pem.enc", "etcd-client-key.pem.enc", "worker-ca-key.pem.enc",
 			}
 
 			for _, filename := range files {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -22,7 +22,7 @@ coreos:
     reboot-strategy: "off"
   flannel:
     interface: $private_ipv4
-    etcd_cafile: /etc/kubernetes/ssl/ca.pem
+    etcd_cafile: /etc/kubernetes/ssl/etcd-trusted-ca.pem
     etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
 
@@ -167,7 +167,7 @@ coreos:
             ExecStartPre=/opt/bin/decrypt-assets
             {{- end}}
             ExecStartPre=/usr/bin/etcdctl \
-            --ca-file=/etc/kubernetes/ssl/ca.pem \
+            --ca-file=/etc/kubernetes/ssl/etcd-trusted-ca.pem \
             --cert-file=/etc/kubernetes/ssl/etcd-client.pem \
             --key-file=/etc/kubernetes/ssl/etcd-client-key.pem \
             --endpoints="${ETCD_ENDPOINTS}" \
@@ -211,7 +211,7 @@ coreos:
         Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
         Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
         Environment="RKT_RUN_ARGS=--volume dns,kind=host,source=/etc/resolv.conf {{.HyperkubeImage.Options}}\
-        --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/ca.pem \
+        --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd-trusted-ca.pem \
         --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
         --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
         --mount volume=dns,target=/etc/resolv.conf \
@@ -237,7 +237,7 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/usr/bin/etcdctl \
-                       --ca-file /etc/kubernetes/ssl/ca.pem \
+                       --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
                        --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
                        --cert-file /etc/kubernetes/ssl/etcd-client.pem \
                        --endpoints "${ETCD_ENDPOINTS}" \
@@ -1044,7 +1044,7 @@ write_files:
     content: |
       #!/bin/bash -e
 
-      etcd_ca=$(cat /etc/kubernetes/ssl/ca.pem | base64 | tr -d '\n')
+      etcd_ca=$(cat /etc/kubernetes/ssl/etcd-trusted-ca.pem | base64 | tr -d '\n')
       etcd_key=$(cat /etc/kubernetes/ssl/etcd-client-key.pem | base64 | tr -d '\n')
       etcd_cert=$(cat /etc/kubernetes/ssl/etcd-client.pem | base64 | tr -d '\n')
 
@@ -1742,7 +1742,7 @@ write_files:
           - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .ControllerCount }}{{end}}
           - --bind-address=0.0.0.0
           - --etcd-servers=#ETCD_ENDPOINTS#
-          - --etcd-cafile=/etc/kubernetes/ssl/ca.pem
+          - --etcd-cafile=/etc/kubernetes/ssl/etcd-trusted-ca.pem
           - --etcd-certfile=/etc/kubernetes/ssl/etcd-client.pem
           - --etcd-keyfile=/etc/kubernetes/ssl/etcd-client-key.pem
           - --allow-privileged=true
@@ -1884,8 +1884,8 @@ write_files:
           - --service-account-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           {{ if .Experimental.TLSBootstrap.Enabled }}
           - --insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap
-          - --cluster-signing-cert-file=/etc/kubernetes/ssl/ca.pem
-          - --cluster-signing-key-file=/etc/kubernetes/ssl/ca-key.pem
+          - --cluster-signing-cert-file=/etc/kubernetes/ssl/worker-ca.pem
+          - --cluster-signing-key-file=/etc/kubernetes/ssl/worker-ca-key.pem
           {{ end }}
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
@@ -2677,9 +2677,9 @@ write_files:
     content: {{.AssetsConfig.CACert}}
 
 {{ if .Experimental.TLSBootstrap.Enabled }}
-  - path: /etc/kubernetes/ssl/ca-key.pem.enc
+  - path: /etc/kubernetes/ssl/worker-ca-key.pem.enc
     encoding: gzip+base64
-    content: {{.AssetsConfig.CAKey}}
+    content: {{.AssetsConfig.WorkerCAKey}}
 {{ end }}
 
   - path: /etc/kubernetes/ssl/apiserver.pem
@@ -2698,6 +2698,9 @@ write_files:
     encoding: gzip+base64
     content: {{.AssetsConfig.EtcdClientKey}}
 
+  - path: /etc/kubernetes/ssl/etcd-trusted-ca.pem
+    encoding: gzip+base64
+    content: {{.AssetsConfig.EtcdTrustedCA}}
 {{ end }}
 
   - path: /etc/kubernetes/controller-kubeconfig.yaml
@@ -2740,7 +2743,7 @@ write_files:
           "etcd_endpoints": "#ETCD_ENDPOINTS#",
           "etcd_key_file": "/etc/kubernetes/ssl/etcd-client-key.pem",
           "etcd_cert_file": "/etc/kubernetes/ssl/etcd-client.pem",
-          "etcd_ca_cert_file": "/etc/kubernetes/ssl/ca.pem",
+          "etcd_ca_cert_file": "/etc/kubernetes/ssl/etcd-trusted-ca.pem",
           "log_level": "info",
           "policy": {
             "type": "k8s",

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2672,7 +2672,7 @@ write_files:
 {{ end }}
 
 {{ if .ManageCertificates }}
-  - path: /etc/kubernetes/ssl/ca.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+  - path: /etc/kubernetes/ssl/ca.pem
     encoding: gzip+base64
     content: {{.AssetsConfig.CACert}}
 
@@ -2682,7 +2682,7 @@ write_files:
     content: {{.AssetsConfig.CAKey}}
 {{ end }}
 
-  - path: /etc/kubernetes/ssl/apiserver.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+  - path: /etc/kubernetes/ssl/apiserver.pem
     encoding: gzip+base64
     content: {{.AssetsConfig.APIServerCert}}
 
@@ -2690,7 +2690,7 @@ write_files:
     encoding: gzip+base64
     content: {{.AssetsConfig.APIServerKey}}
 
-  - path: /etc/kubernetes/ssl/etcd-client.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+  - path: /etc/kubernetes/ssl/etcd-client.pem
     encoding: gzip+base64
     content: {{.AssetsConfig.EtcdClientCert}}
 

--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -771,7 +771,7 @@ write_files:
 
 {{ if .ManageCertificates }}
 
-  - path: /etc/ssl/certs/ca.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+  - path: /etc/ssl/certs/ca.pem
     encoding: gzip+base64
     content: {{.AssetsConfig.CACert}}
 
@@ -779,11 +779,11 @@ write_files:
     encoding: gzip+base64
     content: {{.AssetsConfig.EtcdKey}}
 
-  - path: /etc/ssl/certs/etcd.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+  - path: /etc/ssl/certs/etcd.pem
     encoding: gzip+base64
     content: {{.AssetsConfig.EtcdCert}}
 
-  - path: /etc/ssl/certs/etcd-client.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+  - path: /etc/ssl/certs/etcd-client.pem
     encoding: gzip+base64
     content: {{.AssetsConfig.EtcdClientCert}}
 

--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -659,12 +659,12 @@ write_files:
 
       echo "KUBE_AWS_ASSUMED_HOSTNAME=$advertised_hostname
       ETCD_NAME=$name
-      ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/ca.pem
+      ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd-trusted-ca.pem
       ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd.pem
       ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd-key.pem
 
       ETCD_CLIENT_CERT_AUTH=true
-      ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/ca.pem
+      ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/etcd-trusted-ca.pem
       ETCD_CERT_FILE=/etc/ssl/certs/etcd.pem
       ETCD_KEY_FILE=/etc/ssl/certs/etcd-key.pem
 
@@ -727,7 +727,7 @@ write_files:
     content: |
       COREOS_PUBLIC_IPV4=$public_ipv4
       COREOS_PRIVATE_IPV4=$private_ipv4
-      ETCDCTL_CA_FILE=/etc/ssl/certs/ca.pem
+      ETCDCTL_CA_FILE=/etc/ssl/certs/etcd-trusted-ca.pem
       ETCDCTL_CERT_FILE=/etc/ssl/certs/etcd-client.pem
       ETCDCTL_KEY_FILE=/etc/ssl/certs/etcd-client-key.pem
       ETCDCTL_ENDPOINT=
@@ -771,9 +771,9 @@ write_files:
 
 {{ if .ManageCertificates }}
 
-  - path: /etc/ssl/certs/ca.pem
+  - path: /etc/ssl/certs/etcd-trusted-ca.pem
     encoding: gzip+base64
-    content: {{.AssetsConfig.CACert}}
+    content: {{.AssetsConfig.EtcdTrustedCA}}
 
   - path: /etc/ssl/certs/etcd-key.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
     encoding: gzip+base64

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -39,7 +39,7 @@ coreos:
     reboot-strategy: "off"
   flannel:
     interface: $private_ipv4
-    etcd_cafile: /etc/kubernetes/ssl/ca.pem
+    etcd_cafile: /etc/kubernetes/ssl/etcd-trusted-ca.pem
     etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
 
@@ -236,7 +236,7 @@ coreos:
         Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
         Environment=KUBELET_IMAGE_URL={{.HyperkubeImage.RktRepoWithoutTag}}
         Environment="RKT_RUN_ARGS=--volume dns,kind=host,source=/etc/resolv.conf {{.HyperkubeImage.Options}}\
-        --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/ca.pem \
+        --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd-trusted-ca.pem \
         --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
         --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
         --mount volume=dns,target=/etc/resolv.conf \
@@ -261,7 +261,7 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /etc/kubernetes/cni/net.d/  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
         ExecStartPre=/usr/bin/etcdctl \
-                       --ca-file /etc/kubernetes/ssl/ca.pem \
+                       --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
                        --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
                        --cert-file /etc/kubernetes/ssl/etcd-client.pem \
                        --endpoints "${ETCD_ENDPOINTS}" \
@@ -728,6 +728,10 @@ write_files:
     encoding: gzip+base64
     content: {{.AssetsConfig.EtcdClientKey}}
 
+  - path: /etc/kubernetes/ssl/etcd-trusted-ca.pem
+    encoding: gzip+base64
+    content: {{.AssetsConfig.EtcdTrustedCA}}
+
 {{ if not .Experimental.TLSBootstrap.Enabled }}
   - path: /etc/kubernetes/ssl/worker.pem
     encoding: gzip+base64
@@ -989,7 +993,7 @@ write_files:
           "etcd_endpoints": "#ETCD_ENDPOINTS#",
           "etcd_key_file": "/etc/kubernetes/ssl/etcd-client-key.pem",
           "etcd_cert_file": "/etc/kubernetes/ssl/etcd-client.pem",
-          "etcd_ca_cert_file": "/etc/kubernetes/ssl/ca.pem",
+          "etcd_ca_cert_file": "/etc/kubernetes/ssl/etcd-trusted-ca.pem",
           "log_level": "info",
           "policy": {
             "type": "k8s",

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -720,7 +720,7 @@ write_files:
 
 {{ if .ManageCertificates }}
 
-  - path: /etc/kubernetes/ssl/etcd-client.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+  - path: /etc/kubernetes/ssl/etcd-client.pem
     encoding: gzip+base64
     content: {{.AssetsConfig.EtcdClientCert}}
 
@@ -729,7 +729,7 @@ write_files:
     content: {{.AssetsConfig.EtcdClientKey}}
 
 {{ if not .Experimental.TLSBootstrap.Enabled }}
-  - path: /etc/kubernetes/ssl/worker.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+  - path: /etc/kubernetes/ssl/worker.pem
     encoding: gzip+base64
     content: {{.AssetsConfig.WorkerCert}}
 
@@ -738,7 +738,7 @@ write_files:
     content: {{.AssetsConfig.WorkerKey}}
 {{ end }}
 
-  - path: /etc/kubernetes/ssl/ca.pem{{if .AssetsEncryptionEnabled}}.enc{{end}}
+  - path: /etc/kubernetes/ssl/ca.pem
     encoding: gzip+base64
     content: {{.AssetsConfig.CACert}}
 


### PR DESCRIPTION
TLSBootstap CA is now loaded from worker-ca.pem
Etcd trusted CA bundle is now loaded from etcd-trusted-ca.pem

Both files by default are symlinks to a well known ca.pem

This change enables advanced, more secure setup, where certificates
stored on worker nodes are trusted only by APIserver and NOT
Etcd server. This kind of setup is not yet supported by
"kube-aws render credentials" command out of the box, and
therefore currently requires users to be generating and
encrypting certs on their own to benefit from it.

Depends on  https://github.com/kubernetes-incubator/kube-aws/pull/882
