### PR TITLE
Convert kube-proxy to a DaemonSet

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2737,6 +2737,7 @@ write_files:
     content: {{.AssetsConfig.EtcdTrustedCA}}
 {{ end }}
 
+  # File needed on every node (used by the kube-proxy DaemonSet), including controllers
   - path: /etc/kubernetes/kubeconfig/kube-proxy.yaml
     content: |
         apiVersion: v1

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1524,6 +1524,9 @@ write_files:
           - kind: ServiceAccount
             name: kube-proxy
             namespace: kube-system
+          # Not needed after migrating to DaemonSet-based kube-proxy
+          - kind: Group
+            name: system:nodes
         roleRef:
           kind: ClusterRole
           name: system:node-proxier

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -250,6 +250,7 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
+        ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/usr/bin/etcdctl \
                        --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
                        --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
@@ -758,7 +759,7 @@ write_files:
       kubectl apply -f "${mfdir}/kube-dns-cm.yaml"
 
       # Service Accounts
-      for manifest in {kube-dns,heapster}; do
+      for manifest in {kube-dns,heapster,kube-proxy}; do
           kubectl apply -f "${mfdir}/$manifest-sa.yaml"
       done
 
@@ -773,6 +774,11 @@ write_files:
       # Deployments
       for manifest in {kube-dns,kube-dns-autoscaler,kube-dashboard,{{ if .Addons.ClusterAutoscaler.Enabled }}cluster-autoscaler,{{ end }}heapster{{ if .KubeResourcesAutosave.Enabled }},kube-resources-autosave{{ end }}}; do
           kubectl apply -f "${mfdir}/$manifest-de.yaml"
+      done
+
+      # Daemonsets
+      for manifest in {kube-proxy,}; do
+          kubectl apply -f "${mfdir}/$manifest-ds.yaml"
       done
 
       # Services
@@ -1504,10 +1510,8 @@ write_files:
           name: cluster-admin
           apiGroup: rbac.authorization.k8s.io
 
-  # Allows both `kube-worker` user and members of the `system:nodes` group
-  # to perform actions needed by the `kube-proxy` component. Once kube-proxy
-  # is migrated to DaemonSets, we could set up a ServiceAccount for it and
-  # associate this role to it instead.
+  # Also allows `kube-worker` user to perform actions needed by the
+  # `kube-proxy` component.
   - path: /srv/kubernetes/rbac/cluster-role-bindings/node-proxier.yaml
     content: |
         kind: ClusterRoleBinding
@@ -1517,8 +1521,9 @@ write_files:
         subjects:
           - kind: User
             name: kube-worker
-          - kind: Group
-            name: system:nodes
+          - kind: ServiceAccount
+            name: kube-proxy
+            namespace: kube-system
         roleRef:
           kind: ClusterRole
           name: system:node-proxier
@@ -1692,10 +1697,10 @@ write_files:
           apiGroup: rbac.authorization.k8s.io
 {{ end }}
 
-  - path: /etc/kubernetes/manifests/kube-proxy.yaml
+  - path: /srv/kubernetes/manifests/kube-proxy-ds.yaml
     content: |
-        apiVersion: v1
-        kind: Pod
+        apiVersion: extensions/v1beta1
+        kind: DaemonSet
         metadata:
           name: kube-proxy
           namespace: kube-system
@@ -1703,32 +1708,49 @@ write_files:
             k8s-app: kube-proxy
           annotations:
             rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
-
         spec:
