### PR TITLE
Add initial support for NLB API endpoints

### DIFF
--- a/core/controlplane/cluster/describer.go
+++ b/core/controlplane/cluster/describer.go
@@ -2,10 +2,13 @@ package cluster
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 )
 
 type ClusterDescriber interface {
@@ -29,8 +32,14 @@ func NewClusterDescriber(clusterName string, stackName string, elbResourceLogica
 }
 
 func (c clusterDescriberImpl) Info() (*Info, error) {
+	// For ELBV1 API objects
 	elbNameRefs := []*string{}
 	elbNames := []string{}
+
+	// For ELBV2 API objects
+	elbv2NameRefs := []*string{}
+	elbv2Names := []string{}
+
 	{
 		cfSvc := cloudformation.New(c.session)
 		for _, lb := range c.elbResourceLogicalNames {
@@ -44,29 +53,56 @@ func (c clusterDescriberImpl) Info() (*Info, error) {
 				errmsg := "unable to get public IP of controller instance:\n" + err.Error()
 				return nil, fmt.Errorf(errmsg)
 			}
-			elbNameRefs = append(elbNameRefs, resp.StackResourceDetail.PhysicalResourceId)
-			elbNames = append(elbNames, *resp.StackResourceDetail.PhysicalResourceId)
+
+			// ELBV2 uses ARN identifiers
+			if strings.HasPrefix(*resp.StackResourceDetail.PhysicalResourceId, "arn:") {
+				elbv2NameRefs = append(elbv2NameRefs, resp.StackResourceDetail.PhysicalResourceId)
+				elbv2Names = append(elbv2Names, *resp.StackResourceDetail.PhysicalResourceId)
+			} else {
+				elbNameRefs = append(elbNameRefs, resp.StackResourceDetail.PhysicalResourceId)
+				elbNames = append(elbNames, *resp.StackResourceDetail.PhysicalResourceId)
+			}
 		}
 	}
 
 	elbSvc := elb.New(c.session)
+	elbv2Svc := elbv2.New(c.session)
 
 	var info Info
 	{
-		resp, err := elbSvc.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
-			LoadBalancerNames: elbNameRefs,
-			PageSize:          aws.Int64(2),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("error describing load balancers %v: %v", elbNames, err)
-		}
-		if len(resp.LoadBalancerDescriptions) == 0 {
-			return nil, fmt.Errorf("could not find load balancers with names %v", elbNames)
+		dnsNames := []string{}
+
+		// Use the proper API to describe classic ELB objects
+		if len(elbNameRefs) > 0 {
+			resp, err := elbSvc.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+				LoadBalancerNames: elbNameRefs,
+				PageSize:          aws.Int64(2),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error describing load balancers %v: %v", elbNames, err)
+			}
+			if len(resp.LoadBalancerDescriptions) == 0 {
+				return nil, fmt.Errorf("could not find load balancers with names %v", elbNames)
+			}
+			for _, d := range resp.LoadBalancerDescriptions {
+				dnsNames = append(dnsNames, *d.DNSName)
+			}
 		}
 
-		dnsNames := []string{}
-		for _, d := range resp.LoadBalancerDescriptions {
-			dnsNames = append(dnsNames, *d.DNSName)
+		// Use the proper API to describe ELBV2 API objects
+		if len(elbv2NameRefs) > 0 {
+			respv2, err := elbv2Svc.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{
+				LoadBalancerArns: elbv2NameRefs,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error describing load balancers %v: %v", elbv2Names, err)
+			}
+			if len(respv2.LoadBalancers) == 0 {
+				return nil, fmt.Errorf("could not find load balancers with names %v", elbv2Names)
+			}
+			for _, d := range respv2.LoadBalancers {
+				dnsNames = append(dnsNames, *d.DNSName)
+			}
 		}
 
 		info.Name = c.clusterName

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1041,6 +1041,12 @@ func (c Cluster) validate() error {
 		}
 	}
 
+	for i, e := range c.APIEndpointConfigs {
+		if e.LoadBalancer.NetworkLoadBalancer() && !c.Region.SupportsNetworkLoadBalancers() {
+			return fmt.Errorf("api endpoint %d is not valid: network load balancer not supported in region", i)
+		}
+	}
+
 	return nil
 }
 

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -922,17 +922,24 @@ func (c Cluster) ExternalDNSNames() []string {
 	return names
 }
 
-// APIAccessAllowedSourceCIDRs returns all the CIDRs of Kubernetes API endpoints that controller nodes must allow access from
-func (c Cluster) APIAccessAllowedSourceCIDRs() []string {
+// APIAccessAllowedSourceCIDRsForControllerSG returns all the CIDRs of Kubernetes API endpoints that controller nodes must allow access from
+func (c Cluster) APIAccessAllowedSourceCIDRsForControllerSG() []string {
 	cidrs := []string{}
 	seen := map[string]bool{}
 
 	for _, e := range c.APIEndpointConfigs {
-		for _, r := range e.LoadBalancer.APIAccessAllowedSourceCIDRs {
-			val := r.String()
-			if _, ok := seen[val]; !ok {
-				cidrs = append(cidrs, val)
-				seen[val] = true
+		if !e.LoadBalancer.NetworkLoadBalancer() {
+			continue
+		}
+
+		ranges := e.LoadBalancer.APIAccessAllowedSourceCIDRs
+		if len(ranges) > 0 {
+			for _, r := range ranges {
+				val := r.String()
+				if _, ok := seen[val]; !ok {
+					cidrs = append(cidrs, val)
+					seen[val] = true
+				}
 			}
 		}
 	}

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -922,6 +922,26 @@ func (c Cluster) ExternalDNSNames() []string {
 	return names
 }
 
+// APIAccessAllowedSourceCIDRs returns all the CIDRs of Kubernetes API endpoints that controller nodes must allow access from
+func (c Cluster) APIAccessAllowedSourceCIDRs() []string {
+	cidrs := []string{}
+	seen := map[string]bool{}
+
+	for _, e := range c.APIEndpointConfigs {
+		for _, r := range e.LoadBalancer.APIAccessAllowedSourceCIDRs {
+			val := r.String()
+			if _, ok := seen[val]; !ok {
+				cidrs = append(cidrs, val)
+				seen[val] = true
+			}
+		}
+	}
+
+	sort.Strings(cidrs)
+
+	return cidrs
+}
+
 // NestedStackName returns a sanitized name of this control-plane which is usable as a valid cloudformation nested stack name
 func (c Cluster) NestedStackName() string {
 	// Convert stack name into something valid as a cfn resource name or

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -146,6 +146,15 @@ apiEndpoints:
     type: network
     recordSetManaged: false
     securityGroupIds: []
+`, `
+apiEndpoints:
+- name: public
+  dnsName: test.staging.core-os.net
+  loadBalancer:
+    type: network
+    recordSetManaged: false
+    securityGroupIds: []
+    apiAccessAllowedSourceCIDRs: []
 `,
 }
 
@@ -211,23 +220,14 @@ apiEndpoints:
     securityGroupIds:
       - sg-1234
 `, `
-# cannot override apiAccessAllowedSourceCIDRs
+# must specify either securityGroupIds or apiAccessAllowedSourceCIDRs for classic ELBs
 apiEndpoints:
 - name: public
+  dnsName: test.staging.core-os.net
   loadBalancer:
-    type: network
-    hostedZone:
-      id: hostedzone-xxxxxx
-    apiAccessAllowedSourceCIDRs:
-      - 127.0.0.1/32
-`, `
-# cannot specify empty apiAccessAllowedSourceCIDRs
-apiEndpoints:
-- name: public
-  loadBalancer:
-    type: network
-    hostedZone:
-      id: hostedzone-xxxxxx
+    type: classic
+    recordSetManaged: false
+    securityGroupIds: []
     apiAccessAllowedSourceCIDRs: []
 `,
 }

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -29,7 +29,7 @@ amiId: "{{.AmiId}}"
 # Required if there are 2 or more API endpoints defined in `apiEndpoints`
 #adminAPIEndpointName: versionedPublic
 
-# Kubernetes API endpoints with each one has a DNS name and is with/without a managed/unmanaged ELB, Route 53 record set
+# Kubernetes API endpoints with each one has a DNS name and is with/without a managed/unmanaged load balancer, Route 53 record set
 # CAUTION: `externalDNSName` must be omitted when there are one or more items under `apiEndpoints`
 apiEndpoints:
 - # The unique name of this API endpoint used to identify it inside CloudFormation stacks or
@@ -43,8 +43,8 @@ apiEndpoints:
   # for you.  Otherwise the deployer is responsible for making this name routable
   dnsName: {{.ExternalDNSName}}
 
-  # Configuration for an ELB serving this endpoint
-  # Omit all the settings when you want kube-aws not to provision an ELB for you
+  # Configuration for the load balancer serving this endpoint
+  # Omit all the settings when you want kube-aws not to provision a load balancer for you
   loadBalancer:
     # Specifies an existing load-balancer used for load-balancing controller nodes and serving this endpoint
     # Setting id requires all the other settings excluding `name` to be omitted because reusing an ELB implies that configuring other resources
@@ -61,6 +61,12 @@ apiEndpoints:
     # When set to true while subnets are omitted, one or more private subnets in the top-level `subnets` must exist
     # Must be omitted when `id` is specified
     #private: false
+
+    # Set to 'network' to provision a Network Load Balancer instead of a classic ELB; this will cause
+    # the controller nodes SG to allow inbound traffic from the VPC CIDR to port 443 TCP, see:
+    # http://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html
+    # Must be omitted when `id` is specified
+    #type: classic
 
     # TTL in seconds for the Route53 RecordSet created if hostedZone.id is set to a non-nil value.
     #recordSetTTL: 300

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1088,7 +1088,7 @@
             "IpProtocol": "tcp",
             "ToPort": 443
           },
-          {{ range $_, $r := $.APIAccessAllowedSourceCIDRs -}}
+          {{ range $_, $r := $.APIAccessAllowedSourceCIDRsForControllerSG -}}
           {
             "CidrIp": "{{$r}}",
             "FromPort": 443,

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -49,7 +49,13 @@
           {{end}}
         ],
         "LoadBalancerNames" : [
-          {{range $i, $ref := .APIEndpoints.ELBRefs -}}
+          {{range $i, $ref := .APIEndpoints.ELBClassicRefs -}}
+          {{- if gt $i 0}},{{end}}
+          {{ $ref }}
+          {{- end}}
+        ],
+        "TargetGroupARNs": [
+          {{range $i, $ref := .APIEndpoints.ELBV2TargetGroupRefs -}}
           {{- if gt $i 0}},{{end}}
           {{ $ref }}
           {{- end}}
@@ -895,6 +901,50 @@
       }
     },
     {{ end -}}
+    {{ if .LoadBalancer.LoadBalancerV2 }}
+    "{{.LoadBalancer.LogicalName}}TargetGroup": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "HealthCheckIntervalSeconds": "10",
+        "HealthyThresholdCount": "3",
+        "UnhealthyThresholdCount": "3",
+        "Port": "443",
+        "VpcId": {{$.VPCRef}},
+        "Protocol": "TCP"
+      }
+    },
+    "{{.LoadBalancer.LogicalName}}Listener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {"Ref": "{{.LoadBalancer.LogicalName}}TargetGroup"},
+            "Type": "forward"
+          }
+        ],
+        "LoadBalancerArn": {"Ref": "{{.LoadBalancer.LogicalName}}"},
+        "Port": "443",
+        "Protocol": "TCP"
+      }
+    },
+    "{{.LoadBalancer.LogicalName}}" : {
+      "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties" : {
+        "Type": "network",
+        "Subnets" : [
+          {{range $index, $subnet := .LoadBalancer.Subnets}}
+          {{if gt $index 0}},{{end}}
+          {{$subnet.Ref}}
+          {{end}}
+        ],
+        {{if .LoadBalancer.Private}}
+        "Scheme": "internal"
+        {{else}}
+        "Scheme": "internet-facing"
+        {{end}}
+      }
+    },
+    {{ else }}
     "{{.LoadBalancer.LogicalName}}" : {
       "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties" : {
@@ -936,6 +986,7 @@
         ]
       }
     },
