### PR TITLE
Add spot fleet support for the `awsNodeLabels` feature

### DIFF
--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -455,6 +455,7 @@ coreos:
         ExecStop=/bin/true
         ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)"
         ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment SECURITY_GROUPS=\"$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')\""
+        {{if not .SpotFleet.Enabled -}}
         ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment AUTOSCALINGGROUP=\"$(/usr/bin/docker run --rm --net=host \
           {{.AWSCliImage.RepoWithTag}} aws \
           autoscaling describe-auto-scaling-instances \
@@ -466,20 +467,25 @@ coreos:
           aws autoscaling describe-auto-scaling-groups \
           --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
           --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)\""
+        {{end -}}
         ExecStart=/usr/bin/docker run --rm -t --net=host \
           -v /etc/kubernetes:/etc/kubernetes \
           -v /etc/resolv.conf:/etc/resolv.conf \
           -e INSTANCE_ID=${INSTANCE_ID} \
           -e SECURITY_GROUPS=${SECURITY_GROUPS} \
+          {{if not .SpotFleet.Enabled -}}
           -e AUTOSCALINGGROUP=${AUTOSCALINGGROUP} \
           -e LAUNCHCONFIGURATION=${LAUNCHCONFIGURATION} \
+          {{end -}}
           {{.HyperkubeImage.RepoWithTag}} /bin/bash \
             -ec 'echo "placing labels and annotations with additional AWS parameters."; \
              kctl="/kubectl --server={{.APIEndpointURL}}:443 --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml"; \
              kctl_label="$kctl label --overwrite nodes/$(hostname)"; \
              kctl_annotate="$kctl annotate --overwrite nodes/$(hostname)"; \
+             {{if not .SpotFleet.Enabled -}}
              $kctl_label kube-aws.coreos.com/autoscalinggroup=${AUTOSCALINGGROUP}; \
              $kctl_label kube-aws.coreos.com/launchconfiguration=${LAUNCHCONFIGURATION}; \
+             {{end -}}
              $kctl_annotate kube-aws.coreos.com/securitygroups=${SECURITY_GROUPS}; \
              echo "done."'
 {{end}}


### PR DESCRIPTION
Resolves #803

This is verified to work by seeing the appropriate annotation added on a worker node powered by a spot instance:

```
Annotations:		kube-aws.coreos.com/securitygroups=k8s72-Controlplane-1P1L3VDQ165MB-SecurityGroupWorker-Y3OMIAZXMEHQ
			node.alpha.kubernetes.io/ttl=0
			volumes.kubernetes.io/controller-managed-attach-detach=true
```
