### PR TITLE
Add RotateKubeletClientCertificate feature gate automatically when rotating certificates

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1311,8 +1311,7 @@ experimental:
 
 kubelet:
   # Tell Kubelet to renew its certificate as its expiration time is approaching
-  # Requires FeatureGate RotateKubeletClientCertificate=true on worker
-  # Also requires Experimental.tlsBootstrap to be enabled
+  # Requires Experimental.tlsBootstrap to be enabled
   RotateCerts:
     enabled: true
 

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -293,6 +293,9 @@ func (c ProvidedConfig) FeatureGates() model.FeatureGates {
 	if c.Gpu.Nvidia.IsEnabledOn(c.InstanceType) {
 		gates["Accelerators"] = "true"
 	}
+	if c.Kubelet.RotateCerts.Enabled {
+		gates["RotateKubeletClientCertificate"] = "true"
+	}
 	return gates
 }
 

--- a/core/nodepool/config/config_test.go
+++ b/core/nodepool/config/config_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	cfg "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
+	"testing"
+)
+
+const cluster_config = `
+availabilityZone: us-west-1c
+keyName: test-key-name
+region: us-west-1
+clusterName: test-cluster-name
+kmsKeyArn: "arn:aws:kms:us-west-1:xxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
+apiEndpoints:
+- name: public
+  dnsName: test.staging.core-os.net
+  loadBalancer:
+    hostedZone:
+      id: hostedzone-xxxxxx
+
+kubelet:
+  rotateCerts: 
+    enabled: true
+`
+
+func TestRotateCerts(t *testing.T) {
+	controlplane_config, _ := cfg.ConfigFromBytes([]byte(cluster_config))
+
+	config, _ := ClusterFromBytes([]byte(""), controlplane_config)
+
+	if !(config.FeatureGates()["RotateKubeletClientCertificate"] == "true") {
+		t.Errorf("When RotateCerts is enabled, Feature Gate RotateKubeletClientCertificate should be automatically enabled too")
+	}
+
+}


### PR DESCRIPTION
This PR implements what was discussed in 
https://github.com/kubernetes-incubator/kube-aws/pull/1086#discussion_r159886263

In short: When we enable `rotateCerts` apart from the required flag, the feature gate `RotateKubeletClientCertificate` should be also added automatically. 