### PR TITLE
Check to ensure new API servers can receive communication from workers

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -390,6 +390,7 @@ coreos:
         {{ if .UseCalico }}
         ExecStartPre=/usr/bin/bash -c "until /usr/bin/docker run --net=host --pid=host --rm {{ .CalicoCtlImage.RepoWithTag }} node status > /dev/null; do sleep 3; done && echo Calico running"
         {{ end }}
+        ExecStartPre=/opt/bin/check-worker-communication
         ExecStart=/opt/bin/cfn-signal
 {{end}}
 {{if .Experimental.AwsNodeLabels.Enabled }}
@@ -3090,5 +3091,43 @@ write_files:
               sleep $attempt_interval_sec;
           fi
       done
+
+  - path: /opt/bin/check-worker-communication
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash -e
+      set -ue
+
+      kubectl() {
+        /usr/bin/docker run --rm --net=host -v /srv/kubernetes:/srv/kubernetes {{.HyperkubeImage.RepoWithTag}} /hyperkube kubectl "$@"
+      }
+
+      queryserver() {
+        echo "Checking to see if workers are communicating with API server."
+        docker logs --tail 10 ${DOCKERIMAGE} |& grep -v 127.0.0.1 | awk 'BEGIN {C=1} /kubelet\// && $8 == "200" {C=0} END {exit C}'
+      }
+
+      #This checks whether there are any nodes other than controllers. If there is, this indicates it is a cluster update, if there is not, is a fresh cluster.
+      #If it is an update, we check whether the workers can communicate with the API server before reporting success.
+
+      kubectl get nodes 2>/dev/null
+      RC=$?
+      if [[ $RC -gt 0 ]]; then
+        echo "No nodes present, assuming API server not yet ready, cannot verify cluster is up."
+        exit 1
+      fi
+
+      NUM_WORKERS=$(kubectl get nodes -l node-role.kubernetes.io/master!="" 2>/dev/null)
+      if [[ -z ${NUM_WORKERS} ]]; then
+        echo "Fresh cluster, not checking for existing workers."
+        exit 0
+      else
+        #We first retrieve the name of the image which is running the api-server, and then search its logs for any mentions of kubelet with a 200 response.
+
+        DOCKERIMAGE=$(docker ps | grep -i k8s_kube-apiserver_kube-apiserver | awk '{print $1}')
+        until queryserver; do echo "Worker communication failed, retrying." && sleep 10; done
+        echo "Communication with workers has been established."
+      fi
 
 {{ end }}


### PR DESCRIPTION
An issue was encountered where RBAC was turned on in cluster and the new controllers started rejecting all communication from the 'old' workers.

The controllers have no check for problems like this, so their cfn-signal returned 'true' to cloud-formation, which triggered the update of the worker nodepools.

The controllers should not be considered healthy/deployed-successfully if a new apiserver instance cannot receive communication from the existing workers. 