### PR TITLE
GPU Build Fix + Adding G3 and P3 Instances

### DIFF
--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -1040,7 +1040,7 @@ write_files:
       set -e
       function is_gpu_enabled(){
         local instance_type=$1
-        [[ -n $instance_type ]] && ([[ $instance_type == p2* ]] || [[ $instance_type ==  g2* ]])
+        [[ -n $instance_type ]] && ([[ $instance_type == p2* ]] || [[ $instance_type ==  g2* ]] || [[ $instance_type == g3* ]])
       }
 
       INSTANCE_TYPE=$(curl -s http://169.254.169.254/latest/meta-data/instance-type)
@@ -1099,6 +1099,18 @@ write_files:
       # Create the device node for the nvidia-uvm module
       ACTION=="add" DEVPATH=="/module/nvidia_uvm" SUBSYSTEM=="module" RUN+="/opt/nvidia/current/bin/create-uvm-dev-node.sh"
 
+  - path: /opt/nvidia-build/git_versions.sh
+    owner: root:root
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      set -e
+      source /usr/share/coreos/release
+      OVERLAY_VERSION=`curl -s https://raw.githubusercontent.com/coreos/manifest/v${COREOS_RELEASE_VERSION}/release.xml | grep coreos-overlay | cut -d\" -f 8`
+      PORTAGE_VERSION=`curl -s https://raw.githubusercontent.com/coreos/manifest/v${COREOS_RELEASE_VERSION}/release.xml | grep portage-stable | cut -d\" -f 8`
+      git -C /var/lib/portage/coreos-overlay checkout ${OVERLAY_VERSION}
+      git -C /var/lib/portage/portage-stable checkout ${PORTAGE_VERSION}
+
   - path: /opt/nvidia-build/_container_build.sh
     owner: root:root
     permissions: 0755
@@ -1106,7 +1118,8 @@ write_files:
       #!/bin/sh
 
       # Default: use binary packages instead of building everything from source
-      EMERGE_SOURCE_FLAGS=gK
+      # Default: build everything from source.
+      #EMERGE_SOURCE_FLAGS=gK
       while :; do
         case $1 in
           --emerge-sources)
@@ -1132,6 +1145,7 @@ write_files:
       emerge-gitclone
       . /usr/share/coreos/release
       git -C /var/lib/portage/coreos-overlay checkout build-${COREOS_RELEASE_VERSION%%.*}
+      bash git_versions.sh
       emerge -${EMERGE_SOURCE_FLAGS}q --jobs 4 --load-average 4 coreos-sources
 
       cd /usr/src/linux
@@ -1391,6 +1405,8 @@ write_files:
 
       mkdir -p /etc/ld.so.conf.d/ 2>/dev/null
       echo "/opt/nvidia/current/lib64" > /etc/ld.so.conf.d/nvidia.conf
+      rm /opt/nvidia/current/lib64/libEGL.so.1
+      ln -s /opt/nvidia/current/lib64/libEGL.so.$DRIVER_VERSION /opt/nvidia/current/lib64/libEGL.so.1
       ldconfig
 
   - path: /opt/nvidia-build/util/retry.sh

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -1286,6 +1286,7 @@ write_files:
 
       systemd-nspawn -i ${DEV_CONTAINER} \
         --bind=${PWD}/_container_build.sh:/build.sh \
+        --bind=${PWD}/git_versions.sh:/git_versions.sh \
         --bind=${PWD}/${WORK_DIR}:/nvidia_installers \
         /bin/bash -x /build.sh ${EMERGE_SOURCES} ${DRIVER_VERSION} || echo "nspawn fails as expected.  Because kernel modules can't install in the container"
 

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -1040,7 +1040,7 @@ write_files:
       set -e
       function is_gpu_enabled(){
         local instance_type=$1
-        [[ -n $instance_type ]] && ([[ $instance_type == p2* ]] || [[ $instance_type ==  g2* ]] || [[ $instance_type == g3* ]])
+        [[ -n $instance_type ]] && ([[ $instance_type == p2* ]] || [[ $instance_type == p3* ]] || [[ $instance_type ==  g2* ]] || [[ $instance_type == g3* ]])
       }
 
       INSTANCE_TYPE=$(curl -s http://169.254.169.254/latest/meta-data/instance-type)

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -1099,18 +1099,6 @@ write_files:
       # Create the device node for the nvidia-uvm module
       ACTION=="add" DEVPATH=="/module/nvidia_uvm" SUBSYSTEM=="module" RUN+="/opt/nvidia/current/bin/create-uvm-dev-node.sh"
 
-  - path: /opt/nvidia-build/git_versions.sh
-    owner: root:root
-    permissions: 0755
-    content: |
-      #!/bin/bash
-      set -e
-      source /usr/share/coreos/release
-      OVERLAY_VERSION=`curl -s https://raw.githubusercontent.com/coreos/manifest/v${COREOS_RELEASE_VERSION}/release.xml | grep coreos-overlay | cut -d\" -f 8`
-      PORTAGE_VERSION=`curl -s https://raw.githubusercontent.com/coreos/manifest/v${COREOS_RELEASE_VERSION}/release.xml | grep portage-stable | cut -d\" -f 8`
-      git -C /var/lib/portage/coreos-overlay checkout ${OVERLAY_VERSION}
-      git -C /var/lib/portage/portage-stable checkout ${PORTAGE_VERSION}
-
   - path: /opt/nvidia-build/_container_build.sh
     owner: root:root
     permissions: 0755
@@ -1118,8 +1106,7 @@ write_files:
       #!/bin/sh
 
       # Default: use binary packages instead of building everything from source
-      # Default: build everything from source.
-      #EMERGE_SOURCE_FLAGS=gK
+      EMERGE_SOURCE_FLAGS=gK
       while :; do
         case $1 in
           --emerge-sources)
