### PR TITLE
Add [optional] explicit IAM role specification to NodeDrainer

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -104,6 +104,7 @@ func NewDefaultCluster() *Cluster {
 		NodeDrainer: model.NodeDrainer{
 			Enabled:      false,
 			DrainTimeout: 5,
+			IAMRole:      model.IAMRole{},
 		},
 		Oidc: model.Oidc{
 			Enabled:       false,

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -930,6 +930,7 @@ func TestNodeDrainerConfig(t *testing.T) {
 			nodeDrainer: model.NodeDrainer{
 				Enabled:      false,
 				DrainTimeout: 5,
+				IAMRole:      model.IAMRole{},
 			},
 		},
 		{
@@ -937,10 +938,13 @@ func TestNodeDrainerConfig(t *testing.T) {
 experimental:
   nodeDrainer:
     enabled: true
+    iamRole:
+      arn: arn:aws:iam::0123456789012:role/asg-list-role
 `,
 			nodeDrainer: model.NodeDrainer{
 				Enabled:      true,
 				DrainTimeout: 5,
+				IAMRole:      model.IAMRole{ARN: model.ARN{Arn: "arn:aws:iam::0123456789012:role/asg-list-role"}},
 			},
 		},
 		{

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1332,6 +1332,9 @@ write_files:
                 k8s-app: kube-node-drainer-asg-status-updater
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
+                {{if ne .Experimental.NodeDrainer.IAMRole.ARN.Arn "" -}}
+                iam.amazonaws.com/role: {{ .Experimental.NodeDrainer.IAMRole.ARN.Arn }}
+                {{ end }}
             spec:
               {{if .Experimental.Admission.Priority.Enabled -}}
               priorityClassName: system-node-critical

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1220,7 +1220,7 @@ addons:
 
   # When set to true this configures security groups for prometheus between nodes.
   # This includes the following ports: 10252, 10251, 10250, 9100, and 4194
-  prometheus: 
+  prometheus:
     securityGroupsEnabled: false
 
 # Experimental features will change in backward-incompatible ways
@@ -1296,6 +1296,10 @@ experimental:
     enabled: false
     # Maximum time to wait, in minutes, for the node to be completely drained. Must be an integer between 1 and 60.
     drainTimeout: 5
+    # IAM role to assume with kube2iam for the pod in "kube-node-drainer-asg-status-updater" deployment.
+    iamRole:
+      # Empty, inactive by default. Set it to valid ARN "arn: arn:aws:iam::0123456789012:role/roleName" to activate.
+      arn: ""
 
   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
   # For using Dex as a custom OIDC provider, please check "contrib/dex/README.md".

--- a/model/node_drainer.go
+++ b/model/node_drainer.go
@@ -6,8 +6,9 @@ import (
 )
 
 type NodeDrainer struct {
-	Enabled      bool `yaml:"enabled"`
-	DrainTimeout int  `yaml:"drainTimeout"`
+	Enabled      bool    `yaml:"enabled"`
+	DrainTimeout int     `yaml:"drainTimeout"`
+	IAMRole      IAMRole `yaml:"iamRole,omitempty"`
 }
 
 func (nd *NodeDrainer) DrainTimeoutInSeconds() int {


### PR DESCRIPTION
Add [optional] explicit IAM role specification to NodeDrainer.

If you are happy **kube2iam** user depending on your setup you may want **no AWS credentials** being available on pods having no IAM role specifications. At least I believe default access is an evil thing to be avoided.