### PR TITLE
Fix max iops typo

### DIFF
--- a/core/controlplane/cluster/cluster_test.go
+++ b/core/controlplane/cluster/cluster_test.go
@@ -666,7 +666,7 @@ controller:
 		},
 		{
 			expectedRootVolume: &ec2.CreateVolumeInput{
-				Iops:       aws.Int64(2000),
+				Iops:       aws.Int64(20000),
 				Size:       aws.Int64(100),
 				VolumeType: aws.String("io1"),
 			},
@@ -675,7 +675,7 @@ controller:
   rootVolume:
     type: io1
     size: 100
-    iops: 2000
+    iops: 20000
 `,
 		},
 		// TODO Remove test cases for deprecated keys in v0.9.7
@@ -702,14 +702,14 @@ controllerRootVolumeSize: 50
 		},
 		{
 			expectedRootVolume: &ec2.CreateVolumeInput{
-				Iops:       aws.Int64(2000),
+				Iops:       aws.Int64(20000),
 				Size:       aws.Int64(100),
 				VolumeType: aws.String("io1"),
 			},
 			clusterYaml: `
 controllerRootVolumeType: io1
 controllerRootVolumeSize: 100
-controllerRootVolumeIOPS: 2000
+controllerRootVolumeIOPS: 20000
 `,
 		},
 	}

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1310,7 +1310,7 @@ func (c DeploymentSettings) NATGateways() []model.NATGateway {
 
 func (c DefaultWorkerSettings) Validate() error {
 	if c.WorkerRootVolumeType == "io1" {
-		if c.WorkerRootVolumeIOPS < 100 || c.WorkerRootVolumeIOPS > 2000 {
+		if c.WorkerRootVolumeIOPS < 100 || c.WorkerRootVolumeIOPS > 20000 {
 			return fmt.Errorf("invalid workerRootVolumeIOPS: %d", c.WorkerRootVolumeIOPS)
 		}
 	} else {
@@ -1331,7 +1331,7 @@ func (c ControllerSettings) Validate() error {
 	rootVolume := controller.RootVolume
 
 	if rootVolume.Type == "io1" {
-		if rootVolume.IOPS < 100 || rootVolume.IOPS > 2000 {
+		if rootVolume.IOPS < 100 || rootVolume.IOPS > 20000 {
 			return fmt.Errorf("invalid controller.rootVolume.iops: %d", rootVolume.IOPS)
 		}
 	} else {

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -751,10 +751,10 @@ controller:
 controller:
   rootVolume:
     type: io1
-    iops: 2000
+    iops: 20000
 `,
 			volumeType: "io1",
-			iops:       2000,
+			iops:       20000,
 		},
 	}
 
@@ -777,7 +777,7 @@ controller:
 controller:
   rootVolume:
     type: gp2
-    iops: 2000
+    iops: 20000
 `,
 		`
 # IOPS smaller than the minimum (100)
@@ -787,11 +787,11 @@ controller:
     iops: 99
 `,
 		`
-# IOPS greater than the maximum (2000)
+# IOPS greater than the maximum (20000)
 controller:
   rootVolume:
     type: io1
-    iops: 2001
+    iops: 20001
 `,
 	}
 
@@ -858,10 +858,10 @@ workerRootVolumeIOPS: 100
 		{
 			conf: `
 workerRootVolumeType: io1
-workerRootVolumeIOPS: 2000
+workerRootVolumeIOPS: 20000
 `,
 			volumeType: "io1",
-			iops:       2000,
+			iops:       20000,
 		},
 	}
 
@@ -878,7 +878,7 @@ workerRootVolumeIOPS: 100
 		`
 # IOPS must be zero for volume types != 'io1'
 workerRootVolumeType: gp2
-workerRootVolumeIOPS: 2000
+workerRootVolumeIOPS: 20000
 `,
 		`
 # IOPS smaller than the minimum (100)
@@ -886,9 +886,9 @@ workerRootVolumeType: io1
 workerRootVolumeIOPS: 99
 `,
 		`
-# IOPS greater than the maximum (2000)
+# IOPS greater than the maximum (20000)
 workerRootVolumeType: io1
