### PR TITLE
 Fix kubelet-to-apiserver connection checks on controller nodes not to fail in certain cases

### DIFF
--- a/core/controlplane/config/credential.go
+++ b/core/controlplane/config/credential.go
@@ -80,7 +80,10 @@ func EncryptedCredentialCacheFromRawCredential(raw *RawCredentialOnDisk, bytesEn
 }
 
 func RawCredentialFileFromPath(filePath string, defaultValue *string) (*RawCredentialOnDisk, error) {
-	if _, err := os.Stat(filePath); os.IsNotExist(err) && defaultValue != nil {
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		if defaultValue == nil {
+			return nil, fmt.Errorf("%s must exist. Please confirm that you have not deleted the file manually", filePath)
+		}
 		if err := ioutil.WriteFile(filePath, []byte(*defaultValue), 0644); err != nil {
 			return nil, err
 		}
@@ -102,6 +105,9 @@ func (c *RawCredentialOnDisk) Fingerprint() string {
 }
 
 func (c *RawCredentialOnDisk) Persist() error {
+	if len(c.content) == 0 {
+		return fmt.Errorf("%s is going to be empty. Maybe a bug", c.filePath)
+	}
 	if err := ioutil.WriteFile(c.filePath, c.content, 0600); err != nil {
 		return err
 	}

--- a/core/controlplane/config/encrypted_assets.go
+++ b/core/controlplane/config/encrypted_assets.go
@@ -440,39 +440,46 @@ func ReadOrEncryptAssets(dirname string, manageCertificates bool, caKeyRequiredO
 }
 
 func (r *RawAssetsOnMemory) WriteToDir(dirname string, includeCAKey bool) error {
+	workerCAKeyDefaultSymlinkTo := ""
+	if includeCAKey {
+		workerCAKeyDefaultSymlinkTo = "ca-key.pem"
+	}
+
 	assets := []struct {
-		name      string
-		data      []byte
-		overwrite bool
+		name             string
+		data             []byte
+		overwrite        bool
+		ifEmptySymlinkTo string
 	}{
-		{"ca.pem", r.CACert, true},
-		{"worker-ca.pem", r.WorkerCACert, true},
-		{"worker-ca-key.pem", r.WorkerCAKey, true},
-		{"apiserver.pem", r.APIServerCert, true},
-		{"apiserver-key.pem", r.APIServerKey, true},
-		{"worker.pem", r.WorkerCert, true},
-		{"worker-key.pem", r.WorkerKey, true},
-		{"admin.pem", r.AdminCert, true},
-		{"admin-key.pem", r.AdminKey, true},
-		{"etcd.pem", r.EtcdCert, true},
-		{"etcd-key.pem", r.EtcdKey, true},
-		{"etcd-client.pem", r.EtcdClientCert, true},
-		{"etcd-client-key.pem", r.EtcdClientKey, true},
-		{"etcd-trusted-ca.pem", r.EtcdTrustedCA, true},
-		{"kubelet-tls-bootstrap-token", r.TLSBootstrapToken, true},
+		{"ca.pem", r.CACert, true, ""},
+		{"worker-ca.pem", r.WorkerCACert, true, "ca.pem"},
+		{"worker-ca-key.pem", r.WorkerCAKey, true, workerCAKeyDefaultSymlinkTo},
+		{"apiserver.pem", r.APIServerCert, true, ""},
+		{"apiserver-key.pem", r.APIServerKey, true, ""},
+		{"worker.pem", r.WorkerCert, true, ""},
+		{"worker-key.pem", r.WorkerKey, true, ""},
+		{"admin.pem", r.AdminCert, true, ""},
+		{"admin-key.pem", r.AdminKey, true, ""},
+		{"etcd.pem", r.EtcdCert, true, ""},
+		{"etcd-key.pem", r.EtcdKey, true, ""},
+		{"etcd-client.pem", r.EtcdClientCert, true, ""},
+		{"etcd-client-key.pem", r.EtcdClientKey, true, ""},
+		{"etcd-trusted-ca.pem", r.EtcdTrustedCA, true, "ca.pem"},
+		{"kubelet-tls-bootstrap-token", r.TLSBootstrapToken, true, ""},
 
 		// Content entirely provided by user, so do not overwrite it if
 		// the file already exists
-		{"tokens.csv", r.AuthTokens, false},
+		{"tokens.csv", r.AuthTokens, false, ""},
 	}
 
 	if includeCAKey {
 		// This is required to be linked from worker-ca-key.pem
 		assets = append(assets, struct {
-			name      string
-			data      []byte
-			overwrite bool
-		}{"ca-key.pem", r.CAKey, true})
+			name             string
+			data             []byte
+			overwrite        bool
+			ifEmptySymlinkTo string
+		}{"ca-key.pem", r.CAKey, true, ""})
 	}
 
 	for _, asset := range assets {
@@ -489,55 +496,62 @@ func (r *RawAssetsOnMemory) WriteToDir(dirname string, includeCAKey bool) error 
 				return err
 			}
 		}
+		if len(asset.data) == 0 {
+			if asset.ifEmptySymlinkTo != "" {
+				// etcd trusted ca and worker-ca are separate files, but pointing to ca.pem by default.
+				// In advanced configurations, when certs are managed outside of kube-aws,
+				// these can be separate CAs to ensure that worker nodes have no certs which would let them
+				// access etcd directly. If worker-ca.pem != ca.pem, then ca.pem should include worker-ca.pem
+				// to let TLS bootstrapped workers acces APIServer.
+				wd, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+
+				if err := os.Chdir(dirname); err != nil {
+					return err
+				}
+
+				// The path of the symlink
+				from := asset.name
+				// The path to the actual file
+				to := asset.ifEmptySymlinkTo
+
+				lstatFileInfo, lstatErr := os.Lstat(from)
+				symlinkExists := lstatErr == nil && (lstatFileInfo.Mode()&os.ModeSymlink == os.ModeSymlink)
+				fileExists := lstatErr == nil && !symlinkExists
+
+				if fileExists {
+					fmt.Printf("INFO: Removing a file at %s\n", from)
+					if err := os.Remove(from); err != nil {
+						return err
+					}
+				}
+
+				if symlinkExists {
+					fmt.Printf("INFO: Removing a symlink at %s\n", from)
+					if err := os.Remove(from); err != nil {
+						return err
+					}
+				}
+
+				fmt.Printf("INFO: Creating a symlink from %s to %s\n", from, to)
+				if err := os.Symlink(to, from); err != nil {
+					return err
+				}
+
+				if err := os.Chdir(wd); err != nil {
+					return err
+				}
+				continue
+			} else if asset.name != "tokens.csv" {
+				return fmt.Errorf("Not sure what to do for %s", path)
+			}
+		}
+		fmt.Printf("INFO: Writing %d bytes to %s\n", len(asset.data), path)
 		if err := ioutil.WriteFile(path, asset.data, 0600); err != nil {
 			return err
 		}
-	}
-
-	// etcd trusted ca and worker-ca are separate files, but pointing to ca.pem by default.
-	// In advanced configurations, when certs are managed outside of kube-aws,
-	// these can be separate CAs to ensure that worker nodes have no certs which would let them
-	// access etcd directly. If worker-ca.pem != ca.pem, then ca.pem should include worker-ca.pem
-	// to let TLS bootstrapped workers acces APIServer.
-	type symlink struct {
-		from string
-		to   string
-	}
-	symlinks := []symlink{
-		{"ca.pem", "worker-ca.pem"},
-		{"ca.pem", "etcd-trusted-ca.pem"},
-	}
-
-	if includeCAKey {
-		symlinks = append(symlinks, symlink{"ca-key.pem", "worker-ca-key.pem"})
-	}
-
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	if err := os.Chdir(dirname); err != nil {
-		return err
-	}
-
-	for _, sl := range symlinks {
-		from := sl.from
-		to := sl.to
-
-		if _, err := os.Lstat(to); err == nil {
-			if err := os.Remove(to); err != nil {
-				return err
-			}
-		}
-
-		if err := os.Symlink(from, to); err != nil {
-			return err
-		}
-	}
-
-	if err := os.Chdir(wd); err != nil {
-		return err
 	}
 
 	return nil

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -390,7 +390,9 @@ coreos:
         {{ if .UseCalico }}
         ExecStartPre=/usr/bin/bash -c "until /usr/bin/docker run --net=host --pid=host --rm {{ .CalicoCtlImage.RepoWithTag }} node status > /dev/null; do sleep 3; done && echo Calico running"
         {{ end }}
