### PR TITLE
Make kube-node-label more reliable

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -411,36 +411,7 @@ coreos:
         Type=oneshot
         ExecStop=/bin/true
         RemainAfterExit=true
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)"
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment SECURITY_GROUPS=\"$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')\""
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment AUTOSCALINGGROUP=\"$(/usr/bin/docker run --rm --net=host \
-          {{.AWSCliImage.RepoWithTag}} aws \
-          autoscaling describe-auto-scaling-instances \
-          --instance-ids ${INSTANCE_ID} --region {{.Region}} \
-          --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)\""
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment \
-          LAUNCHCONFIGURATION=\"$(/usr/bin/docker run --rm --net=host \
-          {{.AWSCliImage.RepoWithTag}} \
-          aws autoscaling describe-auto-scaling-groups \
-          --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
-          --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)\""
-        ExecStartPre=/usr/bin/bash -c "until /usr/bin/curl -s -f http://127.0.0.1:8080/version; do echo waiting until apiserver starts; sleep 1; done"
-        ExecStart=/bin/sh -c "/usr/bin/curl \
-          --retry 3 \
-          --request PATCH \
-          -H 'Content-Type: application/strategic-merge-patch+json' \
-          -d'{ \
-          \"metadata\": { \
-            \"labels\": { \
-              \"kube-aws.coreos.com/autoscalinggroup\": \"${AUTOSCALINGGROUP}\", \
-              \"kube-aws.coreos.com/launchconfiguration\": \"${LAUNCHCONFIGURATION}\" \
-            }, \
-            \"annotations\": { \
-              \"kube-aws.coreos.com/securitygroups\": \"${SECURITY_GROUPS}\" \
-            } \
-          } \
-          }\"' \
-          http://localhost:8080/api/v1/nodes/$(hostname)"
+        ExecStart=/opt/bin/kube-node-label
 {{end}}
 
 {{if .Experimental.EphemeralImageStorage.Enabled}}
@@ -658,6 +629,48 @@ write_files:
 
       rkt rm --uuid-file=/var/run/coreos/set-aws-environment.uuid || :
 {{end}}
+
+  {{if .Experimental.AwsNodeLabels.Enabled -}}
+  - path: /opt/bin/kube-node-label
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash -e
+      set -ue
+
+      INSTANCE_ID="$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)"
+      SECURITY_GROUPS="$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')"
+      AUTOSCALINGGROUP="$(/usr/bin/docker run --rm --net=host \
+                {{.AWSCliImage.RepoWithTag}} aws \
+                autoscaling describe-auto-scaling-instances \
+                --instance-ids ${INSTANCE_ID} --region {{.Region}} \
+                --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)"
+      LAUNCHCONFIGURATION="$(/usr/bin/docker run --rm --net=host \
+                {{.AWSCliImage.RepoWithTag}} \
+                aws autoscaling describe-auto-scaling-groups \
+                --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
+                --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)"
+
+       until /usr/bin/curl -s -f http://127.0.0.1:8080/version; do echo waiting until apiserver starts; sleep 1; done
+
+       /usr/bin/curl \
+         --retry 5 \
+         --request PATCH \
+         -H 'Content-Type: application/strategic-merge-patch+json' \
+         -d '{
+              "metadata": {
+                "labels": {
+                  "kube-aws.coreos.com/autoscalinggroup": "'${AUTOSCALINGGROUP}'",
+                   "kube-aws.coreos.com/launchconfiguration": "'${LAUNCHCONFIGURATION}'"
+                 },
+                 "annotations": {
+                  "kube-aws.coreos.com/securitygroups": "'${SECURITY_GROUPS}'"
+                }
+              }
+            }' \
+         http://localhost:8080/api/v1/nodes/$(hostname)
+  {{end -}}
+
 {{ if .SharedPersistentVolume }}
   - path: /opt/bin/set-efs-pv
     owner: root:root

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -468,43 +468,9 @@ coreos:
 
         [Service]
         Type=oneshot