@@ -1145,7 +1132,6 @@ write_files:
       emerge-gitclone
       . /usr/share/coreos/release
       git -C /var/lib/portage/coreos-overlay checkout build-${COREOS_RELEASE_VERSION%%.*}
-      bash git_versions.sh
       emerge -${EMERGE_SOURCE_FLAGS}q --jobs 4 --load-average 4 coreos-sources
 
       cd /usr/src/linux
@@ -1286,7 +1272,6 @@ write_files:
 
       systemd-nspawn -i ${DEV_CONTAINER} \
         --bind=${PWD}/_container_build.sh:/build.sh \
-        --bind=${PWD}/git_versions.sh:/git_versions.sh \
         --bind=${PWD}/${WORK_DIR}:/nvidia_installers \
         /bin/bash -x /build.sh ${EMERGE_SOURCES} ${DRIVER_VERSION} || echo "nspawn fails as expected.  Because kernel modules can't install in the container"
 

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -360,7 +360,7 @@ worker:
 #
 #      # (Experimental) GPU Driver installation support
 #      # Currently, only Nvidia driver is supported.
-#      # This setting takes effect only when configured instance type is GPU enabled (p2 or g2).
+#      # This setting takes effect only when configured instance type is GPU enabled (p2, g2, or g3).
 #      # Make sure to choose 'docker' as container runtime when enabled this feature.
 #      # Ensure that automatic Container Linux is disabled(it is disabled by default btw).
 #      # Otherwise the installed driver may stop working when an OS update resulted in an updated kernel

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -360,7 +360,7 @@ worker:
 #
 #      # (Experimental) GPU Driver installation support
 #      # Currently, only Nvidia driver is supported.
-#      # This setting takes effect only when configured instance type is GPU enabled (p2, g2, or g3).
+#      # This setting takes effect only when configured instance type is GPU enabled (p2, p3, g2, or g3).
 #      # Make sure to choose 'docker' as container runtime when enabled this feature.
 #      # Ensure that automatic Container Linux is disabled(it is disabled by default btw).
 #      # Otherwise the installed driver may stop working when an OS update resulted in an updated kernel

--- a/model/gpu.go
+++ b/model/gpu.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var GPUEnabledInstanceFamily = []string{"p2", "g2"}
+var GPUEnabledInstanceFamily = []string{"p2", "g2", "g3"}
 
 type Gpu struct {
 	Nvidia NvidiaSetting `yaml:"nvidia"`

--- a/model/gpu.go
+++ b/model/gpu.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var GPUEnabledInstanceFamily = []string{"p2", "g2", "g3"}
+var GPUEnabledInstanceFamily = []string{"p2", "p3", "g2", "g3"}
 
 type Gpu struct {
 	Nvidia NvidiaSetting `yaml:"nvidia"`

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -4232,7 +4232,7 @@ worker:
         enabled: true
         version: ""
 `,
-			expectedErrorMessage: `instance type t2.medium doesn't support GPU. You can enable Nvidia driver intallation support only when use [p2 g2 g3] instance family.`,
+			expectedErrorMessage: `instance type t2.medium doesn't support GPU. You can enable Nvidia driver intallation support only when use [p2 p3 g2 g3] instance family.`,
 		},
 	}
 

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -4232,7 +4232,7 @@ worker:
         enabled: true
         version: ""
 `,
-			expectedErrorMessage: `instance type t2.medium doesn't support GPU. You can enable Nvidia driver intallation support only when use [p2 g2] instance family.`,
+			expectedErrorMessage: `instance type t2.medium doesn't support GPU. You can enable Nvidia driver intallation support only when use [p2 g2 g3] instance family.`,
 		},
 	}
 


### PR DESCRIPTION
This PR fixes the build process for building NVIDIA drivers. It also adds support for P3 and G3 instances.