### PR TITLE
Warn that 'kube-aws update' can replace all if 'amiId' is blank

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -9,6 +9,7 @@ clusterName: {{.ClusterName}}
 
 # The AMI ID of CoreOS.
 # If omitted, the latest AMI for the releaseChannel is used.
+# This happens every time 'kube-aws update' is run, potentially replacing all instances with a newer version
 {{if .AmiId -}}
 amiId: "{{.AmiId}}"
 {{else -}}


### PR DESCRIPTION
Following on from #1106, add a small warning that a blank 'amiId' can lead to all instances being rolled during any 'kube-aws update'.