+        {{if .Experimental.AuditLog.Enabled -}}
         ExecStartPre=/opt/bin/check-worker-communication
+        {{end -}}
         ExecStart=/opt/bin/cfn-signal
 {{end}}
 {{if .Experimental.AwsNodeLabels.Enabled }}
@@ -1883,6 +1885,7 @@ write_files:
           - --audit-log-maxage={{.Experimental.AuditLog.MaxAge}}
           - --audit-log-path={{.Experimental.AuditLog.LogPath}}
           - --audit-log-maxbackup=1
+          - --audit-policy-file=/etc/kubernetes/apiserver/audit-policy.yaml
           {{ end }}
           - --authorization-mode={{if .Experimental.NodeAuthorizer.Enabled}}Node,{{end}}RBAC
           {{if .Experimental.Authentication.Webhook.Enabled}}
@@ -1947,6 +1950,9 @@ write_files:
           - mountPath: /var/log
             name: var-log
             readOnly: false
+          - mountPath: /etc/kubernetes/apiserver
+            name: apiserver
+            readOnly: true
           {{end}}
           {{range $v := .APIServerVolumes}}
           - mountPath: {{quote $v.Path}}
@@ -1974,6 +1980,9 @@ write_files:
         - hostPath:
             path: /var/log
           name: var-log
