### PR TITLE
controlplane config: Rotate Certificates on workers kubelet

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -36,6 +36,11 @@ const (
 )
 
 func NewDefaultCluster() *Cluster {
+	kubelet := Kubelet{
+		RotateCerts: RotateCerts{
+			Enabled: false,
+		},
+	}
 	experimental := Experimental{
 		Admission: Admission{
 			PodSecurityPolicy{
@@ -126,6 +131,7 @@ func NewDefaultCluster() *Cluster {
 			Subnets:            []model.Subnet{},
 			EIPAllocationIDs:   []string{},
 			Experimental:       experimental,
+			Kubelet:            kubelet,
 			ManageCertificates: true,
 			AmazonSsmAgent: AmazonSsmAgent{
 				Enabled:     false,
@@ -431,6 +437,7 @@ type DeploymentSettings struct {
 	SSHAuthorizedKeys       []string          `yaml:"sshAuthorizedKeys,omitempty"`
 	Addons                  model.Addons      `yaml:"addons"`
 	Experimental            Experimental      `yaml:"experimental"`
+	Kubelet                 Kubelet           `yaml:"kubelet"`
 	ManageCertificates      bool              `yaml:"manageCertificates,omitempty"`
 	WaitSignal              WaitSignal        `yaml:"waitSignal"`
 	CloudWatchLogging       `yaml:"cloudWatchLogging,omitempty"`
@@ -515,6 +522,11 @@ type Cluster struct {
 	KubeResourcesAutosave       `yaml:"kubeResourcesAutosave,omitempty"`
 }
 
+// Kubelet options
+type Kubelet struct {
+	RotateCerts RotateCerts `yaml:"rotateCerts"`
+}
+
 type Experimental struct {
 	Admission      Admission      `yaml:"admission"`
 	AuditLog       AuditLog       `yaml:"auditLog"`
@@ -592,6 +604,10 @@ type AwsNodeLabels struct {
 }
 
 type TLSBootstrap struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type RotateCerts struct {
 	Enabled bool `yaml:"enabled"`
 }
 

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -975,6 +975,67 @@ experimental:
 
 }
 
+func TestRotateCerts(t *testing.T) {
+
+	validConfigs := []struct {
+		conf        string
+		rotateCerts RotateCerts
+	}{
+		{
+			conf: `
+`,
+			rotateCerts: RotateCerts{
+				Enabled: false,
+			},
+		},
+		{
+			conf: `
+kubelet:
+  rotateCerts:
+    enabled: false
+`,
+			rotateCerts: RotateCerts{
+				Enabled: false,
+			},
+		},
+		{
+			conf: `
+kubelet:
+  rotateCerts:
+    enabled: true
+`,
+			rotateCerts: RotateCerts{
+				Enabled: true,
+			},
+		},
+		{
+			conf: `
+rotateCerts:
+  enabled: true
+`,
+			rotateCerts: RotateCerts{
+				Enabled: false,
+			},
+		},
+	}
+
+	for _, conf := range validConfigs {
+		confBody := singleAzConfigYaml + conf.conf
+		c, err := ClusterFromBytes([]byte(confBody))
+		if err != nil {
+			t.Errorf("failed to parse config %s: %v", confBody, err)
+			continue
+		}
+		if !reflect.DeepEqual(c.Kubelet.RotateCerts, conf.rotateCerts) {
+			t.Errorf(
+				"parsed Rotate Certificates settings %+v does not match config: %s",
+				c.Kubelet.RotateCerts,
+				confBody,
+			)
+		}
+	}
+}
+
 func TestTLSBootstrapConfig(t *testing.T) {
 
 	validConfigs := []struct {

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -309,6 +309,9 @@ coreos:
         --cert-dir=/etc/kubernetes/ssl \
         {{- if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}
         --experimental-bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
+        {{- if .Kubelet.RotateCerts.Enabled }}
+        --rotate-certificates \
+        {{- end }}
         {{- else }}
         --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1309,6 +1309,13 @@ experimental:
   # Must be N times more than kubelet's nodeStatusUpdateFrequency (default 10s).
 #   nodeMonitorGracePeriod: "40s"
 
+kubelet:
+  # Tell Kubelet to renew its certificate as its expiration time is approaching
+  # Requires FeatureGate RotateKubeletClientCertificate=true on worker
+  # Also requires Experimental.tlsBootstrap to be enabled
+  RotateCerts:
+    enabled: true
+
 # AWS Tags for cloudformation stack resources
 #stackTags:
 #  Name: "Kubernetes"

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -39,6 +39,7 @@ type ProvidedConfig struct {
 	WorkerNodePoolConfig    `yaml:",inline"`
 	DeploymentSettings      `yaml:",inline"`
 	cfg.Experimental        `yaml:",inline"`
+	cfg.Kubelet             `yaml:",inline"`
 	Plugins                 model.PluginConfigs `yaml:"kubeAwsPlugins,omitempty"`
 	Private                 bool                `yaml:"private,omitempty"`
 	NodePoolName            string              `yaml:"name,omitempty"`
@@ -164,6 +165,7 @@ func (c *ProvidedConfig) Load(main *cfg.Config) error {
 	c.KubeClusterSettings = main.KubeClusterSettings
 	c.Experimental.TLSBootstrap = main.DeploymentSettings.Experimental.TLSBootstrap
 	c.Experimental.NodeDrainer = main.DeploymentSettings.Experimental.NodeDrainer
+	c.Kubelet.RotateCerts = main.DeploymentSettings.Kubelet.RotateCerts
 
 	if c.Experimental.ClusterAutoscalerSupport.Enabled {
 		if !main.Addons.ClusterAutoscaler.Enabled {


### PR DESCRIPTION
Added a flag to enable automatic cert rotation when TLS Bootstraping
is used.