### PR TITLE
Enable RBAC by default

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -93,7 +93,7 @@ func NewDefaultCluster() *Cluster {
 		},
 		Plugins: Plugins{
 			Rbac: Rbac{
-				Enabled: false,
+				Enabled: true,
 			},
 		},
 		Oidc: model.Oidc{

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -91,11 +91,7 @@ func NewDefaultCluster() *Cluster {
 			Enabled:      false,
 			DrainTimeout: 5,
 		},
-		Plugins: Plugins{
-			Rbac: Rbac{
-				Enabled: true,
-			},
-		},
+		Plugins: Plugins{},
 		Oidc: model.Oidc{
 			Enabled:       false,
 			IssuerUrl:     "https://accounts.google.com",
@@ -651,11 +647,6 @@ type TargetGroup struct {
 }
 
 type Plugins struct {
-	Rbac Rbac `yaml:"rbac"`
-}
-
-type Rbac struct {
-	Enabled bool `yaml:"enabled"`
 }
 
 type KubeDns struct {
@@ -853,10 +844,6 @@ func (c Cluster) StackConfig(opts StackTemplateOptions, extra ...[]*pluginmodel.
 		}
 
 		stackConfig.Config.AssetsConfig = rawAssets
-	}
-
-	if c.Experimental.TLSBootstrap.Enabled && !c.Experimental.Plugins.Rbac.Enabled {
-		fmt.Println(`WARNING: enabling cluster-level TLS bootstrapping without RBAC is not recommended. See https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/ for more information`)
 	}
 
 	stackConfig.StackTemplateOptions = opts
@@ -1095,10 +1082,6 @@ func (c Cluster) validate() error {
 	if c.Experimental.NodeAuthorizer.Enabled {
 		if !c.Experimental.TLSBootstrap.Enabled {
 			return fmt.Errorf("TLS bootstrap is required in order to enable the node authorizer")
-		}
-
-		if !c.Experimental.Plugins.Rbac.Enabled {
-			return fmt.Errorf("RBAC is required in order to enable the node authorizer")
 		}
 	}
 

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -835,6 +835,18 @@ experimental:
     enabled: true
   tlsBootstrap:
     enabled: true
+`,
+			nodeAuthorizer: NodeAuthorizer{
+				Enabled: true,
+			},
+		},
+		{
+			conf: `
+experimental:
+  nodeAuthorizer:
+    enabled: true
+  tlsBootstrap:
+    enabled: true
   plugins:
     rbac:
       enabled: true
@@ -859,14 +871,6 @@ experimental:
     enabled: true
   tlsBootstrap:
     enabled: false
-`,
-		`
-# RBAC must be enabled as well
-experimental:
-  nodeAuthorizer:
-    enabled: true
-  tlsBootstrap:
-    enabled: true
 `,
 		`
 # RBAC must be enabled as well

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -840,50 +840,23 @@ experimental:
 				Enabled: true,
 			},
 		},
-		{
-			conf: `
-experimental:
-  nodeAuthorizer:
-    enabled: true
-  tlsBootstrap:
-    enabled: true
-  plugins:
-    rbac:
-      enabled: true
-`,
-			nodeAuthorizer: NodeAuthorizer{
-				Enabled: true,
-			},
-		},
 	}
 
 	invalidConfigs := []string{
 		`
-# TLS bootstrap + RBAC must be enabled as well
+# TLS bootstrap must be enabled as well
 experimental:
   nodeAuthorizer:
     enabled: true
 `,
 		`
-# TLS bootstrap + RBAC must be enabled as well
+# TLS bootstrap must be enabled as well
 experimental:
   nodeAuthorizer:
     enabled: true
   tlsBootstrap:
     enabled: false
-`,
-		`
-# RBAC must be enabled as well
-experimental:
-  nodeAuthorizer:
-    enabled: true
-  tlsBootstrap:
-    enabled: true
-  plugins:
-    rbac:
-      enabled: false
-`,
-	}
+`}
 
 	for _, conf := range validConfigs {
 		confBody := singleAzConfigYaml + conf.conf

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -770,7 +770,6 @@ write_files:
       kubectl apply -f "${mfdir}/kube-rescheduler-de.yaml"
       {{- end }}
 
-      {{if .Experimental.Plugins.Rbac.Enabled}}
       mfdir=/srv/kubernetes/rbac
 
       # Cluster roles and bindings
@@ -798,13 +797,10 @@ write_files:
           kubectl apply -f "${mfdir}/cluster-role-bindings/$manifest.yaml"
       done
       {{ end }}
-      {{ end }}
 
       {{if .Experimental.Kube2IamSupport.Enabled }}
         mfdir=/srv/kubernetes/manifests
-       {{if .Experimental.Plugins.Rbac.Enabled}}
         kubectl apply -f "${mfdir}/kube2iam-rbac.yaml"
-       {{end}}
         kubectl apply -f "${mfdir}/kube2iam-ds.yaml";
       {{ end }}
 
@@ -1415,7 +1411,6 @@ write_files:
                       optional: true
 {{end}}
 
-{{if .Experimental.Plugins.Rbac.Enabled }}
   # TODO: remove the following binding once the TLS Bootstrapping feature is enabled by default, see:
   # https://github.com/kubernetes-incubator/kube-aws/pull/618#discussion_r115162048
   # https://kubernetes.io/docs/admin/authorization/rbac/#core-component-roles
@@ -1682,7 +1677,6 @@ write_files:
           name: kube-aws:node-bootstrapper
           apiGroup: rbac.authorization.k8s.io
 {{ end }}
-{{ end }}
 
   - path: /etc/kubernetes/manifests/kube-proxy.yaml
     content: |
@@ -1762,9 +1756,7 @@ write_files:
           - --audit-log-path={{.Experimental.AuditLog.LogPath}}
           - --audit-log-maxbackup=1
           {{ end }}
-          {{if .Experimental.Plugins.Rbac.Enabled}}
           - --authorization-mode={{if .Experimental.NodeAuthorizer.Enabled}}Node,{{end}}RBAC
-          {{ end }}
           {{if .Experimental.Authentication.Webhook.Enabled}}
           - --authentication-token-webhook-config-file=/etc/kubernetes/webhooks/authentication.yaml
           - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
@@ -1787,7 +1779,7 @@ write_files:
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1{{if .Experimental.Plugins.Rbac.Enabled}},rbac.authorization.k8s.io/v1beta1=true{{ end }}{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},extensions/v1beta1/podsecuritypolicy=true{{ end }}
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1,rbac.authorization.k8s.io/v1beta1=true{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},extensions/v1beta1/podsecuritypolicy=true{{ end }}
           - --cloud-provider=aws
           {{range $f := .APIServerFlags}}
           - --{{$f.Name}}={{$f.Value}}
@@ -2792,9 +2784,7 @@ write_files:
             labels:
               name: kube2iam
           spec:
-            {{- if .Experimental.Plugins.Rbac.Enabled}}
             serviceAccountName: kube2iam
-            {{- end}}
             hostNetwork: true
             tolerations:
             - operator: Exists
@@ -2835,7 +2825,6 @@ write_files:
                     memory: 32Mi
                 securityContext:
                   privileged: true
-  {{if .Experimental.Plugins.Rbac.Enabled}}
   - path: /srv/kubernetes/manifests/kube2iam-rbac.yaml
     content: |
       apiVersion: v1
@@ -2877,7 +2866,6 @@ write_files:
       - kind: ServiceAccount
         name: kube2iam
         namespace: kube-system
-  {{end}}
 {{end}}
 
   - path: /opt/bin/retry

--- a/e2e/run
+++ b/e2e/run
@@ -282,13 +282,6 @@ experimental:
   fi
 
 
-  if [ "${RBAC}" != "" ]; then
-    echo -e "
-  plugins:
-    rbac:
-      enabled: true" >> cluster.yaml
-  fi
-
   echo -e "
 addons:
   clusterAutoscaler:

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -131,6 +131,11 @@ func TestMainClusterConfig(t *testing.T) {
 				Enabled:      false,
 				DrainTimeout: 5,
 			},
+			Plugins: controlplane_config.Plugins{
+				Rbac: controlplane_config.Rbac{
+					Enabled: true,
+				},
+			},
 		}
 
 		actual := c.Experimental

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -131,11 +131,7 @@ func TestMainClusterConfig(t *testing.T) {
 				Enabled:      false,
 				DrainTimeout: 5,
 			},
-			Plugins: controlplane_config.Plugins{
-				Rbac: controlplane_config.Rbac{
-					Enabled: true,
-				},
-			},
+			Plugins: controlplane_config.Plugins{},
 		}
 
 		actual := c.Experimental
@@ -1296,11 +1292,7 @@ worker:
 							Enabled:      true,
 							DrainTimeout: 3,
 						},
-						Plugins: controlplane_config.Plugins{
-							Rbac: controlplane_config.Rbac{
-								Enabled: true,
-							},
-						},
+						Plugins: controlplane_config.Plugins{},
 					}
 
 					actual := c.Experimental


### PR DESCRIPTION
Resolves #655

**Release note**:

* If you had never enabled RBAC before, you might have not configured appropriate cluster role/role binding/service account for your apps. It is strongly recommended to do so before upgrading your cluster or otherwise your apps may fail due to missing RBAC permissions.
* Although it isn't recommended for security, you can also retain the existing behavior that all the service accounts have all the permissions by running the following command to create permissive RBAC permissions:
  ```
  kubectl create clusterrolebinding permissive-binding \
    --clusterrole=cluster-admin \
    --user=admin \
    --user=kubelet \
    --group=system:serviceaccounts
  ```