+        - hostPath:
+            path: /etc/kubernetes/apiserver
+          name: apiserver
         {{end}}
         {{range $v := .APIServerVolumes}}
         - hostPath:
@@ -2942,6 +2951,143 @@ write_files:
 
 {{ end }}
 
+# AdvancedAuditing is enabled by default since K8S v1.8.
+# With AdvancedAuditing, you have to provide a audit policy file.
+# Otherwise no audit logs are recorded at all.
+{{if .Experimental.AuditLog.Enabled -}}
+  # Refer to the audit profile used by GCE
+  # https://github.com/kubernetes/kubernetes/blob/v1.8.3/cluster/gce/gci/configure-helper.sh#L517
+  - path: /etc/kubernetes/apiserver/audit-policy.yaml
+    owner: root:root
+    permissions: 0600
+    content: |
+      apiVersion: audit.k8s.io/v1beta1
+      kind: Policy
+      rules:
+        # The following requests were manually identified as high-volume and low-risk,
+        # so drop them.
+        - level: None
+          users: ["system:kube-proxy"]
+          verbs: ["watch"]
+          resources:
+            - group: "" # core
+              resources: ["endpoints", "services", "services/status"]
+        - level: None
+          # Ingress controller reads `configmaps/ingress-uid` through the unsecured port.
+          # TODO(#46983): Change this to the ingress controller service account.
+          users: ["system:unsecured"]
+          namespaces: ["kube-system"]
+          verbs: ["get"]
+          resources:
+            - group: "" # core
+              resources: ["configmaps"]
+        - level: None
+          users: ["kubelet"] # legacy kubelet identity
+          verbs: ["get"]
+          resources:
+            - group: "" # core
+              resources: ["nodes", "nodes/status"]
+        - level: None
+          userGroups: ["system:nodes"]
+          verbs: ["get"]
+          resources:
+            - group: "" # core
+              resources: ["nodes", "nodes/status"]
+        - level: None
+          users:
+            - system:kube-controller-manager
+            - system:kube-scheduler
+            - system:serviceaccount:kube-system:endpoint-controller
+          verbs: ["get", "update"]
+          namespaces: ["kube-system"]
+          resources:
+            - group: "" # core
+              resources: ["endpoints"]
+        - level: None
+          users: ["system:apiserver"]
+          verbs: ["get"]
+          resources:
+            - group: "" # core
+              resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+        # Don't log HPA fetching metrics.
+        - level: None
+          users:
+            - system:kube-controller-manager
+          verbs: ["get", "list"]
+          resources:
+            - group: "metrics.k8s.io"
+        # Don't log these read-only URLs.
+        - level: None
+          nonResourceURLs:
+            - /healthz*
+            - /version
+            - /swagger*
+        # Don't log events requests.
+        - level: None
+          resources:
+            - group: "" # core
+              resources: ["events"]
+        # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
+        # so only log at the Metadata level.
+        - level: Metadata
+          resources:
+            - group: "" # core
+              resources: ["secrets", "configmaps"]
+            - group: authentication.k8s.io
+              resources: ["tokenreviews"]
+          omitStages:
+            - "RequestReceived"
+        # Get responses can be large; skip them.
+        - level: Request
+          verbs: ["get", "list", "watch"]
+          resources:
+            - group: "" # core
+            - group: "admissionregistration.k8s.io"
+            - group: "apiextensions.k8s.io"
+            - group: "apiregistration.k8s.io"
+            - group: "apps"
+            - group: "authentication.k8s.io"
+            - group: "authorization.k8s.io"
+            - group: "autoscaling"
+            - group: "batch"
+            - group: "certificates.k8s.io"
+            - group: "extensions"
+            - group: "metrics.k8s.io"
+            - group: "networking.k8s.io"
+            - group: "policy"
+            - group: "rbac.authorization.k8s.io"
+            - group: "settings.k8s.io"
+            - group: "storage.k8s.io"
+          omitStages:
+            - "RequestReceived"
+        # Default level for known APIs
+        - level: RequestResponse
+          resources:
+            - group: "" # core
+            - group: "admissionregistration.k8s.io"
+            - group: "apiextensions.k8s.io"
+            - group: "apiregistration.k8s.io"
+            - group: "apps"
+            - group: "authentication.k8s.io"
+            - group: "authorization.k8s.io"
+            - group: "autoscaling"
+            - group: "batch"
+            - group: "certificates.k8s.io"
+            - group: "extensions"
+            - group: "metrics.k8s.io"
+            - group: "networking.k8s.io"
+            - group: "policy"
+            - group: "rbac.authorization.k8s.io"
+            - group: "settings.k8s.io"
+            - group: "storage.k8s.io"
+          omitStages:
+            - "RequestReceived"
+        # Default level for all other requests.
+        - level: Metadata
+          omitStages:
+            - "RequestReceived"
+{{ end -}}
+
 {{if .Experimental.Authentication.Webhook.Enabled}}
   - path: /etc/kubernetes/webhooks/authentication.yaml
     encoding: base64
