### PR TITLE
Update RBAC API version to v1 from v1beta1

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1474,7 +1474,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-role-bindings/node.yaml
     content: |
         kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kube-aws:node
         subjects:
@@ -1490,7 +1490,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-roles/node-extensions.yaml
     content: |
         kind: ClusterRole
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
             name: kube-aws:node-extensions
         rules:
@@ -1533,7 +1533,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-role-bindings/kube-admin.yaml
     content: |
         kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kube-aws:admin
         subjects:
@@ -1549,7 +1549,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-role-bindings/node-proxier.yaml
     content: |
         kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kube-aws:node-proxier
         subjects:
@@ -1570,7 +1570,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-role-bindings/system-worker.yaml
     content: |
         kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kube-aws:system-worker
         subjects:
@@ -1591,7 +1591,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-role-bindings/node-extensions.yaml
     content: |
         kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kube-aws:node-extensions
         subjects:
@@ -1608,7 +1608,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-role-bindings/heapster.yaml
     content: |
         kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: heapster
         roleRef:
@@ -1624,7 +1624,7 @@ write_files:
   # the resources of the deployment if necessary.
   - path: /srv/kubernetes/rbac/roles/pod-nanny.yaml
     content: |
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:
           name: system:pod-nanny
@@ -1651,7 +1651,7 @@ write_files:
   - path: /srv/kubernetes/rbac/role-bindings/heapster-nanny.yaml
     content: |
         kind: RoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: heapster-nanny
           namespace: kube-system
@@ -1673,7 +1673,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-roles/kubelet-certificate-bootstrap.yaml
     content: |
         kind: ClusterRole
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kube-aws:kubelet-certificate-bootstrap
         rules:
@@ -1688,7 +1688,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-role-bindings/kubelet-certificate-bootstrap.yaml
     content: |
         kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kube-aws:kubelet-certificate-bootstrap
         subjects:
@@ -1704,7 +1704,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-roles/node-bootstrapper.yaml
     content: |
         kind: ClusterRole
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kube-aws:node-bootstrapper
         rules:
@@ -1721,7 +1721,7 @@ write_files:
   - path: /srv/kubernetes/rbac/cluster-role-bindings/node-bootstrapper.yaml
     content: |
         kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kube-aws:node-bootstrapper
         subjects:
@@ -1738,7 +1738,7 @@ write_files:
   - path: /srv/kubernetes/rbac/roles/kubernetes-dashboard.yaml
     content: |
         kind: Role
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         metadata:
           name: kubernetes-dashboard-minimal
           namespace: kube-system
@@ -1757,7 +1757,7 @@ write_files:
 
   - path: /srv/kubernetes/rbac/role-bindings/kubernetes-dashboard.yaml
     content: |
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         metadata:
           name: kubernetes-dashboard-minimal
@@ -1774,7 +1774,7 @@ write_files:
 {{ if .KubeDashboardAdminPrivileges }}
   - path: /srv/kubernetes/rbac/cluster-role-bindings/kubernetes-dashboard-admin.yaml
     content: |
-        apiVersion: rbac.authorization.k8s.io/v1beta1
+        apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRoleBinding
         metadata:
           name: kubernetes-dashboard
@@ -1923,7 +1923,7 @@ write_files:
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1,rbac.authorization.k8s.io/v1beta1=true{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},extensions/v1beta1/podsecuritypolicy=true{{ end }}{{if .Experimental.Admission.Initializers.Enabled}},admissionregistration.k8s.io/v1alpha1{{end}}
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},extensions/v1beta1/podsecuritypolicy=true{{ end }}{{if .Experimental.Admission.Initializers.Enabled}},admissionregistration.k8s.io/v1alpha1{{end}}
           - --cloud-provider=aws
           {{range $f := .APIServerFlags}}
           - --{{$f.Name}}={{$f.Value}}
@@ -3194,7 +3194,7 @@ write_files:
         namespace: kube-system
       ---
 
-      apiVersion: rbac.authorization.k8s.io/v1beta1
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         annotations:
@@ -3214,7 +3214,7 @@ write_files:
         - watch
       ---
 
-      apiVersion: rbac.authorization.k8s.io/v1beta1
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
         name: kube2iam


### PR DESCRIPTION
This commit removes "rbac.authorization.k8s.io/v1beta1=true" from "--runtime-config" option as well.

Fixes #955