-        RemainAfterExit=true
         ExecStop=/bin/true
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)"
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment SECURITY_GROUPS=\"$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')\""
-        {{if not .SpotFleet.Enabled -}}
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment AUTOSCALINGGROUP=\"$(/usr/bin/docker run --rm --net=host \
-          {{.AWSCliImage.RepoWithTag}} aws \
-          autoscaling describe-auto-scaling-instances \
-          --instance-ids ${INSTANCE_ID} --region {{.Region}} \
-          --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)\""
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment \
-          LAUNCHCONFIGURATION=\"$(/usr/bin/docker run --rm --net=host \
-          {{.AWSCliImage.RepoWithTag}} \
-          aws autoscaling describe-auto-scaling-groups \
-          --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
-          --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)\""
-        {{end -}}
-        ExecStart=/usr/bin/docker run --rm -t --net=host \
-          -v /etc/kubernetes:/etc/kubernetes \
-          -v /etc/resolv.conf:/etc/resolv.conf \
-          -e INSTANCE_ID=${INSTANCE_ID} \
-          -e SECURITY_GROUPS=${SECURITY_GROUPS} \
-          {{if not .SpotFleet.Enabled -}}
-          -e AUTOSCALINGGROUP=${AUTOSCALINGGROUP} \
-          -e LAUNCHCONFIGURATION=${LAUNCHCONFIGURATION} \
-          {{end -}}
-          {{.HyperkubeImage.RepoWithTag}} /bin/bash \
-            -ec 'echo "placing labels and annotations with additional AWS parameters."; \
-             kctl="/kubectl --server={{.APIEndpointURL}}:443 --kubeconfig=/etc/kubernetes/kubeconfig/worker.yaml"; \
-             kctl_label="$kctl label --overwrite nodes/$(hostname)"; \
-             kctl_annotate="$kctl annotate --overwrite nodes/$(hostname)"; \
-             {{if not .SpotFleet.Enabled -}}
-             $kctl_label kube-aws.coreos.com/autoscalinggroup=${AUTOSCALINGGROUP}; \
-             $kctl_label kube-aws.coreos.com/launchconfiguration=${LAUNCHCONFIGURATION}; \
-             {{end -}}
-             $kctl_annotate kube-aws.coreos.com/securitygroups=${SECURITY_GROUPS}; \
-             echo "done."'
+        RemainAfterExit=true
+        ExecStart=/opt/bin/kube-node-label
 {{end}}
 
 {{if .Experimental.EphemeralImageStorage.Enabled}}
@@ -692,6 +658,74 @@ write_files:
 
       rkt rm --uuid-file=/var/run/coreos/set-aws-environment.uuid || :
 {{end}}
+
+  {{if .Experimental.AwsNodeLabels.Enabled -}}
+  - path: /opt/bin/kube-node-label
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash -e
+      set -ue
+
+      INSTANCE_ID="$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)"
+      SECURITY_GROUPS="$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')"
+      {{if not .SpotFleet.Enabled -}}
+      AUTOSCALINGGROUP="$(/usr/bin/docker run --rm --net=host \
+        {{.AWSCliImage.RepoWithTag}} aws \
+        autoscaling describe-auto-scaling-instances \
+        --instance-ids ${INSTANCE_ID} --region {{.Region}} \
+        --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)"
+      LAUNCHCONFIGURATION="$(/usr/bin/docker run --rm --net=host \
+        {{.AWSCliImage.RepoWithTag}} \
+        aws autoscaling describe-auto-scaling-groups \
+        --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
+        --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)"
+      {{end -}}
+
+      label() {
+        /usr/bin/docker run --rm -t --net=host \
+          -v /etc/kubernetes:/etc/kubernetes \
+          -v /etc/resolv.conf:/etc/resolv.conf \
+          -e INSTANCE_ID=${INSTANCE_ID} \
+          -e SECURITY_GROUPS=${SECURITY_GROUPS} \
+          {{if not .SpotFleet.Enabled -}}
+          -e AUTOSCALINGGROUP=${AUTOSCALINGGROUP} \
+          -e LAUNCHCONFIGURATION=${LAUNCHCONFIGURATION} \
+          {{end -}}
+          {{.HyperkubeImage.RepoWithTag}} /bin/bash \
+            -ec 'echo "placing labels and annotations with additional AWS parameters."; \
+             kctl="/kubectl --server={{.APIEndpointURL}}:443 --kubeconfig=/etc/kubernetes/kubeconfig/worker.yaml"; \
+             kctl_label="$kctl label --overwrite nodes/$(hostname)"; \
+             kctl_annotate="$kctl annotate --overwrite nodes/$(hostname)"; \
+             {{if not .SpotFleet.Enabled -}}
+             $kctl_label kube-aws.coreos.com/autoscalinggroup=${AUTOSCALINGGROUP}; \
+             $kctl_label kube-aws.coreos.com/launchconfiguration=${LAUNCHCONFIGURATION}; \
+             {{end -}}
+             $kctl_annotate kube-aws.coreos.com/securitygroups=${SECURITY_GROUPS}; \
+             echo "done."'
+      }
+
+      set +e
+
+      max_attempts=5
+      attempt_num=0
+      attempt_initial_interval_sec=1
+
+      until label
+      do
+        ((attempt_num++))
+        if (( attempt_num == max_attempts ))
+        then
+            echo "Attempt $attempt_num failed and there are no more attempts left!"
+            return 1
+        else
+            attempt_interval_sec=$((attempt_initial_interval_sec*2**$((attempt_num-1))))
+            echo "Attempt $attempt_num failed! Trying again in $attempt_interval_sec seconds..."
+            sleep $attempt_interval_sec;
+        fi
+      done
+
+  {{end -}}
 
   - path: /opt/bin/cfn-signal
     owner: root:root


### PR DESCRIPTION
kube-node-label now retries until at most 10 seconds pass.
It is 7 seconds longer for controllers and 10 seconds longer for workers.

Resolves #866

cc @danielfm This is a fix for the issue you've reported before.