### PR TITLE
Fix the scheduling and permissions issue of CA

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -64,7 +64,7 @@ func NewDefaultCluster() *Cluster {
 			Enabled: false,
 		},
 		ClusterAutoscalerSupport: model.ClusterAutoscalerSupport{
-			Enabled: false,
+			Enabled: true,
 		},
 		TLSBootstrap: TLSBootstrap{
 			Enabled: false,

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -233,7 +233,7 @@
                   "Resource": [ "*" ]
                 },
                 {{end}}
-                {{if .Addons.ClusterAutoscaler.Enabled}}
+                {{if (and .Addons.ClusterAutoscaler.Enabled .Experimental.ClusterAutoscalerSupport.Enabled) }}
                 {
                   "Action": [
                     "autoscaling:DescribeAutoScalingGroups",

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -163,6 +163,12 @@ func (c *ProvidedConfig) Load(main *cfg.Config) error {
 	c.Experimental.TLSBootstrap = main.DeploymentSettings.Experimental.TLSBootstrap
 	c.Experimental.NodeDrainer = main.DeploymentSettings.Experimental.NodeDrainer
 
+	if c.Experimental.ClusterAutoscalerSupport.Enabled {
+		if !main.Addons.ClusterAutoscaler.Enabled {
+			return fmt.Errorf("clusterAutoscalerSupport can't be enabled on node pools when cluster-autoscaler is not going to be deployed to the cluster")
+		}
+	}
+
 	// Validate whole the inputs including inherited ones
 	if err := c.validate(); err != nil {
 		return err

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -379,7 +379,7 @@
                   "Resource": [ "*" ]
                 },
                 {{end}}
-                {{if .Addons.ClusterAutoscaler.Enabled}}
+                {{if .ClusterAutoscalerSupport.Enabled}}
                 {
                   "Action": [
                     "autoscaling:DescribeAutoScalingGroups",

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -104,7 +104,7 @@ func TestMainClusterConfig(t *testing.T) {
 				Enabled: false,
 			},
 			ClusterAutoscalerSupport: model.ClusterAutoscalerSupport{
-				Enabled: false,
+				Enabled: true,
 			},
 			TLSBootstrap: controlplane_config.TLSBootstrap{
 				Enabled: false,
@@ -145,6 +145,10 @@ func TestMainClusterConfig(t *testing.T) {
 
 		if c.WaitSignal.MaxBatchSize() != 1 {
 			t.Errorf("waitSignal.maxBatchSize should be 1 but was %d: %v", c.WaitSignal.MaxBatchSize(), c.WaitSignal)
+		}
+
+		if len(c.NodePools) > 0 && c.NodePools[0].ClusterAutoscalerSupport.Enabled {
+			t.Errorf("ClusterAutoscalerSupport must be disabled by default on node pools")
 		}
 	}
 
@@ -1256,7 +1260,7 @@ worker:
 							Enabled: true,
 						},
 						ClusterAutoscalerSupport: model.ClusterAutoscalerSupport{
-							Enabled: false,
+							Enabled: true,
 						},
 						TLSBootstrap: controlplane_config.TLSBootstrap{
 							Enabled: true,
@@ -1317,6 +1321,9 @@ worker:
 		{
 			context: "WithExperimentalFeaturesForWorkerNodePool",
 			configYaml: minimalValidConfigYaml + `
+addons:
+  clusterAutoscaler:
+    enabled: true
 worker:
   nodePools:
   - name: pool1


### PR DESCRIPTION
by fixing the conditional in stack-template.json for worker and controller stacks, while making configuration easier.

Resolves #897

## Context

The intended way of enabling cluster-autoscaler on your cluster has been to:

1. Set `addons.clusterAutoscaler.enabled` to `true`
2. Set `experimental.clusterAutoscalerSupport.enabled` to `true` to allow CA to be run on controller nodes, while providing appropriate IAM permissions to the controller nodes
3. Set `worker.nodePools[].clusterAutoscalerSupport.enabled` to `true` to allow CA to be run on worker nodes, while providing appropriate IAM permissions to the worker nodes
4. Finally, set `worker.nodePools[].autoscaling.clusterAutoscaler.enabled` to `true` for registering the node pool(s) as the scaling targets

Note that:

* 1. is required in order to deploy CA on your cluster.
* 2. and/or 3. is required to actually allow scheduling CA to any node
* 4. is required to instruct CA to start auto-scaling. Btw, missing this step had been resulted in #800 before.

## The fix

`worker.nodePools[].clusterAutoscalerSupport.enabled` has been configured CA to run on worker nodes, certainly. However, it was not providing required IAM permissions to the worker nodes.
More concretely, you had to set `worker.nodePools[].addons.clusterAutoscaler.enabled` instead and that's not an expected way of configuring things. This is now fixed.

#897 is considered to be affected by this.

## The easier configuration

To make this process easier, `experimental.clusterAutoscalerSupport.enabled` is now set to `true` by default.
This way, 2. and 3. can be completely omitted when you don't mind on which node CA runs.

A validation to prevent a misconfiguration is also added.
