### PR TITLE
Add rkt container cleanup to journald-cloudwatch-logs service

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -106,7 +106,9 @@ coreos:
                   --mount volume=journal,target=/var/log/journal \
                   --volume machine-id,kind=host,source=/etc/machine-id,readOnly=true \
                   --mount volume=machine-id,target=/etc/machine-id \
+                  --uuid-file-save=/var/journald-cloudwatch-logs/journald-cloudwatch-logs.uuid \
                   {{ .JournaldCloudWatchLogsImage.RktRepo }} -- {{.ClusterName}}
+        ExecStopPost=/usr/bin/rkt rm --uuid-file=/var/journald-cloudwatch-logs/journald-cloudwatch-logs.uuid
         Restart=always
         RestartSec=60s
 

--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -129,7 +129,9 @@ coreos:
                   --mount volume=journal,target=/var/log/journal \
                   --volume machine-id,kind=host,source=/etc/machine-id,readOnly=true \
                   --mount volume=machine-id,target=/etc/machine-id \
+                  --uuid-file-save=/var/journald-cloudwatch-logs/journald-cloudwatch-logs.uuid \
                   {{ .JournaldCloudWatchLogsImage.RktRepo }} -- {{.ClusterName}}
+        ExecStopPost=/usr/bin/rkt rm --uuid-file=/var/journald-cloudwatch-logs/journald-cloudwatch-logs.uuid
         Restart=always
         RestartSec=60s
 

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -141,7 +141,9 @@ coreos:
                   --mount volume=journal,target=/var/log/journal \
                   --volume machine-id,kind=host,source=/etc/machine-id,readOnly=true \
                   --mount volume=machine-id,target=/etc/machine-id \
+                  --uuid-file-save=/var/journald-cloudwatch-logs/journald-cloudwatch-logs.uuid \
                   {{ .JournaldCloudWatchLogsImage.RktRepo }} -- {{.ClusterName}}
+        ExecStopPost=/usr/bin/rkt rm --uuid-file=/var/journald-cloudwatch-logs/journald-cloudwatch-logs.uuid
         Restart=always
         RestartSec=60s
 


### PR DESCRIPTION
A case was encountered where the journald-cloudwatch-logs service was failing, and this caused an issue where the rkt gc cannot unmount the containers and then the number of mountpoints causes the kernel to be unresponsive.

This change adds a cleanup step, so that the container is removed in the case that the service functionality has been interrupted.