### PR TITLE
Template kube-dns-autoscaler parameters

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -154,6 +154,11 @@ func NewDefaultCluster() *Cluster {
 			KubeDns: KubeDns{
 				NodeLocalResolver:   false,
 				DeployToControllers: false,
+				Autoscaler: KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
 			},
 			KubernetesDashboard: KubernetesDashboard{
 				AdminPrivileges: true,
@@ -686,9 +691,16 @@ type IPVSMode struct {
 	MinSyncPeriod string `yaml:"minSyncPeriod"`
 }
 
+type KubeDnsAutoscaler struct {
+	CoresPerReplica int `yaml:"coresPerReplica"`
+	NodesPerReplica int `yaml:"nodesPerReplica"`
+	Min             int `yaml:"min"`
+}
+
 type KubeDns struct {
-	NodeLocalResolver   bool `yaml:"nodeLocalResolver"`
-	DeployToControllers bool `yaml:"deployToControllers"`
+	NodeLocalResolver   bool              `yaml:"nodeLocalResolver"`
+	DeployToControllers bool              `yaml:"deployToControllers"`
+	Autoscaler          KubeDnsAutoscaler `yaml:"autoscaler"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -1050,25 +1050,49 @@ func TestKubeDns(t *testing.T) {
 			conf: `
 `,
 			kubeDns: KubeDns{
+				NodeLocalResolver:   false,
 				DeployToControllers: false,
+				Autoscaler: KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
 			},
 		},
 		{
 			conf: `
 kubeDns:
+  nodeLocalResolver: false
   deployToControllers: false
 `,
 			kubeDns: KubeDns{
+				NodeLocalResolver:   false,
 				DeployToControllers: false,
+				Autoscaler: KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
 			},
 		},
 		{
 			conf: `
 kubeDns:
+  nodeLocalResolver: true
   deployToControllers: true
+  autoscaler:
+    coresPerReplica: 5
+    nodesPerReplica: 10
+    min: 15
 `,
 			kubeDns: KubeDns{
+				NodeLocalResolver:   true,
 				DeployToControllers: true,
+				Autoscaler: KubeDnsAutoscaler{
+					CoresPerReplica: 5,
+					NodesPerReplica: 10,
+					Min:             15,
+				},
 			},
 		},
 	}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2380,7 +2380,7 @@ write_files:
                   - --namespace=kube-system
                   - --configmap=kube-dns-autoscaler
                   - --target=Deployment/kube-dns
-                  - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":2}}
+                  - --default-params={"linear":{"coresPerReplica":{{ .KubeDns.Autoscaler.CoresPerReplica }},"nodesPerReplica":{{ .KubeDns.Autoscaler.NodesPerReplica }},"min":{{ .KubeDns.Autoscaler.Min}}}}
                   - --logtostderr=true
                   - --v=2
 

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1176,12 +1176,16 @@ kubernetesDashboard:
 #  sha1sum: a6fff8f9839d5905934e7e3df3123b54020a1f5e
 
 
-#kubeDns:
+kubeDns:
 # When enabled, will enable a DNS-masq DaemonSet to make PODs to resolve DNS names via locally running dnsmasq
 # It is disabled by default.
 # nodeLocalResolver: false
 # When enabled, will deploy kube-dns to K8s controllers instead of workers.
 # deployToControllers: false
+  autoscaler:
+    coresPerReplica: 256
+    nodesPerReplica: 16
+    min: 2
 
 kubeProxy:
   # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.9.0+ to work reliably)


### PR DESCRIPTION
We need to customise these values in our cluster. Seeing as it's always deployed (and not optional) I have just uncommented the `kubeDns` section in `cluster.yaml` and added an `autoscaling` key with the values in it. If you would rather I can add default values in the template so we can keep the config commented out.