@@ -3092,6 +3238,8 @@ write_files:
           fi
       done
 
+  {{if .Experimental.AuditLog.Enabled -}}
+  # Check worker communication by searching audit logs
   - path: /opt/bin/check-worker-communication
     permissions: 0700
     owner: root:root
@@ -3099,13 +3247,25 @@ write_files:
       #!/bin/bash -e
       set -ue
 
+      AUDIT_LOG_PATH="{{.Experimental.AuditLog.LogPath}}"
+
       kubectl() {
         /usr/bin/docker run --rm --net=host -v /srv/kubernetes:/srv/kubernetes {{.HyperkubeImage.RepoWithTag}} /hyperkube kubectl "$@"
       }
 
       queryserver() {
         echo "Checking to see if workers are communicating with API server."
-        docker logs --tail 10 ${DOCKERIMAGE} |& grep -v 127.0.0.1 | awk 'BEGIN {C=1} /kubelet\// && $8 == "200" {C=0} END {exit C}'
+        auditlogs | grep -v 127.0.0.1 | awk 'BEGIN {C=1} /kubelet\// && $8 == "200" {C=0} END {exit C}'
+      }
+
+      auditlogs() {
+        if [ "$AUDIT_LOG_PATH" == "/dev/stdout" ]; then
+          # Let `docker logs` gather logs for periods slightly longer than the delay between `queryserver` calls
+          # so that we won't drop any lines.
+          docker logs --since 11s ${DOCKERIMAGE} |& cat
+        else
+          cat "$AUDIT_LOG_PATH"
+        fi
       }
 
       #This checks whether there are any nodes other than controllers. If there is, this indicates it is a cluster update, if there is not, is a fresh cluster.
@@ -3129,5 +3289,6 @@ write_files:
         until queryserver; do echo "Worker communication failed, retrying." && sleep 10; done
         echo "Communication with workers has been established."
       fi
+  {{end -}}
 
 {{ end }}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3255,7 +3255,7 @@ write_files:
 
       queryserver() {
         echo "Checking to see if workers are communicating with API server."
-        auditlogs | grep -v 127.0.0.1 | awk 'BEGIN {C=1} /kubelet\// && $8 == "200" {C=0} END {exit C}'
+        auditlogs | grep -v 127.0.0.1 | grep kubelet | jq -c 'select(.responseStatus.code == 200)' --exit-status
       }
 
       auditlogs() {


### PR DESCRIPTION
- check-worker-connection was failing when audit logging is disabled
- In addition to that, it was failing since K8S v1.8 due to the change in K8S that no audits are logged when missing an audit policy file

Follow-up for #991 and #996 
Fix for https://github.com/kubernetes-incubator/kube-aws/pull/991#commitcomment-25459898
Depends on #1014