-          hostNetwork: true
-          containers:
-          - name: kube-proxy
-            image: {{.HyperkubeImage.RepoWithTag}}
-            command:
-            - /hyperkube
-            - proxy
-            - --master=http://127.0.0.1:8080
-            securityContext:
-              privileged: true
-            volumeMounts:
-            - mountPath: /etc/ssl/certs
-              name: ssl-certs-host
-              readOnly: true
-            - mountPath: /var/run/dbus
-              name: dbus
-              readOnly: false
-          volumes:
-          - hostPath:
-              path: /usr/share/ca-certificates
-            name: ssl-certs-host
-          - hostPath:
-              path: /var/run/dbus
-            name: dbus
+          updateStrategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                k8s-app: kube-proxy
+              annotations:
+                scheduler.alpha.kubernetes.io/critical-pod: ''
+            spec:
+              serviceAccountName: kube-proxy
+              tolerations:
+              - operator: Exists
+                effect: NoSchedule
+              - operator: Exists
+                effect: NoExecute
+              - operator: Exists
+                key: CriticalAddonsOnly
+              hostNetwork: true
+              containers:
+              - name: kube-proxy
+                image: {{.HyperkubeImage.RepoWithTag}}
+                command:
+                - /hyperkube
+                - proxy
+                - --kubeconfig=/etc/kubernetes/proxy-kubeconfig.yaml
+                - --cluster-cidr={{.PodCIDR}}
+                securityContext:
+                  privileged: true
+                volumeMounts:
+                - mountPath: /etc/kubernetes
+                  name: kubeconfig
+                  readOnly: true
+                - mountPath: /var/run/dbus
+                  name: dbus
+                  readOnly: false
+              volumes:
+              - name: kubeconfig
+                hostPath:
+                  path: /etc/kubernetes
+              - hostPath:
+                  path: /var/run/dbus
+                name: dbus
 
   - path: /etc/kubernetes/manifests/kube-apiserver.yaml
     content: |
@@ -1998,6 +2020,16 @@ write_files:
                   cpu: 10m
                   memory: 100Mi
   {{- end }}
+
+  - path: /srv/kubernetes/manifests/kube-proxy-sa.yaml
+    content: |
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: kube-proxy
+          namespace: kube-system
+          labels:
+            kubernetes.io/cluster-service: "true"
 
   - path: /srv/kubernetes/manifests/kube-dns-sa.yaml
     content: |
@@ -2711,6 +2743,23 @@ write_files:
     content: {{.AssetsConfig.EtcdTrustedCA}}
 {{ end }}
 
+  - path: /etc/kubernetes/proxy-kubeconfig.yaml
+    content: |
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: local
+          cluster:
+            server: http://127.0.0.1:8080
+        users:
+        - name: kubelet
+        contexts:
+        - context:
+            cluster: local
+            user: kubelet
+          name: kubelet-context
+        current-context: kubelet-context
+
   - path: /etc/kubernetes/controller-kubeconfig.yaml
     content: |
         apiVersion: v1
@@ -2718,7 +2767,7 @@ write_files:
         clusters:
         - name: local
           cluster:
-            server: http://localhost:8080
+            server: http://127.0.0.1:8080
         users:
         - name: kubelet
         contexts:

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2744,9 +2744,12 @@ write_files:
         clusters:
         - name: local
           cluster:
+            certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             server: http://127.0.0.1:8080
         users:
         - name: kubelet
+          user:
+            tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
         contexts:
         - context:
             cluster: local

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2743,20 +2743,19 @@ write_files:
         apiVersion: v1
         kind: Config
         clusters:
-        - name: local
+        - name: default
           cluster:
-            certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             server: http://localhost:8080
         users:
-        - name: kubelet
+        - name: default
           user:
             tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
         contexts:
         - context:
-            cluster: local
-            user: kubelet
-          name: kubelet-context
-        current-context: kubelet-context
+            cluster: default
+            user: default
+          name: default
+        current-context: default
 
   - path: /etc/kubernetes/kubeconfig/controller.yaml
     content: |

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -264,7 +264,7 @@ coreos:
         ExecStartPre=/usr/bin/docker run --rm -e SLEEP=false -e KUBERNETES_SERVICE_HOST= -e KUBERNETES_SERVICE_PORT= -v /opt/cni/bin:/host/opt/cni/bin {{ .CalicoCniImage.RepoWithTag }} /install-cni.sh
         {{end -}}
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
-        --kubeconfig=/etc/kubernetes/controller-kubeconfig.yaml \
+        --kubeconfig=/etc/kubernetes/kubeconfig/controller.yaml \
         --require-kubeconfig \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
         {{/* Work-around until https://github.com/kubernetes/kubernetes/issues/43967 is fixed via https://github.com/kubernetes/kubernetes/pull/43995 */ -}}
