### PR TITLE
Remove `createRecordSet` to help newcomers bring up their first clusters

### DIFF
--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -300,10 +300,11 @@ type r53Service interface {
 	GetHostedZone(*route53.GetHostedZoneInput) (*route53.GetHostedZoneOutput, error)
 }
 
+// TODO validateDNSConfig seems to be called from nowhere but should be called while validating `apiEndpoints` config
 func (c *ClusterRef) validateDNSConfig(r53 r53Service) error {
-	if !c.CreateRecordSet {
-		return nil
-	}
+	//if !c.CreateRecordSet {
+	//	return nil
+	//}
 
 	hzOut, err := r53.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(c.HostedZoneID)})
 	if err != nil {

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -179,7 +179,6 @@ func NewDefaultCluster() *Cluster {
 		// for base cloudformation stack
 		TLSCADurationDays:           365 * 10,
 		TLSCertDurationDays:         365,
-		CreateRecordSet:             false,
 		RecordSetTTL:                300,
 		SSHAccessAllowedSourceCIDRs: model.DefaultCIDRRanges(),
 		CustomSettings:              make(map[string]interface{}),
@@ -264,7 +263,6 @@ func (c *Cluster) Load() error {
 			c.ExternalDNSName,
 			subnetRefs,
 			c.HostedZoneID,
-			c.CreateRecordSet,
 			c.RecordSetTTL,
 			c.Controller.LoadBalancer.Private,
 		)
@@ -503,7 +501,6 @@ type Cluster struct {
 	FlannelSettings        `yaml:",inline"`
 	AdminAPIEndpointName   string              `yaml:"adminAPIEndpointName,omitempty"`
 	ServiceCIDR            string              `yaml:"serviceCIDR,omitempty"`
-	CreateRecordSet        bool                `yaml:"createRecordSet,omitempty"`
 	RecordSetTTL           int                 `yaml:"recordSetTTL,omitempty"`
 	TLSCADurationDays      int                 `yaml:"tlsCADurationDays,omitempty"`
 	TLSCertDurationDays    int                 `yaml:"tlsCertDurationDays,omitempty"`
@@ -961,28 +958,6 @@ func (c Cluster) validate() error {
 	validClusterNaming := regexp.MustCompile("^[a-zA-Z0-9-:]+$")
 	if !validClusterNaming.MatchString(c.ClusterName) {
 		return fmt.Errorf("clusterName(=%s) is malformed. It must consist only of alphanumeric characters, colons, or hyphens", c.ClusterName)
-	}
-
-	if c.CreateRecordSet {
-		if c.HostedZoneID == "" {
-			return errors.New("hostedZoneID must be specified when createRecordSet is true")
-		}
-
-		if c.RecordSetTTL < 1 {
-			return errors.New("TTL must be at least 1 second")
-		}
-	} else {
-		if c.RecordSetTTL != NewDefaultCluster().RecordSetTTL {
-			return errors.New(
-				"recordSetTTL should not be modified when createRecordSet is false",
-			)
-		}
-
-		if c.HostedZoneID != "" {
-			return errors.New(
-				"hostedZoneId should not be modified when createRecordSet is false",
-			)
-		}
 	}
 
 	var dnsServiceIPAddr net.IP

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -847,6 +847,18 @@ func (c Cluster) StackConfig(opts StackTemplateOptions, extra ...[]*pluginmodel.
 	return &stackConfig, nil
 }
 
+type InitialConfig struct {
+	AmiId            string
+	AvailabilityZone string
+	ClusterName      string
+	ExternalDNSName  string
+	HostedZoneID     string
+	KMSKeyARN        string
+	KeyName          string
+	NoRecordSet      bool
+	Region           model.Region
+}
+
 // Config contains configuration parameters available when rendering userdata injected into a controller or an etcd node from golang text templates
 type Config struct {
 	Cluster

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -104,23 +104,46 @@ dnsServiceIP: 172.6.100.101 #dnsServiceIP not in service CIDR
 `, `
 routeTableId: rtb-xxxxxx # routeTableId specified without vpcId
 `, `
-# invalid TTL
-recordSetTTL: 0
+# hostedZone.id shouldn't be blank when recordSetManaged is true
+apiEndpoints:
+- name: public
+  loadBalancer:
+    hostedZone:
+      id:
+    recordSetManaged: true
+
 `, `
-# hostedZone and hostedZoneID shouldn't be blank when createRecordSet is true
-createRecordSet: true
+# hostedZone.id shouldn't be blank when recordSetManaged is true(=default)
+apiEndpoints:
+- name: public
+  loadBalancer:
+    hostedZone:
+      id:
 `, `
-# recordSetTTL shouldn't be modified when createRecordSet is false
-createRecordSet: false
-recordSetTTL: 400
+# recordSetTTL shouldn't be modified when you're going to manage the hostname yourself(=hostedZone.id is nil and recordSetManaged is false)
+apiEndpoints:
+- name: public
+  loadBalancer:
+    hostedZone:
+      id:
+    recordSetManaged: false
+    recordSetTTL: 400
 `, `
-# hostedZoneId should'nt be modified when createRecordSet is false
-createRecordSet: false
-hostedZoneId: /hostedzone/staging_id_2 #hostedZone and hostedZoneId defined
+# hostedZoneId should'nt be modified when recordSetManaged is false
+apiEndpoints:
+- name: public
+  loadBalancer:
+    hostedZone:
+      id: hostedzone-xxxxxx
+    recordSetManaged: false
 `, `
-# hostedZone had been deprecated and then dropped
-createRecordSet: true
-hostedZone: "staging.core-os.net"
+# recordSetTTL should be greater than zero
+apiEndpoints:
+- name: public
+  loadBalancer:
+    hostedZone:
+      id: hostedzone-xxxxxx
+    recordSetTTL: 0
 `,
 }
 

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -52,13 +52,6 @@ apiEndpoints:
     # Also, don't forget to add controller.securityGroupIds to include a glue SG to allow your existing ELB to access controller nodes created by kube-aws
     #id: existing-elb
 
-    # Set to true when you want kube-aws to create a Route53 ALIAS record set for this API load balancer for you
-    # Must be omitted when `id` is specified
-    {{if .HostedZoneID -}}
-    createRecordSet: true
-    {{else -}}
-    createRecordSet: false
-    {{- end}}
     # All the subnets assigned to this load-balancer. Specified only when this load balancer is not reused but managed one
     # Must be omitted when `id` is specified
     #subnets:
@@ -67,13 +60,17 @@ apiEndpoints:
     # Set to true so that the managed ELB becomes an `internal` one rather than `internet-facing` one
     # When set to true while subnets are omitted, one or more private subnets in the top-level `subnets` must exist
     # Must be omitted when `id` is specified
-    #private: false
+    private: false
 
-    # TTL in seconds for the Route53 RecordSet created if createRecordSet is set to true.
+    # TTL in seconds for the Route53 RecordSet created if hostedZone.id is set to a non-nil value.
     #recordSetTTL: 300
 
     # The Route 53 hosted zone is where the resulting Alias record is created for this endpoint
-    # Must be omitted when `id` is specified
+    #
+    # Omitting hostedZone.id implies you must configure Route 53 hosted zone and record set or your own DNS so that worker nodes
+    # are able to resolve DNS names of this API endpoint.
+    #
+    # Must be omitted when `id` is specified because kube-aws doesn't deal with the existing ELB by design
     {{if .HostedZoneID -}}
     hostedZone:
       # The ID of hosted zone to add the dnsName to.
@@ -116,6 +113,18 @@ apiEndpoints:
 #  #
 #  - name: extra
 #    dnsName: youralias.example.com
+#    loadBalancer:
+#      managed: false
+#
+#  #
+#  # Uncommon configuration #1: Managed, internet-facing API endpoint, without a Route53 record set
+#  #
+#  - name: elbOnly
+#    dnsName: youralias.example.com
+#    loadBalancer:
+#      # Setting this to false allows you to omit hostedZone.id and hence the creation of Route53 record set is skipped
+#      recordSetManaged: false
+#
 
 # Name of the SSH keypair already loaded into the AWS
 # account being used to deploy this cluster.

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -60,10 +60,14 @@ apiEndpoints:
     # Set to true so that the managed ELB becomes an `internal` one rather than `internet-facing` one
     # When set to true while subnets are omitted, one or more private subnets in the top-level `subnets` must exist
     # Must be omitted when `id` is specified
-    private: false
+    #private: false
 
     # TTL in seconds for the Route53 RecordSet created if hostedZone.id is set to a non-nil value.
     #recordSetTTL: 300
+
+    {{if .NoRecordSet -}}
+    recordSetManaged: false
+    {{- end}}
 
     # The Route 53 hosted zone is where the resulting Alias record is created for this endpoint
     #

--- a/core/nodepool/cluster/cluster_test.go
+++ b/core/nodepool/cluster/cluster_test.go
@@ -88,7 +88,12 @@ func (svc dummyEC2DescribeKeyPairsService) DescribeKeyPairs(input *ec2.DescribeK
 
 func TestValidateKeyPair(t *testing.T) {
 	main, err := controlplane.ConfigFromBytes([]byte(`clusterName: test-cluster
-externalDNSName: test-cluster.example.com
+apiEndpoints:
+- name: public
+  dnsName: test-cluster.example.com
+  loadBalancer:
+    hostedZone:
+      id: hostedzone-xxxx
 keyName: mykey
 kmsKeyArn: mykeyarn
 region: us-west-1
@@ -123,7 +128,11 @@ const minimalYaml = `name: pool1
 
 func TestValidateWorkerRootVolume(t *testing.T) {
 	main, err := controlplane.ConfigFromBytes([]byte(`clusterName: test-cluster
-externalDNSName: test-cluster.example.com
+apiEndpoints:
+- name: public
+  dnsName: test-cluster.example.com
+  loadBalancer:
+    recordSetManaged: false
 keyName: mykey
 kmsKeyArn: mykeyarn
 region: us-west-1
@@ -204,7 +213,11 @@ rootVolume:
 
 func TestStackUploadsAndCreation(t *testing.T) {
 	mainConfigBody := `
-externalDNSName: test.staging.core-os.net
+apiEndpoints:
+- name: public
+  dnsName: test.staging.core-os.net
+  loadBalancer:
+    recordSetManaged: false
 keyName: test-key-name
 region: us-west-1
 clusterName: test-cluster-name

--- a/model/api_endpoints.go
+++ b/model/api_endpoints.go
@@ -10,7 +10,7 @@ type APIEndpoints []APIEndpoint
 const DefaultAPIEndpointName = "Default"
 
 // NewDefaultAPIEndpoints creates the slice of API endpoints containing only the default one which is with arbitrary DNS name and an ELB
-func NewDefaultAPIEndpoints(dnsName string, subnets []SubnetReference, hostedZoneId string, createRecordSet bool, recordSetTTL int, private bool) APIEndpoints {
+func NewDefaultAPIEndpoints(dnsName string, subnets []SubnetReference, hostedZoneId string, recordSetTTL int, private bool) APIEndpoints {
 	return []APIEndpoint{
 		APIEndpoint{
 			Name:    DefaultAPIEndpointName,
@@ -23,7 +23,6 @@ func NewDefaultAPIEndpoints(dnsName string, subnets []SubnetReference, hostedZon
 						ID: hostedZoneId,
 					},
 				},
-				CreateRecordSet:       &createRecordSet,
 				RecordSetTTLSpecified: &recordSetTTL,
 				PrivateSpecified:      &private,
 			},

--- a/test/integration/aws_test.go
+++ b/test/integration/aws_test.go
@@ -76,7 +76,12 @@ func newKubeAwsSettingsFromEnv(t *testing.T) kubeAwsSettings {
 
 func (s kubeAwsSettings) mainClusterYaml() string {
 	return fmt.Sprintf(`clusterName: %s
-externalDNSName: "%s"
+apiEndpoints:
+- name: public
+  dnsName: "%s"
+  loadBalancer:
+    hostedZone:
+      id: hostedzone-xxxx
 keyName: "%s"
 kmsKeyArn: "%s"
 region: "%s"
@@ -89,7 +94,7 @@ region: "%s"
 	)
 }
 
-func (s kubeAwsSettings) mainClusterYamlWithoutExternalDNS() string {
+func (s kubeAwsSettings) mainClusterYamlWithoutAPIEndpoint() string {
 	return fmt.Sprintf(`clusterName: %s
 keyName: "%s"
 kmsKeyArn: "%s"
@@ -107,9 +112,15 @@ func (s kubeAwsSettings) minimumValidClusterYaml() string {
 }
 
 func (s kubeAwsSettings) minimumValidClusterYamlWithAZ(suffix string) string {
-	return s.mainClusterYaml() + fmt.Sprintf(`
+	return s.mainClusterYamlWithoutAPIEndpoint() + fmt.Sprintf(`
 availabilityZone: %s
-`, s.region+suffix)
+apiEndpoints:
+- name: public
+  dnsName: "%s"
+  loadBalancer:
+    hostedZone:
+      id: hostedzone-xxxx
+`, s.region+suffix, s.externalDNSName)
 }
 
 func (s kubeAwsSettings) withClusterName(n string) kubeAwsSettings {

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -39,8 +39,10 @@ func TestMainClusterConfig(t *testing.T) {
 		t.FailNow()
 	}
 
+	firstAz := kubeAwsSettings.region + "c"
+
 	hasDefaultEtcdSettings := func(c *config.Config, t *testing.T) {
-		subnet1 := model.NewPublicSubnet("us-west-1c", "10.0.0.0/24")
+		subnet1 := model.NewPublicSubnet(firstAz, "10.0.0.0/24")
 		subnet1.Name = "Subnet0"
 		expected := controlplane_config.EtcdSettings{
 			Etcd: model.Etcd{
@@ -380,10 +382,9 @@ func TestMainClusterConfig(t *testing.T) {
 	}
 
 	mainClusterYaml := kubeAwsSettings.mainClusterYaml()
-	minimalValidConfigYaml := mainClusterYaml + `
-availabilityZone: us-west-1c
-`
-	configYamlWithoutExernalDNSName := kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+	minimalValidConfigYaml := kubeAwsSettings.minimumValidClusterYamlWithAZ("c")
+
+	configYamlWithoutExernalDNSName := kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 availabilityZone: us-west-1c
 `
 
@@ -507,27 +508,6 @@ apiEndpoints:
 					expected := "0.0.0.0/0"
 					if actual != expected {
 						t.Errorf("unexpected cidr in apiEndpoints[0].loadBalancer.apiAccessAllowedSourceCIDRs[0]. expected = %s, actual = %s", expected, actual)
-					}
-				},
-			},
-		},
-		{
-			context: "WithAPIEndpointLBAPIAccessAllowedSourceCIDRsEmptied",
-			configYaml: configYamlWithoutExernalDNSName + `
-apiEndpoints:
-- name: default
-  dnsName: k8s.example.com
-  loadBalancer:
-    apiAccessAllowedSourceCIDRs:
-    hostedZone:
-      id: a1b2c4
-`,
-			assertConfig: []ConfigTester{
-				func(c *config.Config, t *testing.T) {
-					l := len(c.APIEndpointConfigs[0].LoadBalancer.APIAccessAllowedSourceCIDRs)
-					if l != 0 {
-						t.Errorf("unexpected size of apiEndpoints[0].loadBalancer.apiAccessAllowedSourceCIDRs: %d", l)
-						t.FailNow()
 					}
 				},
 			},
@@ -696,7 +676,7 @@ etcd:
 `,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
-					subnet1 := model.NewPublicSubnet("us-west-1c", "10.0.0.0/24")
+					subnet1 := model.NewPublicSubnet(firstAz, "10.0.0.0/24")
 					subnet1.Name = "Subnet0"
 					expected := controlplane_config.EtcdSettings{
 						Etcd: model.Etcd{
@@ -753,7 +733,7 @@ etcd:
 `,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
-					subnet1 := model.NewPublicSubnet("us-west-1c", "10.0.0.0/24")
+					subnet1 := model.NewPublicSubnet(firstAz, "10.0.0.0/24")
 					subnet1.Name = "Subnet0"
 					expected := controlplane_config.EtcdSettings{
 						Etcd: model.Etcd{
@@ -811,7 +791,7 @@ etcd:
 `,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
-					subnet1 := model.NewPublicSubnet("us-west-1c", "10.0.0.0/24")
+					subnet1 := model.NewPublicSubnet(firstAz, "10.0.0.0/24")
 					subnet1.Name = "Subnet0"
 					expected := controlplane_config.EtcdSettings{
 						Etcd: model.Etcd{
@@ -873,7 +853,7 @@ etcd:
 `,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
-					subnet1 := model.NewPublicSubnet("us-west-1c", "10.0.0.0/24")
+					subnet1 := model.NewPublicSubnet(firstAz, "10.0.0.0/24")
 					subnet1.Name = "Subnet0"
 					expected := controlplane_config.EtcdSettings{
 						Etcd: model.Etcd{
@@ -947,7 +927,7 @@ etcd:
 `,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
-					subnet1 := model.NewPublicSubnet("us-west-1c", "10.0.0.0/24")
+					subnet1 := model.NewPublicSubnet(firstAz, "10.0.0.0/24")
 					subnet1.Name = "Subnet0"
 					expected := controlplane_config.EtcdSettings{
 						Etcd: model.Etcd{
@@ -1022,7 +1002,7 @@ etcd:
 `,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
-					subnet1 := model.NewPublicSubnet("us-west-1c", "10.0.0.0/24")
+					subnet1 := model.NewPublicSubnet(firstAz, "10.0.0.0/24")
 					subnet1.Name = "Subnet0"
 					manageRecordSets := false
 					expected := controlplane_config.EtcdSettings{
@@ -1100,7 +1080,7 @@ etcd:
 `,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
-					subnet1 := model.NewPublicSubnet("us-west-1c", "10.0.0.0/24")
+					subnet1 := model.NewPublicSubnet(firstAz, "10.0.0.0/24")
 					subnet1.Name = "Subnet0"
 					expected := controlplane_config.EtcdSettings{
 						Etcd: model.Etcd{
@@ -1637,7 +1617,7 @@ worker:
 		},
 		{
 			context: "WithMultiAPIEndpoints",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 vpc:
   id: vpc-1a2b3c4d
 internetGateway:
@@ -1721,6 +1701,12 @@ apiEndpoints:
       id: hostedzone-private
 - name: addedToCertCommonNames
   dnsName: api-alt.example.com
+  loadBalancer:
+    managed: false
+- name: elbOnly
+  dnsName: registerme.example.com
+  loadBalancer:
+    recordSetManaged: false
 `,
 			assertCluster: []ClusterTester{
 				func(rootCluster root.Cluster, t *testing.T) {
@@ -1765,6 +1751,7 @@ apiEndpoints:
 					versionedPublicAlt := c.APIEndpoints["versionedPublicAlt"]
 					versionedPrivateAlt := c.APIEndpoints["versionedPrivateAlt"]
 					addedToCertCommonNames := c.APIEndpoints["addedToCertCommonNames"]
+					elbOnly := c.APIEndpoints["elbOnly"]
 
 					if len(unversionedPublic.LoadBalancer.Subnets) != 0 {
 						t.Errorf("unversionedPublic: subnets shuold be empty but was not: actual=%+v", unversionedPublic.LoadBalancer.Subnets)
@@ -1809,17 +1796,27 @@ apiEndpoints:
 					}
 
 					if len(addedToCertCommonNames.LoadBalancer.Subnets) != 0 {
-						t.Errorf("addedToCertCommonNames: subnets shuold be empty but was not: actual=%+v", addedToCertCommonNames.LoadBalancer.Subnets)
+						t.Errorf("addedToCertCommonNames: subnets should be empty but was not: actual=%+v", addedToCertCommonNames.LoadBalancer.Subnets)
 					}
 					if addedToCertCommonNames.LoadBalancer.Enabled() {
 						t.Errorf("addedToCertCommonNames: it should not be enabled as the lb to which controller nodes are added, but it was: loadBalancer=%+v", addedToCertCommonNames.LoadBalancer)
 					}
 
-					if !reflect.DeepEqual(c.ExternalDNSNames(), []string{"api-alt.example.com", "api.example.com", "api.internal.example.com", "v1api.example.com", "v1api.internal.example.com", "v1apialt.example.com", "v1apialt.internal.example.com"}) {
+					if !reflect.DeepEqual(elbOnly.LoadBalancer.Subnets, publicSubnets) {
+						t.Errorf("elbOnly: subnets didn't match: expected=%+v actual=%+v", publicSubnets, elbOnly.LoadBalancer.Subnets)
+					}
+					if !elbOnly.LoadBalancer.Enabled() {
+						t.Errorf("elbOnly: it should be enabled but it was not: loadBalancer=%+v", elbOnly.LoadBalancer)
+					}
+					if elbOnly.LoadBalancer.ManageELBRecordSet() {
+						t.Errorf("elbOnly: record set should not be managed but it was: loadBalancer=%+v", elbOnly.LoadBalancer)
+					}
+
+					if !reflect.DeepEqual(c.ExternalDNSNames(), []string{"api-alt.example.com", "api.example.com", "api.internal.example.com", "registerme.example.com", "v1api.example.com", "v1api.internal.example.com", "v1apialt.example.com", "v1apialt.internal.example.com"}) {
 						t.Errorf("unexpected external DNS names: %s", strings.Join(c.ExternalDNSNames(), ", "))
 					}
 
-					if !reflect.DeepEqual(c.APIEndpoints.ManagedELBLogicalNames(), []string{"APIEndpointVersionedPrivateAltELB", "APIEndpointVersionedPrivateELB", "APIEndpointVersionedPublicAltELB", "APIEndpointVersionedPublicELB"}) {
+					if !reflect.DeepEqual(c.APIEndpoints.ManagedELBLogicalNames(), []string{"APIEndpointElbOnlyELB", "APIEndpointVersionedPrivateAltELB", "APIEndpointVersionedPrivateELB", "APIEndpointVersionedPublicAltELB", "APIEndpointVersionedPublicELB"}) {
 						t.Errorf("unexpected managed ELB logical names: %s", strings.Join(c.APIEndpoints.ManagedELBLogicalNames(), ", "))
 					}
 				},
@@ -1827,7 +1824,7 @@ apiEndpoints:
 		},
 		{
 			context: "WithNetworkTopologyAllPreconfiguredPrivateDeprecated",
-			configYaml: mainClusterYaml + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + fmt.Sprintf(`
 vpc:
   id: vpc-1a2b3c4d
 # This, in combination with mapPublicIPs=false, implies that the route table contains a route to a preconfigured NAT gateway
@@ -1848,7 +1845,14 @@ subnets:
   # private: true
   # routeTable
   #   id: rtb-1a2b3c4d
-`,
+apiEndpoints:
+- name: public
+  dnsName: %s
+  loadBalancer:
+    private: true
+    hostedZone:
+      id: hostedzone-xxxxx
+`, kubeAwsSettings.externalDNSName),
 			assertConfig: []ConfigTester{
 				hasDefaultExperimentalFeatures,
 				hasNoNGWsOrEIPsOrRoutes,
@@ -2468,7 +2472,7 @@ worker:
 		},
 		{
 			context: "WithNetworkTopologyAllExistingPrivateSubnets",
-			configYaml: mainClusterYaml + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + fmt.Sprintf(`
 vpc:
   id: vpc-1a2b3c4d
 subnets:
@@ -2480,9 +2484,6 @@ subnets:
   availabilityZone: us-west-1b
   idFromStackOutput: mycluster-private-subnet-1
   private: true
-controller:
-  loadBalancer:
-    private: true
 etcd:
   subnets:
   - name: private1
@@ -2493,7 +2494,14 @@ worker:
     subnets:
     - name: private1
     - name: private2
-`,
+apiEndpoints:
+- name: public
+  dnsName: "%s"
+  loadBalancer:
+    hostedZone:
+      id: hostedzone-xxxx
+    private: true
+`, kubeAwsSettings.externalDNSName),
 			assertConfig: []ConfigTester{
 				hasDefaultExperimentalFeatures,
 				hasNoNGWsOrEIPsOrRoutes,
@@ -2511,9 +2519,6 @@ subnets:
 - name: public2
   availabilityZone: us-west-1b
   idFromStackOutput: mycluster-public-subnet-1
-controller:
-  loadBalancer:
-    private: false
 etcd:
   subnets:
   - name: public1
@@ -2990,7 +2995,7 @@ routeTableId: rtb-1a2b3c4d
 			assertConfig: []ConfigTester{
 				hasDefaultExperimentalFeatures,
 				func(c *config.Config, t *testing.T) {
-					subnet1 := model.NewPublicSubnetWithPreconfiguredRouteTable("us-west-1c", "10.0.0.0/24", "rtb-1a2b3c4d")
+					subnet1 := model.NewPublicSubnetWithPreconfiguredRouteTable(firstAz, "10.0.0.0/24", "rtb-1a2b3c4d")
 					subnet1.Name = "Subnet0"
 					subnets := []model.Subnet{
 						subnet1,
@@ -3481,6 +3486,19 @@ worker:
 		expectedErrorMessage string
 	}{
 		{
+			context: "WithAPIEndpointLBAPIAccessAllowedSourceCIDRsEmptied",
+			configYaml: configYamlWithoutExernalDNSName + `
+apiEndpoints:
+- name: default
+  dnsName: k8s.example.com
+  loadBalancer:
+    apiAccessAllowedSourceCIDRs:
+    hostedZone:
+      id: a1b2c4
+`,
+			expectedErrorMessage: `invalid cluster: invalid apiEndpoint "default" at index 0: invalid loadBalancer: either apiAccessAllowedSourceCIDRs or securityGroupIds must be present. Try not to explicitly empty apiAccessAllowedSourceCIDRs or set one or more securityGroupIDs`,
+		},
+		{
 			context: "WithAutoscalingEnabledButClusterAutoscalerIsDefault",
 			configYaml: minimalValidConfigYaml + `
 worker:
@@ -3683,7 +3701,7 @@ experimental:
 		},
 		{
 			context: "WithMultiAPIEndpointsInvalidLB",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 vpc:
   id: vpc-1a2b3c4d
 internetGateway:
@@ -3708,11 +3726,11 @@ apiEndpoints:
     hostedZone:
       id: hostedzone-public
 `,
-			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: createRecordSet, private, subnets, hostedZone must be omitted when id is specified to reuse an existing ELB",
+			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: private, subnets, hostedZone must be omitted when id is specified to reuse an existing ELB",
 		},
 		{
 			context: "WithMultiAPIEndpointsInvalidWorkerAPIEndpointName",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 vpc:
   id: vpc-1a2b3c4d
 internetGateway:
@@ -3749,7 +3767,7 @@ apiEndpoints:
 		},
 		{
 			context: "WithMultiAPIEndpointsInvalidWorkerNodePoolAPIEndpointName",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 vpc:
   id: vpc-1a2b3c4d
 internetGateway:
@@ -3790,7 +3808,7 @@ apiEndpoints:
 		},
 		{
 			context: "WithMultiAPIEndpointsMissingDNSName",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 vpc:
   id: vpc-1a2b3c4d
 internetGateway:
@@ -3804,12 +3822,15 @@ subnets:
 apiEndpoints:
 - name: unversionedPublic
   dnsName:
+  loadBalancer:
+    hostedZone:
+      id: hostedzone-public
 `,
 			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: dnsName must be set",
 		},
 		{
 			context: "WithMultiAPIEndpointsMissingGlobalAPIEndpointName",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 vpc:
   id: vpc-1a2b3c4d
 internetGateway:
@@ -3850,7 +3871,7 @@ apiEndpoints:
 		},
 		{
 			context: "WithMultiAPIEndpointsRecordSetImpliedBySubnetsMissingHostedZoneID",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 vpc:
   id: vpc-1a2b3c4d
 internetGateway:
@@ -3874,11 +3895,11 @@ apiEndpoints:
     - name: publicSubnet1
     # missing hosted zone id here!
 `,
-			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: missing hostedZoneId",
+			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: missing hostedZone.id",
 		},
 		{
 			context: "WithMultiAPIEndpointsRecordSetImpliedByExplicitPublicMissingHostedZoneID",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 vpc:
   id: vpc-1a2b3c4d
 internetGateway:
@@ -3901,11 +3922,11 @@ apiEndpoints:
     private: false
     # missing hosted zone id here!
 `,
-			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: missing hostedZoneId",
+			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: missing hostedZone.id",
 		},
 		{
 			context: "WithMultiAPIEndpointsRecordSetImpliedByExplicitPrivateMissingHostedZoneID",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
+			configYaml: kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 vpc:
   id: vpc-1a2b3c4d
 internetGateway:
@@ -3931,34 +3952,7 @@ apiEndpoints:
     private: true
     # missing hosted zone id here!
 `,
-			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: missing hostedZoneId",
-		},
-		{
-			context: "WithMultiAPIEndpointsExplicitRecordSetMissingHostedZoneID",
-			configYaml: kubeAwsSettings.mainClusterYamlWithoutExternalDNS() + `
-vpc:
-  id: vpc-1a2b3c4d
-internetGateway:
-  id: igw-1a2b3c4d
-
-subnets:
-- name: publicSubnet1
-  availabilityZone: us-west-1a
-  instanceCIDR: "10.0.1.0/24"
-
-worker:
-  apiEndpointName: unversionedPublic
-
-apiEndpoints:
-- name: unversionedPublic
-  dnsName: api.example.com
-  loadBalancer:
-    # lb is going to be created with a corresponding record set
-    # however no hosted zone for the record set is provided!
-    createRecordSet: true
-    # missing hosted zone id here!
-`,
-			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: missing hostedZoneId",
+			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: missing hostedZone.id",
 		},
 		{
 			context: "WithNetworkTopologyAllExistingPrivateSubnetsRejectingExistingIGW",

--- a/test/integration/nodepool_test.go
+++ b/test/integration/nodepool_test.go
@@ -58,7 +58,12 @@ etcdEndpoints: "10.0.0.1"
 	mainClusterYaml := `
 region: ap-northeast-1
 availabilityZone: ap-northeast-1a
-externalDNSName: kubeawstest.example.com
+apiEndpoints:
+- name: public
+  dnsName: kubeawstest.example.com
+  loadBalancer:
+    hostedZone:
+      id: hostedzone-xxxx
 sshAuthorizedKeys:
 - mydummysshpublickey
 kmsKeyArn: mykmskeyarn

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -23,10 +23,8 @@ func TestPlugin(t *testing.T) {
 		t.Logf(`Falling back s3URI to a stub value "%s" for tests of validating stack templates. No assets will actually be uploaded to S3`, s3URI)
 	}
 
-	mainClusterYaml := kubeAwsSettings.mainClusterYaml()
-	minimalValidConfigYaml := mainClusterYaml + `
-availabilityZone: us-west-1c
-`
+	minimalValidConfigYaml := kubeAwsSettings.minimumValidClusterYamlWithAZ("c")
+
 	validCases := []struct {
 		context       string
 		clusterYaml   string
@@ -37,6 +35,8 @@ availabilityZone: us-west-1c
 		{
 			context: "WithAddons",
 			clusterYaml: minimalValidConfigYaml + `
+
+
 kubeAwsPlugins:
   myPlugin:
     enabled: true


### PR DESCRIPTION
by preventing the Route53 misconfiguration.

The `--hosted-zone-id` flag and the corresponding `hostedZone.id` key in cluster.yaml are now required by default. You can explicitly omit them by setting `--no-record-set` or `recordSetManaged: false`. This way, one can't omit hosted zone id without knowing the implication of omitting the hosted zone id.

Resolves #928
