### PR TITLE
Allow exposing several ports so that external Prometheus can scrape K8S system components' metrics

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1214,6 +1214,11 @@ addons:
   metricsServer:
     enabled: false
 
+  # When set to true this configures security groups for prometheus between nodes.
+  # This includes the following ports: 10252, 10251, 10250, 9100, and 4194
+  prometheus: 
+    securityGroupsEnabled: false
+
 # Experimental features will change in backward-incompatible ways
 experimental:
   # Enable admission controllers

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1362,6 +1362,118 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    "SecurityGroupWorkerIngressFromWorkerToControllerKubelet": {
+      "Properties": {
+        "FromPort": 10250,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 10250
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToWorkerKubelet": {
+      "Properties": {
+        "FromPort": 10250,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 10250
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToWorkerCadvisor": {
+      "Properties": {
+        "FromPort": 4194,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 4194
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToControllerCadvisor": {
+      "Properties": {
+        "FromPort": 4194,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 4194
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToWorkerNodeExporter": {
+      "Properties": {
+        "FromPort": 9100,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 9100
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToControllerNodeExporter": {
+      "Properties": {
+        "FromPort": 9100,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 9100
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToControllerControllerManager": {
+      "Properties": {
+        "FromPort": 10252,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 10252
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToControllerScheduleManager": {
+      "Properties": {
+        "FromPort": 10251,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 10251
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
     "SecurityGroupEtcd": {
       "Properties": {
         "GroupDescription": {

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1362,6 +1362,7 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    {{if .Addons.Prometheus.SecurityGroupsEnabled}}
     "SecurityGroupWorkerIngressFromWorkerToControllerKubelet": {
       "Properties": {
         "FromPort": 10250,
@@ -1474,6 +1475,7 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    {{ end }}
     "SecurityGroupEtcd": {
       "Properties": {
         "GroupDescription": {

--- a/model/addons.go
+++ b/model/addons.go
@@ -4,6 +4,7 @@ type Addons struct {
 	Rescheduler       Rescheduler              `yaml:"rescheduler"`
 	ClusterAutoscaler ClusterAutoscalerSupport `yaml:"clusterAutoscaler,omitempty"`
 	MetricsServer     MetricsServer            `yaml:"metricsServer,omitempty"`
+	Prometheus        Prometheus               `yaml:"prometheus"`
 	UnknownKeys       `yaml:",inline"`
 }
 
@@ -20,4 +21,9 @@ type Rescheduler struct {
 type MetricsServer struct {
 	Enabled     bool `yaml:"enabled"`
 	UnknownKeys `yaml:",inline"`
+}
+
+type Prometheus struct {
+	SecurityGroupsEnabled bool `yaml:"securityGroupsEnabled"`
+	UnknownKeys           `yaml:",inline"`
 }


### PR DESCRIPTION
Continuation of https://github.com/kubernetes-incubator/kube-aws/pull/1032

Added the yaml option and rebased onto the current master.
