### PR TITLE
Add priorityClassName to cloud-config-controller

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -991,6 +991,9 @@ write_files:
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
           spec:
+            {{if .Experimental.Admission.Priority.Enabled -}}
+            priorityClassName: system-node-critical
+            {{ end -}}
             tolerations:
             - operator: Exists
               effect: NoSchedule
@@ -1086,6 +1089,9 @@ write_files:
             labels:
               k8s-app: calico-policy
           spec:
+            {{if .Experimental.Admission.Priority.Enabled -}}
+            priorityClassName: system-node-critical
+            {{ end -}}
             tolerations:
             - key: "node.alpha.kubernetes.io/role"
               operator: "Equal"
@@ -1165,6 +1171,9 @@ write_files:
             labels:
               k8s-app: kube-resources-autosave-policy
           spec:
+            {{if .Experimental.Admission.Priority.Enabled -}}
+            priorityClassName: system-node-critical
+            {{ end -}}
             containers:
             - name: kube-resources-autosave-dumper
               image: {{.HyperkubeImage.RepoWithTag}}
@@ -1324,6 +1333,9 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               initContainers:
                 - name: hyperkube
                   image: {{.HyperkubeImage.RepoWithTag}}
@@ -1406,6 +1418,9 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               tolerations:
               - operator: Exists
                 effect: NoSchedule
@@ -1952,6 +1967,9 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               serviceAccountName: kube-proxy
               tolerations:
               - operator: Exists
@@ -2264,6 +2282,9 @@ write_files:
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
           spec:
+            {{if .Experimental.Admission.Priority.Enabled -}}
+            priorityClassName: system-node-critical
+            {{ end -}}
             tolerations:
             - key: "CriticalAddonsOnly"
               operator: "Exists"
@@ -2338,6 +2359,9 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               tolerations:
               - key: "CriticalAddonsOnly"
                 operator: "Exists"
@@ -2377,6 +2401,9 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               tolerations:
               - operator: Exists
                 effect: NoSchedule
@@ -2484,6 +2511,9 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               volumes:
               - name: kube-dns-config
                 configMap:
@@ -2663,6 +2693,9 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               tolerations:
               - key: "CriticalAddonsOnly"
                 operator: "Exists"
@@ -2755,6 +2788,9 @@ write_files:
               labels:
                 k8s-app: metrics-server
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               serviceAccountName: metrics-server
               containers:
               - name: metrics-server
@@ -2830,6 +2866,9 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               affinity:
                 nodeAffinity:
                   requiredDuringSchedulingIgnoredDuringExecution:
@@ -2929,6 +2968,9 @@ write_files:
               labels:
                 k8s-app: kubernetes-dashboard
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               containers:
               - name: kubernetes-dashboard
                 image: {{ .KubernetesDashboardImage.RepoWithTag }}
@@ -3032,6 +3074,9 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              {{if .Experimental.Admission.Priority.Enabled -}}
+              priorityClassName: system-node-critical
+              {{ end -}}
               tolerations:
               # Additions to the default tiller deployment for allowing to schedule tiller onto controller nodes
               # so that helm can be used to install pods running only on controller nodes
@@ -3415,6 +3460,9 @@ write_files:
             labels:
               name: kube2iam
           spec:
+            {{if .Experimental.Admission.Priority.Enabled -}}
+            priorityClassName: system-node-critical
+            {{ end -}}
             serviceAccountName: kube2iam
             hostNetwork: true
             tolerations:


### PR DESCRIPTION
This adds a baseline priority of `system-node-critical` to system critical pods, instead of the default value of `0`.

[`system-node-critical`](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/priority/admission.go#L48) is a System Priority class, which is used by system critical pods that should not be preempted by workload pods.

`priorityClassName` is only set if the priority feature is enabled.