@@ -1733,24 +1733,18 @@ write_files:
                 command:
                 - /hyperkube
                 - proxy
-                - --kubeconfig=/etc/kubernetes/proxy-kubeconfig.yaml
+                - --kubeconfig=/etc/kubernetes/kubeconfig/kube-proxy.yaml
                 - --cluster-cidr={{.PodCIDR}}
                 securityContext:
                   privileged: true
                 volumeMounts:
-                - mountPath: /etc/kubernetes
+                - mountPath: /etc/kubernetes/kubeconfig
                   name: kubeconfig
                   readOnly: true
-                - mountPath: /var/run/dbus
-                  name: dbus
-                  readOnly: false
               volumes:
               - name: kubeconfig
                 hostPath:
-                  path: /etc/kubernetes
-              - hostPath:
-                  path: /var/run/dbus
-                name: dbus
+                  path: /etc/kubernetes/kubeconfig
 
   - path: /etc/kubernetes/manifests/kube-apiserver.yaml
     content: |
@@ -2743,7 +2737,7 @@ write_files:
     content: {{.AssetsConfig.EtcdTrustedCA}}
 {{ end }}
 
-  - path: /etc/kubernetes/proxy-kubeconfig.yaml
+  - path: /etc/kubernetes/kubeconfig/kube-proxy.yaml
     content: |
         apiVersion: v1
         kind: Config
@@ -2760,7 +2754,7 @@ write_files:
           name: kubelet-context
         current-context: kubelet-context
 
-  - path: /etc/kubernetes/controller-kubeconfig.yaml
+  - path: /etc/kubernetes/kubeconfig/controller.yaml
     content: |
         apiVersion: v1
         kind: Config

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2746,7 +2746,7 @@ write_files:
         - name: local
           cluster:
             certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            server: http://127.0.0.1:8080
+            server: http://localhost:8080
         users:
         - name: kubelet
           user:
@@ -2765,7 +2765,7 @@ write_files:
         clusters:
         - name: local
           cluster:
-            server: http://127.0.0.1:8080
+            server: http://localhost:8080
         users:
         - name: kubelet
         contexts:

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -304,12 +304,12 @@ coreos:
         --cloud-provider=aws \
         --cert-dir=/etc/kubernetes/ssl \
         {{- if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}
-        --experimental-bootstrap-kubeconfig=/etc/kubernetes/worker-bootstrap-kubeconfig.yaml \
+        --experimental-bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- else }}
         --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
         {{- end }}
-        --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+        --kubeconfig=/etc/kubernetes/kubeconfig/worker.yaml \
         {{- if .FeatureGates.Enabled }}
         --feature-gates="{{.FeatureGates.String}}" \
         {{- end }}
@@ -494,7 +494,7 @@ coreos:
           {{end -}}
           {{.HyperkubeImage.RepoWithTag}} /bin/bash \
             -ec 'echo "placing labels and annotations with additional AWS parameters."; \
-             kctl="/kubectl --server={{.APIEndpointURL}}:443 --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml"; \
+             kctl="/kubectl --server={{.APIEndpointURL}}:443 --kubeconfig=/etc/kubernetes/kubeconfig/worker.yaml"; \
              kctl_label="$kctl label --overwrite nodes/$(hostname)"; \
              kctl_annotate="$kctl annotate --overwrite nodes/$(hostname)"; \
              {{if not .SpotFleet.Enabled -}}
