### PR TITLE
Added Priority to the admissioncontrol list

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -50,6 +50,9 @@ func NewDefaultCluster() *Cluster {
 			Initializers{
 				Enabled: false,
 			},
+			Priority{
+				Enabled: false,
+			},
 		},
 		AuditLog: AuditLog{
 			Enabled: false,
@@ -529,6 +532,7 @@ type Admission struct {
 	AlwaysPullImages   AlwaysPullImages   `yaml:"alwaysPullImages"`
 	DenyEscalatingExec DenyEscalatingExec `yaml:"denyEscalatingExec"`
 	Initializers       Initializers       `yaml:"initializers"`
+	Priority           Priority           `yaml:"priority"`
 }
 
 type AlwaysPullImages struct {
@@ -544,6 +548,10 @@ type DenyEscalatingExec struct {
 }
 
 type Initializers struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type Priority struct {
 	Enabled bool `yaml:"enabled"`
 }
 

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -292,7 +292,9 @@ coreos:
         {{ if .KubeDns.NodeLocalResolver }}--cluster-dns=${COREOS_PRIVATE_IPV4} \
         {{ else }}--cluster-dns={{.DNSServiceIP}} \
         {{ end }}--cluster-domain=cluster.local \
-        --cloud-provider=aws \
+        --cloud-provider=aws \{{if .Experimental.Admission.Priority.Enabled}}
+        --feature-gates=PodPriority=true \
+        {{end}}\
         $KUBELET_OPTS
         Restart=always
         RestartSec=10
@@ -2011,7 +2013,7 @@ write_files:
           - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
           {{ end }}
           - --advertise-address=$private_ipv4
-          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }}{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{if .Experimental.NodeAuthorizer.Enabled}},NodeRestriction{{end}},ResourceQuota{{if .Experimental.Admission.DenyEscalatingExec.Enabled}},DenyEscalatingExec{{end}}{{if .Experimental.Admission.Initializers.Enabled}},Initializers{{end}}
+          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }}{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{if .Experimental.NodeAuthorizer.Enabled}},NodeRestriction{{end}},ResourceQuota{{if .Experimental.Admission.DenyEscalatingExec.Enabled}},DenyEscalatingExec{{end}}{{if .Experimental.Admission.Initializers.Enabled}},Initializers{{end}}{{if .Experimental.Admission.Priority.Enabled}},Priority{{end}}
           - --anonymous-auth=false
           {{if .Experimental.Oidc.Enabled}}
           - --oidc-issuer-url={{.Experimental.Oidc.IssuerUrl}}
@@ -2028,7 +2030,10 @@ write_files:
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},extensions/v1beta1/podsecuritypolicy=true{{ end }}{{if .Experimental.Admission.Initializers.Enabled}},admissionregistration.k8s.io/v1alpha1{{end}}
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1=true{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},extensions/v1beta1/podsecuritypolicy=true{{ end }}{{if .Experimental.Admission.Initializers.Enabled}},admissionregistration.k8s.io/v1alpha1{{end}}{{if .Experimental.Admission.Priority.Enabled}},scheduling.k8s.io/v1alpha1=true{{end}}
+         {{if .Experimental.Admission.Priority.Enabled}}
+          - --feature-gates=PodPriority=true
+         {{end}}
           - --cloud-provider=aws
           {{range $f := .APIServerFlags}}
           - --{{$f.Name}}={{$f.Value}}
@@ -2195,6 +2200,9 @@ write_files:
           - scheduler
           - --master=http://127.0.0.1:8080
           - --leader-elect=true
+         {{if .Experimental.Admission.Priority.Enabled}}
+          - --feature-gates=PodPriority=true
+         {{end}}
           resources:
             requests:
               cpu: 100m

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -546,6 +546,9 @@ worker:
 #            Description=Example Custom Service
 #            [Service]
 #            ExecStart=/bin/rkt run --set-env TAGS=Controller ...
+#      # Enable PodPriority (it only makes sense if you enabled priority admission control in experimental section)
+#      featureGates:
+#        PodPriority: true
 
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M
@@ -1209,6 +1212,10 @@ experimental:
     denyEscalatingExec:
       enabled: false
     initializers:
+      enabled: false
+    # Priority enables PodPriority in the API server, scheduler and kubelet. you need to manually add the
+    # featureGate PodPriority:true in the worker
+    priority:
       enabled: false
 
   # Used to provide `/etc/environment` env vars with values from arbitrary CloudFormation refs


### PR DESCRIPTION
In order to properly support Pod Priorities and Preemption (kubernetes 1.8 https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) we need the Priority admission controler