-workerRootVolumeIOPS: 2001
+workerRootVolumeIOPS: 20001
 `,
 	}
 

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -432,7 +432,7 @@ worker:
 #            # Defaults to worker.spotFleet.unitRootVolumeSize * weightedCapacity if omitted
 #            size:
 #            # Number of provisioned IOPS when rootVlumeType is io1
-#            # Must be within the range between 100 and 2000
+#            # Must be within the range between 100 and 20000
 #            # Defaults to worker.spotFleet.unitRootVolumeIOPS * weightedCapacity if omitted
 #            iops:
 #

--- a/core/nodepool/cluster/cluster_test.go
+++ b/core/nodepool/cluster/cluster_test.go
@@ -13,9 +13,10 @@ import (
 
 	"errors"
 	"fmt"
-	"github.com/kubernetes-incubator/kube-aws/plugin/pluginmodel"
 	"strings"
 	"testing"
+
+	"github.com/kubernetes-incubator/kube-aws/plugin/pluginmodel"
 )
 
 type dummyEC2CreateVolumeService struct {
@@ -181,7 +182,7 @@ rootVolume:
 		},
 		{
 			expectedRootVolume: &ec2.CreateVolumeInput{
-				Iops:       aws.Int64(2000),
+				Iops:       aws.Int64(20000),
 				Size:       aws.Int64(100),
 				VolumeType: aws.String("io1"),
 			},
@@ -189,7 +190,7 @@ rootVolume:
 rootVolume:
   type: io1
   size: 100
-  iops: 2000
+  iops: 20000
 `,
 		},
 	}

--- a/model/root_volume.go
+++ b/model/root_volume.go
@@ -27,8 +27,8 @@ func NewIo1RootVolume(size int, iops int) RootVolume {
 
 func (v RootVolume) Validate() error {
 	if v.Type == "io1" {
-		if v.IOPS < 100 || v.IOPS > 2000 {
-			return fmt.Errorf(`invalid rootVolumeIOPS %d in %+v: rootVolumeIOPS must be between 100 and 2000`, v.IOPS, v)
+		if v.IOPS < 100 || v.IOPS > 20000 {
+			return fmt.Errorf(`invalid rootVolumeIOPS %d in %+v: rootVolumeIOPS must be between 100 and 20000`, v.IOPS, v)
 		}
 	} else {
 		if v.IOPS != 0 {

--- a/model/volume_mount.go
+++ b/model/volume_mount.go
@@ -20,8 +20,8 @@ func (v VolumeMount) SystemdMountName() string {
 
 func (v VolumeMount) Validate() error {
 	if v.Type == "io1" {
-		if v.Iops < 100 || v.Iops > 2000 {
-			return fmt.Errorf(`invalid iops "%d" in %+v: iops must be between "100" and "2000"`, v.Iops, v)
+		if v.Iops < 100 || v.Iops > 20000 {
+			return fmt.Errorf(`invalid iops "%d" in %+v: iops must be between "100" and "20000"`, v.Iops, v)
 		}
 	} else {
 		if v.Iops != 0 {

--- a/test/integration/nodepool_test.go
+++ b/test/integration/nodepool_test.go
@@ -2,10 +2,11 @@ package integration
 
 import (
 	"fmt"
-	cfg "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
-	"github.com/kubernetes-incubator/kube-aws/core/nodepool/config"
 	"strings"
 	"testing"
+
+	cfg "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
+	"github.com/kubernetes-incubator/kube-aws/core/nodepool/config"
 )
 
 const nodepoolInsufficientConfigYaml = `clusterName: mycluster
@@ -124,7 +125,7 @@ spotFleet:
     instanceType: c4.large
     rootVolume:
       type: io1
-      # must be 100~2000
+      # must be 100~20000
       iops: 50
 `,
 		},


### PR DESCRIPTION
Max IOPS is `20000` not `2000` according to https://github.com/kubernetes-incubator/kube-aws/blob/master/vendor/github.com/aws/aws-sdk-go/models/apis/autoscaling/2011-01-01/api-2.json#L970 and https://aws.amazon.com/ebs/details/