### PR TITLE
Support EC2 instance tags per node role

### DIFF
--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -881,6 +881,25 @@ write_files:
 
       instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
 
+      TAGS=""
+      TAGS="${TAGS}Key=\"kubernetes.io/cluster/{{ .ClusterName }}\",Value=\"owned\" "
+      TAGS="${TAGS}Key=\"kube-aws:node-pool:name\",Value=\"{{.NodePoolName}}\" "
+      TAGS="${TAGS}Key=\"Name\",Value=\"{{.ClusterName}}-{{.StackName}}-kube-aws-worker\" "
+
+      {{if .Autoscaling.ClusterAutoscaler.Enabled -}}
+      TAGS="${TAGS}Key=\"{{.Autoscaling.ClusterAutoscaler.AutoDiscoveryTagKey}}\",Value=\"\" "
+      {{end -}}
+
+      {{range $k, $v := .StackTags -}}
+      TAGS="${TAGS}Key=\"{{$k}}\",Value=\"{{$v}}\" "
+      {{end -}}
+
+      {{range $k, $v := .InstanceTags -}}
+      TAGS="${TAGS}Key=\"{{$k}}\",Value=\"{{$v}}\" "
+      {{end -}}
+
+      echo Tagging this EC2 instance with: "$TAGS"
+
       rkt run \
         --volume=ssl,kind=host,source=/etc/kubernetes/ssl,readOnly=false \
         --mount=volume=ssl,target=/etc/kubernetes/ssl \
@@ -896,7 +915,7 @@ write_files:
            /usr/bin/aws \
              --region {{.Region}} ec2 create-tags \
              --resource $instance_id \
-             --tags '"'"'Key=kubernetes.io/cluster/{{.ClusterName}},Value=""'"'"' '"'"'Key=Name,Value="{{.ClusterName}}-{{.StackName}}-kube-aws-worker"'"'"' '"'"'Key="kube-aws:node-pool:name",Value="{{.NodePoolName}}"'"'"'
+             --tags '"$TAGS"'
            echo done.'
 
       rkt rm --uuid-file=/var/run/coreos/tag-spot-instance.uuid || :

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -164,6 +164,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #  # CAUTION: Don't use t2.micro or the cluster won't work. See https://github.com/kubernetes/kubernetes/issues/18975
 #  instanceType: t2.medium
 #
+#  # EC2 instance tags for controller nodes
+#  instanceTags:
+#    instanceRole: controller
+#
 #  rootVolume:
 #    # Disk size (GiB) for controller node
 #    size: 30
@@ -342,6 +346,10 @@ worker:
 #      # Instance type for worker nodes
 #      # CAUTION: Don't use t2.micro or the cluster won't work. See https://github.com/kubernetes/kubernetes/issues/16122
 #      instanceType: t2.medium
+#
+#      # EC2 instance tags for worker nodes
+#      instanceTags:
+#        instanceRole: worker
 #
 #      rootVolume:
 #        # Disk size (GiB) for worker nodes
@@ -576,6 +584,10 @@ worker:
 #
 #  # Instance type for etcd node
 #  instanceType: t2.medium
+#
+#  # EC2 instance tags for etcd nodes
+#  instanceTags:
+#    instanceRole: etcd
 #
 #  rootVolume:
 #    # Root volume size (GiB) for etcd node

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -397,7 +397,7 @@ worker:
 #        # IAM role to grant the Spot fleet permission to bid on, launch, and terminate instances on your behalf
 #        # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-requests.html#spot-fleet-prerequisites
 #        #
