### PR TITLE
Fix Key name for kubernetesDashboardImage

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1064,7 +1064,7 @@ worker:
 #  rktPullDocker: false
 
 # Kube Dashboard image repository to use.
-#kubeDashboardImage:
+#kubernetesDashboardImage:
 #  repo: k8s.gcr.io/kubernetes-dashboard-amd64
 #  tag: v1.8.1
 #  rktPullDocker: false


### PR DESCRIPTION
The template cluster.yaml references ```kubeDashboardImage```, but throws an ```Error: Failed to initialize cluster driver: file cluster.yaml: unknown keys found: kubeDashboardImage``` when uncommented.  Code appears to read the key from ```kubernetesDashboardImage```