### PR TITLE
Add support for CloudFormation service role

### DIFF
--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -244,7 +244,9 @@ func (c *Cluster) stackProvisioner() *cfnstack.Provisioner {
 		c.ClusterExportedStacksS3URI(),
 		c.Region,
 		stackPolicyBody,
-		c.session)
+		c.session,
+		c.CloudFormation.RoleARN,
+	)
 }
 
 func (c *Cluster) Validate() error {
@@ -275,7 +277,7 @@ func (c *Cluster) String() string {
 }
 
 func (c *ClusterRef) Destroy() error {
-	return cfnstack.NewDestroyer(c.StackName(), c.session).Destroy()
+	return cfnstack.NewDestroyer(c.StackName(), c.session, c.CloudFormation.RoleARN).Destroy()
 }
 
 func (c *ClusterRef) validateKeyPair(ec2Svc ec2Service) error {

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -413,6 +413,7 @@ type ComputedDeploymentSettings struct {
 // Though it is highly configurable, it's basically users' responsibility to provide `correct` values if they're going beyond the defaults.
 type DeploymentSettings struct {
 	ComputedDeploymentSettings
+	CloudFormation              model.CloudFormation  `yaml:"cloudformation,omitempty"`
 	ClusterName                 string                `yaml:"clusterName,omitempty"`
 	KeyName                     string                `yaml:"keyName,omitempty"`
 	Region                      model.Region          `yaml:",inline"`

--- a/core/nodepool/cluster/cluster.go
+++ b/core/nodepool/cluster/cluster.go
@@ -152,7 +152,7 @@ func (c *Cluster) stackProvisioner() *cfnstack.Provisioner {
   ]
 }`
 
-	return cfnstack.NewProvisioner(c.StackName(), c.WorkerDeploymentSettings().StackTags(), c.S3URI, c.Region, stackPolicyBody, c.session())
+	return cfnstack.NewProvisioner(c.StackName(), c.WorkerDeploymentSettings().StackTags(), c.S3URI, c.Region, stackPolicyBody, c.session(), c.CloudFormation.RoleARN)
 }
 
 func (c *Cluster) session() *session.Session {
@@ -225,5 +225,5 @@ func (c *ClusterRef) Info() (*Info, error) {
 }
 
 func (c *ClusterRef) Destroy() error {
-	return cfnstack.NewDestroyer(c.StackName(), c.session).Destroy()
+	return cfnstack.NewDestroyer(c.StackName(), c.session, c.CloudFormation.RoleARN).Destroy()
 }

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -317,7 +317,9 @@ func (c clusterImpl) stackProvisioner() *cfnstack.Provisioner {
 		c.opts.S3URI,
 		c.controlPlane.Region,
 		stackPolicyBody,
-		c.session)
+		c.session,
+		c.controlPlane.CloudFormation.RoleARN,
+	)
 }
 
 func (c clusterImpl) stackName() string {

--- a/core/root/destroyer.go
+++ b/core/root/destroyer.go
@@ -42,7 +42,7 @@ func ClusterDestroyerFromFile(configPath string, opts DestroyOptions) (ClusterDe
 		return nil, fmt.Errorf("failed to establish aws session: %v", err)
 	}
 
-	cfnDestroyer := cfnstack.NewDestroyer(stackName, session)
+	cfnDestroyer := cfnstack.NewDestroyer(stackName, session, cfg.CloudFormation.RoleARN)
 	return clusterDestroyerImpl{
 		underlying: cfnDestroyer,
 	}, nil

--- a/model/cloudformation.go
+++ b/model/cloudformation.go
@@ -1,0 +1,5 @@
+package model
+
+type CloudFormation struct {
+	RoleARN string `yaml:"roleARN,omitempty"`
+}


### PR DESCRIPTION
 An optional setting named `cloudformation.roleARN` is added to `cluster.yaml` to instruct CloudFormation to use the specific IAM role to manage the IAM policy associated to it.

This is useful when your own IAM role is not open enough to access all the APIs and resources required by a stack operation.

Resolves #1082