### PR TITLE
Set V4 signatures to enable kube-resources-autosave to work in all regions

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1172,6 +1172,7 @@ write_files:
                 - |
                     set -x ;
                     DUMP_DIR_COMPLETE=/kube-resources-autosave/complete ;
+                    aws configure set s3.signature_version s3v4 ;
                     mkdir -p ${DUMP_DIR_COMPLETE} ;
                     while true; do
                       TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)


### PR DESCRIPTION
The coreos awscli container image is ancient and unmaintained and defaults to the old V2 signatures. We need to explicitly set V4 signatures to enable this feature to function in all regions, e.g. us-east-2 where only V4 is supported.