+    {{ end }}
     {{if .LoadBalancer.ManageSecurityGroup -}}
     "{{.LoadBalancer.SecurityGroupLogicalName}}" : {
       "Properties": {
@@ -1029,6 +1080,14 @@
             "ToPort": 22
           },
           {{end -}}
+          {{ if $.KubeClusterSettings.APIEndpointConfigs.HasNetworkLoadBalancers }}
+          {
+            "CidrIp": "{{.VPCCIDR}}",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443
+          },
+          {{ end }}
           {
             "SourceSecurityGroupId" : { "Ref" : "SecurityGroupElbAPIServer" },
             "FromPort": 443,

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -901,7 +901,7 @@
       }
     },
     {{ end -}}
-    {{ if .LoadBalancer.LoadBalancerV2 }}
+    {{ if .LoadBalancer.NetworkLoadBalancer }}
     "{{.LoadBalancer.LogicalName}}TargetGroup": {
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "Properties": {

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1081,12 +1081,21 @@
           },
           {{end -}}
           {{ if $.KubeClusterSettings.APIEndpointConfigs.HasNetworkLoadBalancers }}
+          {{/* Needed for NLB health checks and to allow worker nodes to contact the API servers. */}}
           {
             "CidrIp": "{{.VPCCIDR}}",
             "FromPort": 443,
             "IpProtocol": "tcp",
             "ToPort": 443
           },
+          {{ range $_, $r := $.APIAccessAllowedSourceCIDRs -}}
+          {
+            "CidrIp": "{{$r}}",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443
+          },
+          {{ end -}}
           {{ end }}
           {
             "SourceSecurityGroupId" : { "Ref" : "SecurityGroupElbAPIServer" },

--- a/model/api_endpoint_lb.go
+++ b/model/api_endpoint_lb.go
@@ -31,6 +31,8 @@ type APIEndpointLB struct {
 	//SecurityGroups []SecurityGroup
 	// SecurityGroupIds represents SGs associated to this LB. Required when APIAccessAllowedSourceCIDRs is explicitly set to empty
 	SecurityGroupIds []string `yaml:"securityGroupIds"`
+	// Load balancer type. It is 'classic' by default, but can be changed to 'network'
+	Type *string `yaml:"type,omitempty"`
 }
 
 // UnmarshalYAML unmarshals YAML data to an APIEndpointLB object with defaults
@@ -56,7 +58,22 @@ func (e APIEndpointLB) ManageELB() bool {
 	return e.managedELBImplied() || (e.Managed != nil && *e.Managed)
 }
 
-// ManageELBRecordSet returns tru if kube-aws should create a record set for the ELB
+// ClassicLoadBalancer returns true if the load balancer is a classic ELB
+func (e APIEndpointLB) ClassicLoadBalancer() bool {
+	return e.Type == nil || *e.Type == "classic"
+}
+
+// LoadBalancerV2 returns true if the load balancer is a ELBV2 load balancer (only network load balancer is supported for now)
+func (e APIEndpointLB) LoadBalancerV2() bool {
+	return e.Type != nil && *e.Type != "classic"
+}
+
+// NetworkLoadBalancer returns true if the load balancer is a ELBV2 network load balancer
+func (e APIEndpointLB) NetworkLoadBalancer() bool {
+	return e.Type != nil && *e.Type != "classic"
+}
+
+// ManageELBRecordSet returns true if kube-aws should create a record set for the ELB
 func (e APIEndpointLB) ManageELBRecordSet() bool {
 	return e.HostedZone.HasIdentifier()
 }
@@ -69,9 +86,10 @@ func (e APIEndpointLB) ManageSecurityGroup() bool {
 // Validate returns an error when there's any user error in the settings of the `loadBalancer` field
 func (e APIEndpointLB) Validate() error {
 	if e.Identifier.HasIdentifier() {
-		if e.PrivateSpecified != nil || len(e.SubnetReferences) > 0 || e.HostedZone.HasIdentifier() {
-			return errors.New("private, subnets, hostedZone must be omitted when id is specified to reuse an existing ELB")
+		if e.PrivateSpecified != nil || !e.ClassicLoadBalancer() || len(e.SubnetReferences) > 0 || e.HostedZone.HasIdentifier() {
+			return errors.New("type, private, subnets, hostedZone must be omitted when id is specified to reuse an existing ELB")
 		}
+
 		return nil
 	}
 
@@ -82,6 +100,10 @@ func (e APIEndpointLB) Validate() error {
 
 		if e.HostedZone.HasIdentifier() {
 			return errors.New("hostedZone.id should not be specified when an API endpoint LB is not managed by kube-aws")
+		}
+
+		if e.Type != nil && len(*e.Type) > 0 {
+			return errors.New("type should not be specified when an API endpoint LB is not managed by kube-aws")
 		}
 
 		return nil
@@ -107,8 +129,30 @@ func (e APIEndpointLB) Validate() error {
 		}
 	}
 
-	if e.ManageELB() && len(e.APIAccessAllowedSourceCIDRs) == 0 && len(e.SecurityGroupIds) == 0 {
+	if e.ClassicLoadBalancer() && e.ManageELB() && len(e.APIAccessAllowedSourceCIDRs) == 0 && len(e.SecurityGroupIds) == 0 {
 		return errors.New("either apiAccessAllowedSourceCIDRs or securityGroupIds must be present. Try not to explicitly empty apiAccessAllowedSourceCIDRs or set one or more securityGroupIDs")
+	}
+
+	if !e.NetworkLoadBalancer() && !e.ClassicLoadBalancer() {
+		return errors.New("load balancer type must be either 'classic' or 'network'")
+	}
+
+	if e.NetworkLoadBalancer() {
+		defaultRanges := DefaultCIDRRanges()
+
+		if len(e.SecurityGroupIds) > 0 {
+			return errors.New("cannot specify security group IDs for a network load balancer")
+		}
+
+		if len(e.APIAccessAllowedSourceCIDRs) != len(defaultRanges) {
+			return errors.New("cannot override apiAccessAllowedSourceCIDRs for a network load balancer")
+		}
+
+		for i, r := range defaultRanges {
+			if r != e.APIAccessAllowedSourceCIDRs[i] {
+				return errors.New("cannot override apiAccessAllowedSourceCIDRs for a network load balancer")
+			}
+		}
 	}
 
 	return nil

--- a/model/api_endpoint_lb.go
+++ b/model/api_endpoint_lb.go
@@ -70,7 +70,7 @@ func (e APIEndpointLB) LoadBalancerV2() bool {
 
 // NetworkLoadBalancer returns true if the load balancer is a ELBV2 network load balancer
 func (e APIEndpointLB) NetworkLoadBalancer() bool {
-	return e.Type != nil && *e.Type != "classic"
+	return e.Type != nil && *e.Type == "network"
 }
 
 // ManageELBRecordSet returns true if kube-aws should create a record set for the ELB

--- a/model/api_endpoint_lb.go
+++ b/model/api_endpoint_lb.go
@@ -80,7 +80,7 @@ func (e APIEndpointLB) ManageELBRecordSet() bool {
 
 // ManageSecurityGroup returns true if kube-aws should create a security group for this ELB
 func (e APIEndpointLB) ManageSecurityGroup() bool {
-	return len(e.APIAccessAllowedSourceCIDRs) > 0
+	return !e.NetworkLoadBalancer() && len(e.APIAccessAllowedSourceCIDRs) > 0
 }
 
 // Validate returns an error when there's any user error in the settings of the `loadBalancer` field
@@ -138,20 +138,8 @@ func (e APIEndpointLB) Validate() error {
 	}
 
 	if e.NetworkLoadBalancer() {
-		defaultRanges := DefaultCIDRRanges()
-
 		if len(e.SecurityGroupIds) > 0 {
 			return errors.New("cannot specify security group IDs for a network load balancer")
-		}
-
-		if len(e.APIAccessAllowedSourceCIDRs) != len(defaultRanges) {
-			return errors.New("cannot override apiAccessAllowedSourceCIDRs for a network load balancer")
-		}
-
-		for i, r := range defaultRanges {
-			if r != e.APIAccessAllowedSourceCIDRs[i] {
-				return errors.New("cannot override apiAccessAllowedSourceCIDRs for a network load balancer")
-			}
 		}
 	}
 

--- a/model/api_endpoints.go
+++ b/model/api_endpoints.go
@@ -6,16 +6,24 @@ import (
 
 type APIEndpoints []APIEndpoint
 
-// DefaultAPIEndpointName is the default endpoint name used when you've omitted `apiEndpoints` but not `externalDNSName`
-const DefaultAPIEndpointName = "Default"
+const (
+	// DefaultAPIEndpointName is the default endpoint name used when you've omitted `apiEndpoints` but not `externalDNSName`
+	DefaultAPIEndpointName = "Default"
+
+	// DefaultLoadBalancerType is the default load balancer to be provisioned by kube-aws for the API endpoints
+	DefaultLoadBalancerType = "classic"
+)
 
 // NewDefaultAPIEndpoints creates the slice of API endpoints containing only the default one which is with arbitrary DNS name and an ELB
 func NewDefaultAPIEndpoints(dnsName string, subnets []SubnetReference, hostedZoneId string, recordSetTTL int, private bool) APIEndpoints {
+	defaultLBType := DefaultLoadBalancerType
+
 	return []APIEndpoint{
 		APIEndpoint{
 			Name:    DefaultAPIEndpointName,
 			DNSName: dnsName,
 			LoadBalancer: APIEndpointLB{
+				Type: &defaultLBType,
 				APIAccessAllowedSourceCIDRs: DefaultCIDRRanges(),
 				SubnetReferences:            subnets,
 				HostedZone: HostedZone{
@@ -38,6 +46,16 @@ func (e APIEndpoints) Validate() error {
 		}
 	}
 	return nil
+}
+
+// HasNetworkLoadBalancers returns true if there's any API endpoint load balancer of type 'network'
+func (e APIEndpoints) HasNetworkLoadBalancers() bool {
+	for _, apiEndpoint := range e {
+		if apiEndpoint.LoadBalancer.NetworkLoadBalancer() {
+			return true
+		}
+	}
+	return false
 }
 
 //type APIDNSRoundRobin struct {

--- a/model/derived/api_endpoint_lb.go
+++ b/model/derived/api_endpoint_lb.go
@@ -33,7 +33,7 @@ func (b APIEndpointLB) HostedZoneRef() string {
 	return b.HostedZone.Identifier.ID
 }
 
-// LogicalName returns the unique resource name of the ELB
+// LogicalName returns the unique resource name of the load balancer
 func (b APIEndpointLB) LogicalName() string {
 	return fmt.Sprintf("APIEndpoint%sELB", strings.Title(b.Name))
 }
@@ -43,13 +43,21 @@ func (b APIEndpointLB) Enabled() bool {
 	return b.ManageELB() || b.Identifier.HasIdentifier()
 }
 
-// Ref returns a CloudFormation ref for the ELB backing the API endpoint
+// Ref returns a CloudFormation ref for the load balancer backing the API endpoint
 func (b APIEndpointLB) Ref() string {
 	return b.Identifier.Ref(func() string {
 		return b.LogicalName()
 	})
 }
 
+// TargetGroupRef returns a CloudFormation ref for the Target Group backing the API endpoint
+func (b APIEndpointLB) TargetGroupRef() string {
+	return b.Identifier.Ref(func() string {
+		return fmt.Sprintf("%sTargetGroup", b.LogicalName())
+	})
+}
+
+// SecurityGroupLogicalName returns a CloudFormation ref for the Security Group backing the API endpoint
 func (b APIEndpointLB) SecurityGroupLogicalName() string {
 	return fmt.Sprintf("APIEndpoint%sSG", strings.Title(b.Name))
 }

--- a/model/derived/api_endpoints.go
+++ b/model/derived/api_endpoints.go
@@ -88,12 +88,23 @@ func (e APIEndpoints) FindByName(name string) (*APIEndpoint, error) {
 	return nil, fmt.Errorf("no API endpoint named \"%s\" defined under the `apiEndpoints[]`. The name must be one of: %s", name, strings.Join(apiEndpointNames, ", "))
 }
 
-// ELBRefs returns the names of all the ELBs to which controller nodes should be associated
-func (e APIEndpoints) ELBRefs() []string {
+// ELBClassicRefs returns the names of all the Classic ELBs to which controller nodes should be associated
+func (e APIEndpoints) ELBClassicRefs() []string {
 	refs := []string{}
 	for _, endpoint := range e {
-		if endpoint.LoadBalancer.Enabled() {
+		if endpoint.LoadBalancer.Enabled() && endpoint.LoadBalancer.ClassicLoadBalancer() {
 			refs = append(refs, endpoint.LoadBalancer.Ref())
+		}
+	}
+	return refs
+}
+
+// ELBV2TargetGroupRefs returns the names of all the Load Balancers v2 to which controller nodes should be associated
+func (e APIEndpoints) ELBV2TargetGroupRefs() []string {
+	refs := []string{}
+	for _, endpoint := range e {
+		if endpoint.LoadBalancer.Enabled() && endpoint.LoadBalancer.LoadBalancerV2() {
+			refs = append(refs, endpoint.LoadBalancer.TargetGroupRef())
 		}
 	}
 	return refs

--- a/model/region.go
+++ b/model/region.go
@@ -67,3 +67,7 @@ func (r Region) IsEmpty() bool {
 func (r Region) SupportsKMS() bool {
 	return !r.IsChina()
 }
+
+func (r Region) SupportsNetworkLoadBalancers() bool {
+	return !r.IsChina()
+}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3579,7 +3579,7 @@ apiEndpoints:
     hostedZone:
       id: hostedzone-public
 `,
-			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: private, subnets, hostedZone must be omitted when id is specified to reuse an existing ELB",
+			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: type, private, subnets, hostedZone must be omitted when id is specified to reuse an existing ELB",
 		},
 		{
 			context: "WithMultiAPIEndpointsInvalidWorkerAPIEndpointName",


### PR DESCRIPTION
This adds support for an optional `type` attribute to `apiEndpoints[].loadBalancer`, which supports the following values:

- _undefined_ (defaults to Classic ELBs, just like before)
- `type: classic` (same as above)
- `type: network` (provisions a Network Load Balancer instead of a Classic ELB)

The idea is to use NLB-backed API endpoints for worker nodes in an attempt to mitigate issues like #598.

The first version implemented in this PR has a few limitations:

- It can only be used if load balancer is managed by kube-aws, that is, we cannot set `type: network` when specifying the load balancer `id`
- It allows inbound connections to TCP port 443 from the VPC CIDR to the controller security group if at least one NLB-backed API endpoint is defined (see below)

A few considerations regarding NLBs at their present form:

- It's not possible to override the check interval (which defaults to 10)
- It's not possible to override the check timeout (which defaults to 10)
- As of now, it's not possible to specify a different value for healthy and unhealthy thresholds, so I set them both to 3
- It's not possible to attach a security group to a NLB; this means controller nodes must accept direct inbound connections to TCP-443 from the VPC CIDR, according to the [docs](http://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-register-targets.html#target-security-groups)
 
TODO

- [x] Document new flag in cluster.yaml
- [x] Fix `kube-aws info` by using the ELBV2 API when trying to fetch NLBs DNS name
- [x] Test with different combinations of public/private controllers/workers
- [x] Add inbound rule to port 443 (TCP) from the VPC CIDR to controller node SG if there are any NLB-backed API endpoints
- [x] Add validation to forbid creation of NLB-backed API endpoints if deploying to the China region, which do not support NLB
- [x] Test upgrade path from ELB API endpoint to a NLB API endpoint for worker nodes
- [x] Fix/add tests

Closes #937.