### PR TITLE
Swap out wget for curl in node drainer scripts

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1362,7 +1362,7 @@ write_files:
                   - /bin/sh
                   - -xec
                   - |
-                    metadata() { curl -s -f http://169.254.169.254/2016-09-02/"$1"; }
+                    metadata() { curl -s -S -f http://169.254.169.254/2016-09-02/"$1"; }
                     asg()      { aws --region="${REGION}" autoscaling "$@"; }
 
                     # Hyperkube binary is not statically linked, so we need to use
@@ -1454,7 +1454,7 @@ write_files:
                   - /bin/sh
                   - -xec
                   - |
-                    metadata() { curl -s -f http://169.254.169.254/2016-09-02/"$1"; }
+                    metadata() { curl -s -S -f http://169.254.169.254/2016-09-02/"$1"; }
                     asg()      { aws --region="${REGION}" autoscaling "$@"; }
 
                     # Hyperkube binary is not statically linked, so we need to use

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1362,7 +1362,7 @@ write_files:
                   - /bin/sh
                   - -xec
                   - |
-                    metadata() { wget -O - -q http://169.254.169.254/2016-09-02/"$1"; }
+                    metadata() { curl -s -f http://169.254.169.254/2016-09-02/"$1"; }
                     asg()      { aws --region="${REGION}" autoscaling "$@"; }
 
                     # Hyperkube binary is not statically linked, so we need to use
@@ -1454,7 +1454,7 @@ write_files:
                   - /bin/sh
                   - -xec
                   - |
-                    metadata() { wget -O - -q http://169.254.169.254/2016-09-02/"$1"; }
+                    metadata() { curl -s -f http://169.254.169.254/2016-09-02/"$1"; }
                     asg()      { aws --region="${REGION}" autoscaling "$@"; }
 
                     # Hyperkube binary is not statically linked, so we need to use


### PR DESCRIPTION
Resolves https://github.com/kubernetes-incubator/kube-aws/issues/1125.

Also both curl and wget used within these scripts, better to use just one of them.

I went with the option to fail fast if the curl fails.