### PR TITLE
Add [experimental] option for using IPVS proxy mode

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -93,6 +93,12 @@ func NewDefaultCluster() *Cluster {
 		TargetGroup: TargetGroup{
 			Enabled: false,
 		},
+		IPVSProxy: IPVSProxy{
+			Enabled:       false,
+			Scheduler:     "rr",
+			SyncPeriod:    "300s",
+			MinSyncPeriod: "60s",
+		},
 		NodeDrainer: model.NodeDrainer{
 			Enabled:      false,
 			DrainTimeout: 5,
@@ -518,6 +524,7 @@ type Experimental struct {
 	LoadBalancer                LoadBalancer                   `yaml:"loadBalancer"`
 	TargetGroup                 TargetGroup                    `yaml:"targetGroup"`
 	NodeDrainer                 model.NodeDrainer              `yaml:"nodeDrainer"`
+	IPVSProxy                   IPVSProxy                      `yaml:"ipvsProxy"`
 	Oidc                        model.Oidc                     `yaml:"oidc"`
 	DisableSecurityGroupIngress bool                           `yaml:"disableSecurityGroupIngress"`
 	NodeMonitorGracePeriod      string                         `yaml:"nodeMonitorGracePeriod"`
@@ -635,6 +642,13 @@ type TargetGroup struct {
 	Enabled          bool     `yaml:"enabled"`
 	Arns             []string `yaml:"arns"`
 	SecurityGroupIds []string `yaml:"securityGroupIds"`
+}
+
+type IPVSProxy struct {
+	Enabled       bool   `yaml:"enabled"`
+	Scheduler     string `yaml:"scheduler"`
+	SyncPeriod    string `yaml:"syncPeriod"`
+	MinSyncPeriod string `yaml:"minSyncPeriod"`
 }
 
 type KubeDns struct {

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -93,12 +93,6 @@ func NewDefaultCluster() *Cluster {
 		TargetGroup: TargetGroup{
 			Enabled: false,
 		},
-		IPVSProxy: IPVSProxy{
-			Enabled:       false,
-			Scheduler:     "rr",
-			SyncPeriod:    "300s",
-			MinSyncPeriod: "60s",
-		},
 		NodeDrainer: model.NodeDrainer{
 			Enabled:      false,
 			DrainTimeout: 5,
@@ -110,6 +104,13 @@ func NewDefaultCluster() *Cluster {
 			UsernameClaim: "email",
 			GroupsClaim:   "groups",
 		},
+	}
+
+	ipvsMode := IPVSMode{
+		Enabled:       false,
+		Scheduler:     "rr",
+		SyncPeriod:    "60s",
+		MinSyncPeriod: "10s",
 	}
 
 	return &Cluster{
@@ -136,6 +137,9 @@ func NewDefaultCluster() *Cluster {
 					Filter:   `{ $.priority = "CRIT" || $.priority = "WARNING" && $.transport = "journal" && $.systemdUnit = "init.scope" }`,
 					interval: 60,
 				},
+			},
+			KubeProxy: KubeProxy{
+				IPVSMode: ipvsMode,
 			},
 			KubeDns: KubeDns{
 				NodeLocalResolver: false,
@@ -429,6 +433,7 @@ type DeploymentSettings struct {
 	CloudWatchLogging       `yaml:"cloudWatchLogging,omitempty"`
 	AmazonSsmAgent          `yaml:"amazonSsmAgent,omitempty"`
 	CloudFormationStreaming bool `yaml:"cloudFormationStreaming,omitempty"`
+	KubeProxy               `yaml:"kubeProxy,omitempty"`
 	KubeDns                 `yaml:"kubeDns,omitempty"`
 	KubernetesDashboard     `yaml:"kubernetesDashboard,omitempty"`
 	// Images repository
@@ -524,7 +529,6 @@ type Experimental struct {
 	LoadBalancer                LoadBalancer                   `yaml:"loadBalancer"`
 	TargetGroup                 TargetGroup                    `yaml:"targetGroup"`
 	NodeDrainer                 model.NodeDrainer              `yaml:"nodeDrainer"`
-	IPVSProxy                   IPVSProxy                      `yaml:"ipvsProxy"`
 	Oidc                        model.Oidc                     `yaml:"oidc"`
 	DisableSecurityGroupIngress bool                           `yaml:"disableSecurityGroupIngress"`
 	NodeMonitorGracePeriod      string                         `yaml:"nodeMonitorGracePeriod"`
@@ -644,7 +648,11 @@ type TargetGroup struct {
 	SecurityGroupIds []string `yaml:"securityGroupIds"`
 }
 
-type IPVSProxy struct {
+type KubeProxy struct {
+	IPVSMode IPVSMode `yaml:"ipvsMode"`
+}
+
+type IPVSMode struct {
 	Enabled       bool   `yaml:"enabled"`
 	Scheduler     string `yaml:"scheduler"`
 	SyncPeriod    string `yaml:"syncPeriod"`

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1918,6 +1918,14 @@ write_files:
           clientConnection:
             kubeconfig: /etc/kubernetes/kubeconfig/kube-proxy.yaml
           clusterCIDR: {{.PodCIDR}}
+          {{if .Experimental.IPVSProxy.Enabled}}
+          featureGates: "SupportIPVSProxyMode=true"
+          mode: ipvs
+          ipvs:
+            scheduler: {{.Experimental.IPVSProxy.Scheduler}}
+            syncPeriod: {{.Experimental.IPVSProxy.SyncPeriod}}
+            minSyncPeriod: {{.Experimental.IPVSProxy.MinSyncPeriod}}
+          {{end}}
 
   - path: /srv/kubernetes/manifests/kube-proxy-ds.yaml
     content: |
@@ -1959,6 +1967,9 @@ write_files:
                 securityContext:
                   privileged: true
                 volumeMounts:
+                - mountPath: /lib/modules
+                  name: lib-modules
+                  readOnly: true
                 - mountPath: /etc/kubernetes/kubeconfig
                   name: kubeconfig
                   readOnly: true
@@ -1966,6 +1977,9 @@ write_files:
                   name: kube-proxy-config
                   readOnly: true
               volumes:
+              - name: lib-modules
+                hostPath:
+                  path: /lib/modules
               - name: kubeconfig
                 hostPath:
                   path: /etc/kubernetes/kubeconfig

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1918,7 +1918,7 @@ write_files:
           clientConnection:
             kubeconfig: /etc/kubernetes/kubeconfig/kube-proxy.yaml
           clusterCIDR: {{.PodCIDR}}
-          {{if .Experimental.IPVSProxy.Enabled}}
+          {{if .Experimental.IPVSProxy.Enabled -}}
           featureGates: "SupportIPVSProxyMode=true"
           mode: ipvs
           ipvs:
@@ -1967,9 +1967,11 @@ write_files:
                 securityContext:
                   privileged: true
                 volumeMounts:
+                {{if .Experimental.IPVSProxy.Enabled -}}
                 - mountPath: /lib/modules
                   name: lib-modules
                   readOnly: true
+                {{end -}}
                 - mountPath: /etc/kubernetes/kubeconfig
                   name: kubeconfig
                   readOnly: true
@@ -1977,9 +1979,11 @@ write_files:
                   name: kube-proxy-config
                   readOnly: true
               volumes:
+              {{if .Experimental.IPVSProxy.Enabled -}}
               - name: lib-modules
                 hostPath:
                   path: /lib/modules
+              {{end -}}
               - name: kubeconfig
                 hostPath:
                   path: /etc/kubernetes/kubeconfig

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1912,19 +1912,19 @@ write_files:
         namespace: kube-system
       data:
         kube-proxy-config.yaml: |
-          apiVersion: componentconfig/v1alpha1
+          apiVersion: {{if ge .K8sVer "v1.9"}}kubeproxy.config.k8s.io{{else}}componentconfig{{end}}/v1alpha1
           kind: KubeProxyConfiguration
           bindAddress: 0.0.0.0
           clientConnection:
             kubeconfig: /etc/kubernetes/kubeconfig/kube-proxy.yaml
           clusterCIDR: {{.PodCIDR}}
-          {{if .Experimental.IPVSProxy.Enabled -}}
+          {{if .KubeProxy.IPVSMode.Enabled -}}
           featureGates: "SupportIPVSProxyMode=true"
           mode: ipvs
           ipvs:
-            scheduler: {{.Experimental.IPVSProxy.Scheduler}}
-            syncPeriod: {{.Experimental.IPVSProxy.SyncPeriod}}
-            minSyncPeriod: {{.Experimental.IPVSProxy.MinSyncPeriod}}
+            scheduler: {{.KubeProxy.IPVSMode.Scheduler}}
+            syncPeriod: {{.KubeProxy.IPVSMode.SyncPeriod}}
+            minSyncPeriod: {{.KubeProxy.IPVSMode.MinSyncPeriod}}
           {{end}}
 
   - path: /srv/kubernetes/manifests/kube-proxy-ds.yaml
@@ -1967,7 +1967,7 @@ write_files:
                 securityContext:
                   privileged: true
                 volumeMounts:
-                {{if .Experimental.IPVSProxy.Enabled -}}
+                {{if .KubeProxy.IPVSMode.Enabled -}}
                 - mountPath: /lib/modules
                   name: lib-modules
                   readOnly: true
@@ -1979,7 +1979,7 @@ write_files:
                   name: kube-proxy-config
                   readOnly: true
               volumes:
-              {{if .Experimental.IPVSProxy.Enabled -}}
+              {{if .KubeProxy.IPVSMode.Enabled -}}
               - name: lib-modules
                 hostPath:
                   path: /lib/modules

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1261,6 +1261,14 @@ experimental:
   kube2IamSupport:
     enabled: false
 
+  # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.8.3+)
+  # This is intended to address performance issues of iptables mode for clusters with big number of nodes and services
+  ipvsProxy:
+    enabled: false
+    scheduler: rr
+    syncPeriod: 300s
+    minSyncPeriod: 60s
+
   # When enabled, `kubectl drain` is run when the instance is being replaced by the auto scaling group, or when
   # the instance receives a termination notice (in case of spot instances)
   nodeDrainer:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1176,6 +1176,19 @@ kubernetesDashboard:
 #kubeDns:
 # nodeLocalResolver: false
 
+kubeProxy:
+  # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.9.0+ to work reliably)
+  # This is intended to address performance issues of iptables mode for clusters with big number of nodes and services
+  # FIXME For those who use hyperkube version 'v1.9.0' / 'v1.9.0_coreos.0', your image may lack `ipset` utility
+  # FIXME Please see: https://github.com/kubernetes/kubernetes/issues/57321 (next Kubernetes release will have a fix)
+  # FIXME https://github.com/kubernetes/kubernetes/commit/787a55bb67ccd2da14aa6e7f91289c859beecb5f#diff-bf0f8d724d18f700f3c821aa5a74f4cf
+  # FIXME IPVS integration is still green, proceed with care! You may get fixed hyperkube image from 'ivanilves/hyperkube' Docker repo
+  ipvsMode:
+    enabled: false
+    scheduler: rr
+    syncPeriod: 300s
+    minSyncPeriod: 60s
+
 # When enabled, CloudFormation events will stream to stdout during kube-aws 'update | up'.
 # It is enabled by default.
 #cloudFormationStreaming: true
@@ -1260,14 +1273,6 @@ experimental:
   # This is intended to be used in combination with .controller.managedIamRoleName. See #297 for more information.
   kube2IamSupport:
     enabled: false
-
-  # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.8.3+)
-  # This is intended to address performance issues of iptables mode for clusters with big number of nodes and services
-  ipvsProxy:
-    enabled: false
-    scheduler: rr
-    syncPeriod: 300s
-    minSyncPeriod: 60s
 
   # When enabled, `kubectl drain` is run when the instance is being replaced by the auto scaling group, or when
   # the instance receives a termination notice (in case of spot instances)

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -122,6 +122,12 @@ func TestMainClusterConfig(t *testing.T) {
 			Kube2IamSupport: controlplane_config.Kube2IamSupport{
 				Enabled: false,
 			},
+			IPVSProxy: controlplane_config.IPVSProxy{
+				Enabled:       false,
+				Scheduler:     "rr",
+				SyncPeriod:    "300s",
+				MinSyncPeriod: "60s",
+			},
 			LoadBalancer: controlplane_config.LoadBalancer{
 				Enabled: false,
 			},
@@ -1183,6 +1189,11 @@ experimental:
   kube2IamSupport:
     enabled: true
   kubeletOpts: '--image-gc-low-threshold 60 --image-gc-high-threshold 70'
+  ipvsProxy:
+    enabled: true
+    scheduler: lc
+    syncPeriod: 900s
+    minSyncPeriod: 120s
   loadBalancer:
     enabled: true
     names:
@@ -1264,6 +1275,12 @@ worker:
 							Enabled: true,
 						},
 						KubeletOpts: "--image-gc-low-threshold 60 --image-gc-high-threshold 70",
+						IPVSProxy: controlplane_config.IPVSProxy{
+							Enabled:       true,
+							Scheduler:     "lc",
+							SyncPeriod:    "900s",
+							MinSyncPeriod: "120s",
+						},
 						LoadBalancer: controlplane_config.LoadBalancer{
 							Enabled:          true,
 							Names:            []string{"manuallymanagedlb"},


### PR DESCRIPTION
Add [experimental] option to use IPVS kube-proxy mode instead of [default] iptables one.

Hope to address performance issues of iptables mode for clusters with big number of nodes and services!

(>20 nodes, >5k services is a big cluster to me)

_We also hope IPVS will handle UDP traffic better (This needs to be validated, a hope-based guess only)_