### PR TITLE
Add setting for worker nodePools to specify --max-pods.

### DIFF
--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -296,6 +296,9 @@ coreos:
         {{end}}--register-node=true \
         {{if .Taints}}--register-with-taints={{.Taints.String}}\
         {{end}}--allow-privileged=true \
+        {{- if .MaxPods }}
+        --max-pods={{.MaxPodsToString}} \ 
+        {{- end }}
         {{if .NodeStatusUpdateFrequency}}--node-status-update-frequency={{.NodeStatusUpdateFrequency}} \
         {{end}}--pod-manifest-path=/etc/kubernetes/manifests \
         {{ if .KubeDns.NodeLocalResolver }}--cluster-dns=${COREOS_PRIVATE_IPV4} \

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -538,6 +538,8 @@ worker:
 #            Description=Example Custom Service
 #            [Service]
 #            ExecStart=/bin/rkt run --set-env TAGS=Controller ...
+#      # Max pods (--max-pods option for kubelet) Number of Pods that can run on this Kubelet. (default 110)
+#      maxPods: 110
 
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -17,6 +17,7 @@ type NodePoolConfig struct {
 	UnknownKeys               `yaml:",inline"`
 	NodeSettings              `yaml:",inline"`
 	NodeStatusUpdateFrequency string              `yaml:"nodeStatusUpdateFrequency"`
+	MaxPods                   int32               `yaml:"maxPods,omitempty"`
 	CustomFiles               []CustomFile        `yaml:"customFiles,omitempty"`
 	CustomSystemdUnits        []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
 	Gpu                       Gpu                 `yaml:"gpu"`
@@ -134,4 +135,8 @@ func (c NodePoolConfig) RollingUpdateMinInstancesInService() int {
 		return 0
 	}
 	return *c.AutoScalingGroup.RollingUpdateMinInstancesInService
+}
+
+func (c NodePoolConfig) MaxPodsToString() string {
+	return fmt.Sprint(c.MaxPods)
 }


### PR DESCRIPTION
I found this option useful in a testing cluster.  Normally there is a hard limit of 100 pods per node.  If you're using very small resource limits you can easily fit more pods than 100 on a node.