-#        # Defaults to "arn:aws:iam::youraccountid:role/aws-ec2-spot-fleet-role" assuming you've arrived "Spot Requests" in EC2 Dashboard
+#        # Defaults to "arn:aws:iam::youraccountid:role/aws-ec2-spot-fleet-tagging-role" assuming you've arrived "Spot Requests" in EC2 Dashboard
 #        # hence the role is automatically created for you
 #        iamFleetRoleArn: "arn:aws:iam::youraccountid:role/kube-aws-doesnt-create-this-for-you"
 #

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -26,6 +26,13 @@
         ],
         "MinSize": "{{.MinControllerCount}}",
         "Tags": [
+          {{range $k, $v := $.Controller.InstanceTags -}}
+          {
+            "Key": "{{$k}}",
+            "PropagateAtLaunch": "true",
+            "Value": "{{$v}}"
+          },
+          {{end -}}
           {
             "Key": "kubernetes.io/cluster/{{.ClusterName}}",
             "PropagateAtLaunch": "true",
@@ -647,6 +654,13 @@
         ],
         "MinSize": "1",
         "Tags": [
+          {{range $k, $v := $.Etcd.InstanceTags -}}
+          {
+            "Key": "{{$k}}",
+            "PropagateAtLaunch": "true",
+            "Value": "{{$v}}"
+          },
+          {{end -}}
           {
             "Key": "kubernetes.io/cluster/{{$.ClusterName}}",
             "PropagateAtLaunch": "true",

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -134,6 +134,13 @@
             "Value": ""
           },
           {{end}}
+          {{range $k, $v := .InstanceTags -}}
+          {
+            "Key": "{{$k}}",
+            "PropagateAtLaunch": "true",
+            "Value": "{{$v}}"
+          },
+          {{end -}}
           {
             "Key": "kubernetes.io/cluster/{{ .ClusterName }}",
             "PropagateAtLaunch": "true",

--- a/model/ec2_instance.go
+++ b/model/ec2_instance.go
@@ -5,5 +5,6 @@ type EC2Instance struct {
 	CreateTimeout string `yaml:"createTimeout,omitempty"`
 	InstanceType  string `yaml:"instanceType,omitempty"`
 	RootVolume    `yaml:"rootVolume,omitempty"`
-	Tenancy       string `yaml:"tenancy,omitempty"`
+	Tenancy       string            `yaml:"tenancy,omitempty"`
+	InstanceTags  map[string]string `yaml:"instanceTags,omitempty"`
 }

--- a/model/spot_fleet.go
+++ b/model/spot_fleet.go
@@ -60,7 +60,7 @@ func (f *SpotFleet) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 func (f SpotFleet) IAMFleetRoleRef() string {
 	if f.IAMFleetRoleARN == "" {
-		return `{"Fn::Join":["", [ "arn:aws:iam::", {"Ref":"AWS::AccountId"}, ":role/aws-ec2-spot-fleet-role" ]]}`
+		return `{"Fn::Join":["", [ "arn:aws:iam::", {"Ref":"AWS::AccountId"}, ":role/aws-ec2-spot-fleet-tagging-role" ]]}`
 	} else {
 		return fmt.Sprintf(`"%s"`, f.IAMFleetRoleARN)
 	}


### PR DESCRIPTION
@c-knowles Would this be what you had needed?

This feature will be handy when e.g. your monitoring tools discovers EC2 instances and then groups resource metrics with EC2 instance tags.

Changes:
- Add support for stackTags to SpotFleet-based node pool
- Add a new configuration key `instanceTags` to cluster.yaml per `worker.nodePools[]`, `controller` and `etcd`.

I recomment to use `stackTags` for adding cluster-wide metadata to all the resources managed by Cfn, whereas `instanceTags` are by definition used for node-group-wide metadata to EC2 instances(node pool name, node role, and anything configurable per node pool for example).

A typical cluster.yaml using both `stackTags` and `instanceTags` would look like:

```yaml
worker:
  nodePools:
  - name: pool1
     instanceTags:
       myrole: worker
       type: ondemand
     # Propagated to (hopefully, it's up to cfn) all the stack resources for the pool1 stack
     stackTags:
       env: prod
  - name: pool2
     spotFleet:
       targetCapacity: 2
     # Propagated to EC2 instances managed by this spot fleet (via tag-spot-instance.service)
     instanceTags:
       myrole: worker
       type: spot
     # Propagated to (hopefully, it's up to cfn) all the stack resources for the pool2 stack
     stackTags:
       env: prod

controller:
  instanceTags:
    myrole: controller
    type: ondemand
  # invalid as controller nodes don't have a dedicated cfn stack
  # stackTags:

etcd:
  instanceTags:
    myrole: etcd
    type: ondemand
  # invalid as etcd nodes don't have a dedicated cfn stack
  # stackTags:

stackTags:
  env: prod
```

Resolves #1026
Depends on #1024 in order to test in combination with spot fleet support