### PR TITLE
Allow GovCloud managed policies and profiles

### DIFF
--- a/model/iamconfig.go
+++ b/model/iamconfig.go
@@ -49,16 +49,16 @@ func (c IAMConfig) Validate() error {
 		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
 	}
 
-	managedPolicyRegexp := regexp.MustCompile(`arn:aws|aws-us-gov:iam::((\d{12})|aws):policy/([a-zA-Z0-9-=,\\.@_]{1,128})`)
-	instanceProfileRegexp := regexp.MustCompile(`arn:aws|aws-us-gov:iam::(\d{12}):instance-profile/([a-zA-Z0-9-=,\\.@_]{1,128})`)
+	managedPolicyRegexp := regexp.MustCompile(`arn:aws(-cn|-us-gov)?:iam::((\d{12})|aws):policy/([a-zA-Z0-9-=,\\.@_]{1,128})`)
+	instanceProfileRegexp := regexp.MustCompile(`arn:aws(-cn|-us-gov)?:iam::(\d{12}):instance-profile/([a-zA-Z0-9-=,\\.@_]{1,128})`)
 	for _, policy := range c.Role.ManagedPolicies {
 		if !managedPolicyRegexp.MatchString(policy.Arn) {
-			return fmt.Errorf("invalid managed policy arn, your managed policy must match this (=arn:aws:iam::(YOURACCOUNTID|aws):policy/POLICYNAME), provided this (%s)", policy.Arn)
+			return fmt.Errorf("invalid managed policy arn, your managed policy must match this (=arn:REGIONIDENTIFIER:iam::(YOURACCOUNTID|aws):policy/POLICYNAME), provided this (%s)", policy.Arn)
 		}
 	}
 	if c.InstanceProfile.Arn != "" {
 		if !instanceProfileRegexp.MatchString(c.InstanceProfile.Arn) {
-			return fmt.Errorf("invalid instance profile, your instance profile must match (=arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME), provided (%s)", c.InstanceProfile.Arn)
+			return fmt.Errorf("invalid instance profile, your instance profile must match (=arn:REGIONIDENTIFIER:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME), provided (%s)", c.InstanceProfile.Arn)
 		}
 
 	}

--- a/model/iamconfig.go
+++ b/model/iamconfig.go
@@ -49,8 +49,8 @@ func (c IAMConfig) Validate() error {
 		return errors.New("failed to parse `iam` config: either you set `role.*` options or `instanceProfile.arn` ones but not both")
 	}
 
-	managedPolicyRegexp := regexp.MustCompile(`arn:aws:iam::((\d{12})|aws):policy/([a-zA-Z0-9-=,\\.@_]{1,128})`)
-	instanceProfileRegexp := regexp.MustCompile(`arn:aws:iam::(\d{12}):instance-profile/([a-zA-Z0-9-=,\\.@_]{1,128})`)
+	managedPolicyRegexp := regexp.MustCompile(`arn:aws|aws-us-gov:iam::((\d{12})|aws):policy/([a-zA-Z0-9-=,\\.@_]{1,128})`)
+	instanceProfileRegexp := regexp.MustCompile(`arn:aws|aws-us-gov:iam::(\d{12}):instance-profile/([a-zA-Z0-9-=,\\.@_]{1,128})`)
 	for _, policy := range c.Role.ManagedPolicies {
 		if !managedPolicyRegexp.MatchString(policy.Arn) {
 			return fmt.Errorf("invalid managed policy arn, your managed policy must match this (=arn:aws:iam::(YOURACCOUNTID|aws):policy/POLICYNAME), provided this (%s)", policy.Arn)

--- a/model/iamconfig_test.go
+++ b/model/iamconfig_test.go
@@ -1,0 +1,26 @@
+package model
+
+import "testing"
+
+func testValidIAMProfile(arn string, t *testing.T) {
+	c := IAMConfig{
+		InstanceProfile: IAMInstanceProfile{
+			ARN: ARN{Arn: arn},
+		},
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("iam profile should have been valid but raised error")
+	}
+}
+
+func TestGovCloudIAMProfile(t *testing.T) {
+	testValidIAMProfile("arn:aws-us-gov:iam::123412341234:instance-profile/Test", t)
+}
+
+func TestChinaIAMProfile(t *testing.T) {
+	testValidIAMProfile("arn:aws-cn:iam::123412341234:instance-profile/Test", t)
+}
+
+func TestIAMProfile(t *testing.T) {
+	testValidIAMProfile("arn:aws:iam::123412341234:instance-profile/Test", t)
+}


### PR DESCRIPTION
I was attempting a new GovCloud deployment that required me to reference existing IAM instance policies, and I wasn't able to so without this change. This might be a problem for other regions too.