### PR TITLE
Adding AlwaysPullImages admission controller option

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -41,6 +41,9 @@ func NewDefaultCluster() *Cluster {
 			PodSecurityPolicy{
 				Enabled: false,
 			},
+			AlwaysPullImages{
+				Enabled: false,
+			},
 			DenyEscalatingExec{
 				Enabled: false,
 			},
@@ -520,8 +523,13 @@ type Experimental struct {
 
 type Admission struct {
 	PodSecurityPolicy  PodSecurityPolicy  `yaml:"podSecurityPolicy"`
+	AlwaysPullImages   AlwaysPullImages   `yaml:"alwaysPullImages"`
 	DenyEscalatingExec DenyEscalatingExec `yaml:"denyEscalatingExec"`
 	Initializers       Initializers       `yaml:"initializers"`
+}
+
+type AlwaysPullImages struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 type PodSecurityPolicy struct {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1890,7 +1890,7 @@ write_files:
           - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
           {{ end }}
           - --advertise-address=$private_ipv4
-          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }}{{if .Experimental.NodeAuthorizer.Enabled}},NodeRestriction{{end}},ResourceQuota{{if .Experimental.Admission.DenyEscalatingExec.Enabled}},DenyEscalatingExec{{end}}{{if .Experimental.Admission.Initializers.Enabled}},Initializers{{end}}
+          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }}{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{if .Experimental.NodeAuthorizer.Enabled}},NodeRestriction{{end}},ResourceQuota{{if .Experimental.Admission.DenyEscalatingExec.Enabled}},DenyEscalatingExec{{end}}{{if .Experimental.Admission.Initializers.Enabled}},Initializers{{end}}
           - --anonymous-auth=false
           {{if .Experimental.Oidc.Enabled}}
           - --oidc-issuer-url={{.Experimental.Oidc.IssuerUrl}}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1177,6 +1177,10 @@ experimental:
   admission:
     podSecurityPolicy:
       enabled: false
+    # alwaysPullImages Note
+    # Recommended to turn this on when and only when docker registries are reliable enough.
+    # Otherwise, automatic pod restarts can be delayed due to temporally docker registry outages.
+    # Please see https://github.com/kubernetes-incubator/kube-aws/pull/1009#discussion_r151197787 for more info.
     alwaysPullImages:
       enabled: false
     denyEscalatingExec:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1177,6 +1177,8 @@ experimental:
   admission:
     podSecurityPolicy:
       enabled: false
+    alwaysPullImages:
+      enabled: false
     denyEscalatingExec:
       enabled: false
     initializers:

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -83,6 +83,9 @@ func TestMainClusterConfig(t *testing.T) {
 				PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
 					Enabled: false,
 				},
+				AlwaysPullImages: controlplane_config.AlwaysPullImages{
+					Enabled: false,
+				},
 				DenyEscalatingExec: controlplane_config.DenyEscalatingExec{
 					Enabled: false,
 				},
@@ -1151,6 +1154,8 @@ experimental:
       enabled: true
     denyEscalatingExec:
       enabled: true
+    alwaysPullImages:
+      enabled: true
   auditLog:
     enabled: true
     maxage: 100
@@ -1208,7 +1213,10 @@ worker:
 				func(c *config.Config, t *testing.T) {
 					expected := controlplane_config.Experimental{
 						Admission: controlplane_config.Admission{
-							PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
+							'PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
+								Enabled: true,
+							},
+							AlwaysPullImages: controlplane_config.AlwaysPullImages{
 								Enabled: true,
 							},
 							DenyEscalatingExec: controlplane_config.DenyEscalatingExec{

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1213,7 +1213,7 @@ worker:
 				func(c *config.Config, t *testing.T) {
 					expected := controlplane_config.Experimental{
 						Admission: controlplane_config.Admission{
-							'PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
+							PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
 								Enabled: true,
 							},
 							AlwaysPullImages: controlplane_config.AlwaysPullImages{


### PR DESCRIPTION
This adds an experimental option to enable the "AlwaysPullImages" admission plugin.

Per https://kubernetes.io/docs/admin/admission-controllers/#alwayspullimages as of now:

> This plug-in modifies every new Pod to force the image pull policy to Always. This is useful in a multitenant cluster so that users can be assured that their private images can only be used by those who have the credentials to pull them. Without this plug-in, once an image has been pulled to a node, any pod from any user can use it simply by knowing the image’s name (assuming the Pod is scheduled onto the right node), without any authorization check against the image. When this plug-in is enabled, images are always pulled prior to starting containers, which means valid credentials are required.