@@ -806,7 +806,7 @@ write_files:
            {{ if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}
            echo injecting token into the kubelet bootstrap kubeconfig file
            bootstrap_token=$(cat /etc/kubernetes/auth/kubelet-tls-bootstrap-token.tmp);
-           sed -i -e "s#\$KUBELET_BOOTSTRAP_TOKEN#$bootstrap_token#g" /etc/kubernetes/worker-bootstrap-kubeconfig.yaml
+           sed -i -e "s#\$KUBELET_BOOTSTRAP_TOKEN#$bootstrap_token#g" /etc/kubernetes/kubeconfig/worker-bootstrap.yaml
            {{ end }}
            echo done.'
 
@@ -907,7 +907,7 @@ write_files:
 {{end}}
 {{end}}
 
-  - path: /etc/kubernetes/proxy-kubeconfig.yaml
+  - path: /etc/kubernetes/kubeconfig/kube-proxy.yaml
     content: |
         apiVersion: v1
         kind: Config
@@ -928,7 +928,7 @@ write_files:
         current-context: default
 
 {{ if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}
-  - path: /etc/kubernetes/worker-bootstrap-kubeconfig.yaml
+  - path: /etc/kubernetes/kubeconfig/worker-bootstrap.yaml
     content: |
         apiVersion: v1
         kind: Config
@@ -948,7 +948,7 @@ write_files:
           name: tls-bootstrap-context
         current-context: tls-bootstrap-context
 {{ else }}
-  - path: /etc/kubernetes/worker-kubeconfig.yaml
+  - path: /etc/kubernetes/kubeconfig/worker.yaml
     content: |
         apiVersion: v1
         kind: Config

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -907,6 +907,7 @@ write_files:
 {{end}}
 {{end}}
 
+  # File needed on every node (used by the kube-proxy DaemonSet), including controllers
   - path: /etc/kubernetes/kubeconfig/kube-proxy.yaml
     content: |
         apiVersion: v1

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -273,6 +273,7 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
+        ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /etc/kubernetes/cni/net.d/  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
         ExecStartPre=/usr/bin/etcdctl \
                        --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
@@ -906,46 +907,25 @@ write_files:
 {{end}}
 {{end}}
 
-  - path: /etc/kubernetes/manifests/kube-proxy.yaml
+  - path: /etc/kubernetes/proxy-kubeconfig.yaml
     content: |
         apiVersion: v1
-        kind: Pod
-        metadata:
-          name: kube-proxy
-          namespace: kube-system
-          annotations:
-            rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
-        spec:
-          hostNetwork: true
-          containers:
-          - name: kube-proxy
-            image: {{.HyperkubeImage.RepoWithTag}}
-            command:
-            - /hyperkube
-            - proxy
-            - --master={{.APIEndpointURL}}
-            - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
-            securityContext:
-              privileged: true
-            volumeMounts:
-              - mountPath: /etc/ssl/certs
-                name: ssl-certs
-              - mountPath: /etc/kubernetes
-                name: kubeconfig
-                readOnly: true
-              - mountPath: /var/run/dbus
-                name: dbus
-                readOnly: false
-          volumes:
-            - name: ssl-certs
-              hostPath:
-                path: /usr/share/ca-certificates
-            - name: kubeconfig
-              hostPath:
-                path: /etc/kubernetes
-            - name: dbus
-              hostPath:
-                path: /var/run/dbus
+        kind: Config
+        clusters:
+        - name: default
+          cluster:
+            certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            server: {{.APIEndpointURL}}:443
+        users:
+        - name: default
+          user:
+            tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+        contexts:
+        - context:
+            cluster: default
+            user: default
+          name: default
+        current-context: default
 
 {{ if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}
   - path: /etc/kubernetes/worker-bootstrap-kubeconfig.yaml


### PR DESCRIPTION
This PR changes the way of deploying kube-proxy; instead of deploying it via a Pod manifest on every node, it creates a `DaemonSet` that tolerates every possible taint.

The way this was implemented does not break any kube-aws feature, most notably the ability to use different API endpoints in different node pools. (This is why the kube-proxy kubeconfig file was not deployed as a `ConfigMap`, [as is done by kubeadm](https://github.com/kubernetes/kubernetes/blob/9d725da4c38ddbce5f8aec6b881df1e2f310c457/cmd/kubeadm/app/phases/addons/proxy/manifests.go#L22-L48))

Closes #793.