### PR TITLE
conditionally deploy kube-dns to controllers

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -151,7 +151,8 @@ func NewDefaultCluster() *Cluster {
 				IPVSMode: ipvsMode,
 			},
 			KubeDns: KubeDns{
-				NodeLocalResolver: false,
+				NodeLocalResolver:   false,
+				DeployToControllers: false,
 			},
 			KubernetesDashboard: KubernetesDashboard{
 				AdminPrivileges: true,
@@ -684,12 +685,14 @@ type IPVSMode struct {
 }
 
 type KubeDns struct {
-	NodeLocalResolver bool `yaml:"nodeLocalResolver"`
+	NodeLocalResolver   bool `yaml:"nodeLocalResolver"`
+	DeployToControllers bool `yaml:"deployToControllers"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {
-	if c.NodeLocalResolver == false {
+	if c.NodeLocalResolver == false && c.DeployToControllers == false {
 		c.NodeLocalResolver = other.NodeLocalResolver
+		c.DeployToControllers = other.DeployToControllers
 	}
 }
 

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -1036,6 +1036,56 @@ rotateCerts:
 	}
 }
 
+func TestKubeDns(t *testing.T) {
+
+	validConfigs := []struct {
+		conf    string
+		kubeDns KubeDns
+	}{
+		{
+			conf: `
+`,
+			kubeDns: KubeDns{
+				DeployToControllers: false,
+			},
+		},
+		{
+			conf: `
+kubeDns:
+  deployToControllers: false
+`,
+			kubeDns: KubeDns{
+				DeployToControllers: false,
+			},
+		},
+		{
+			conf: `
+kubeDns:
+  deployToControllers: true
+`,
+			kubeDns: KubeDns{
+				DeployToControllers: true,
+			},
+		},
+	}
+
+	for _, conf := range validConfigs {
+		confBody := singleAzConfigYaml + conf.conf
+		c, err := ClusterFromBytes([]byte(confBody))
+		if err != nil {
+			t.Errorf("failed to parse config %s: %v", confBody, err)
+			continue
+		}
+		if !reflect.DeepEqual(c.KubeDns, conf.kubeDns) {
+			t.Errorf(
+				"parsed kubeDns settings %+v does not match config: %s",
+				c.KubeDns,
+				confBody,
+			)
+		}
+	}
+}
+
 func TestTLSBootstrapConfig(t *testing.T) {
 
 	validConfigs := []struct {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2489,9 +2489,28 @@ write_files:
                 configMap:
                   name: kube-dns
                   optional: true
+              {{ if .KubeDns.DeployToControllers -}}
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: In
+                        values:
+                        - ""
+              tolerations:
+               - key: "CriticalAddonsOnly"
+                 operator: "Exists"
+               - key: "node.alpha.kubernetes.io/role"
+                 operator: "Equal"
+                 value: "master"
+                 effect: "NoSchedule" 
+              {{ else -}}
               tolerations:
               - key: "CriticalAddonsOnly"
                 operator: "Exists"
+              {{ end -}}
               containers:
               - name: kubedns
                 image: {{ .KubeDnsImage.RepoWithTag }}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1175,10 +1175,13 @@ kubernetesDashboard:
 #  downloadUrl: https://github.com/DailyHotel/amazon-ssm-agent/releases/download/v2.0.805.1/ssm.linux-amd64.tar.gz
 #  sha1sum: a6fff8f9839d5905934e7e3df3123b54020a1f5e
 
+
+#kubeDns:
 # When enabled, will enable a DNS-masq DaemonSet to make PODs to resolve DNS names via locally running dnsmasq
 # It is disabled by default.
-#kubeDns:
 # nodeLocalResolver: false
+# When enabled, will deploy kube-dns to K8s controllers instead of workers.
+# deployToControllers: false
 
 kubeProxy:
   # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.9.0+ to work reliably)


### PR DESCRIPTION
I have an scenario where kube-dns needs to be deployed on controllers instead of K8s workers. I have added a flag to allow this configuration.
