### PR TITLE
Add Mutating/ValidatingAdmissionWebhook to Admission Control List

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -58,6 +58,12 @@ func NewDefaultCluster() *Cluster {
 			Priority{
 				Enabled: false,
 			},
+			MutatingAdmissionWebhook{
+				Enabled: false,
+			},
+			ValidatingAdmissionWebhook{
+				Enabled: false,
+			},
 		},
 		AuditLog: AuditLog{
 			Enabled: false,
@@ -559,11 +565,13 @@ type Experimental struct {
 }
 
 type Admission struct {
-	PodSecurityPolicy  PodSecurityPolicy  `yaml:"podSecurityPolicy"`
-	AlwaysPullImages   AlwaysPullImages   `yaml:"alwaysPullImages"`
-	DenyEscalatingExec DenyEscalatingExec `yaml:"denyEscalatingExec"`
-	Initializers       Initializers       `yaml:"initializers"`
-	Priority           Priority           `yaml:"priority"`
+	PodSecurityPolicy          PodSecurityPolicy          `yaml:"podSecurityPolicy"`
+	AlwaysPullImages           AlwaysPullImages           `yaml:"alwaysPullImages"`
+	DenyEscalatingExec         DenyEscalatingExec         `yaml:"denyEscalatingExec"`
+	Initializers               Initializers               `yaml:"initializers"`
+	Priority                   Priority                   `yaml:"priority"`
+	MutatingAdmissionWebhook   MutatingAdmissionWebhook   `yaml:"mutatingAdmissionWebhook"`
+	ValidatingAdmissionWebhook ValidatingAdmissionWebhook `yaml:"validatingAdmissionWebhook"`
 }
 
 type AlwaysPullImages struct {
@@ -583,6 +591,14 @@ type Initializers struct {
 }
 
 type Priority struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type MutatingAdmissionWebhook struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type ValidatingAdmissionWebhook struct {
 	Enabled bool `yaml:"enabled"`
 }
 

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2063,7 +2063,7 @@ write_files:
           - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
           {{ end }}
           - --advertise-address=$private_ipv4
-          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }}{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{if .Experimental.NodeAuthorizer.Enabled}},NodeRestriction{{end}},ResourceQuota{{if .Experimental.Admission.DenyEscalatingExec.Enabled}},DenyEscalatingExec{{end}}{{if .Experimental.Admission.Initializers.Enabled}},Initializers{{end}}{{if .Experimental.Admission.Priority.Enabled}},Priority{{end}},DefaultTolerationSeconds
+          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }}{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{if .Experimental.NodeAuthorizer.Enabled}},NodeRestriction{{end}},ResourceQuota{{if .Experimental.Admission.DenyEscalatingExec.Enabled}},DenyEscalatingExec{{end}}{{if .Experimental.Admission.Initializers.Enabled}},Initializers{{end}}{{if .Experimental.Admission.Priority.Enabled}},Priority{{end}},DefaultTolerationSeconds{{if .Experimental.Admission.MutatingAdmissionWebhook.Enabled}},MutatingAdmissionWebhook{{end}}{{if .Experimental.Admission.ValidatingAdmissionWebhook.Enabled}},ValidatingAdmissionWebhook{{end}}
           - --anonymous-auth=false
           {{if .Experimental.Oidc.Enabled}}
           - --oidc-issuer-url={{.Experimental.Oidc.IssuerUrl}}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1247,6 +1247,10 @@ experimental:
     # featureGate PodPriority:true in the worker
     priority:
       enabled: false
+    mutatingAdmissionWebhook:
+      enabled: false
+    validatingAdmissionWebhook:
+      enabled: false
 
   # Used to provide `/etc/environment` env vars with values from arbitrary CloudFormation refs
   awsEnvironment:

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1232,7 +1232,7 @@ experimental:
       enabled: true
     priority:
       enabled: true
-    mutatingAdmissionWebhook:
+    mutatingAdmissionWebhook
       enabled: true
     validatingAdmissionWebhook
       enabled: true

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -93,6 +93,12 @@ func TestMainClusterConfig(t *testing.T) {
 				Priority: controlplane_config.Priority{
 					Enabled: false,
 				},
+				MutatingAdmissionWebhook: controlplane_config.MutatingAdmissionWebhook{
+					Enabled: false,
+				},
+				ValidatingAdmissionWebhook: controlplane_config.ValidatingAdmissionWebhook{
+					Enabled: false,
+				},
 			},
 			AuditLog: controlplane_config.AuditLog{
 				Enabled: false,
@@ -1226,6 +1232,10 @@ experimental:
       enabled: true
     priority:
       enabled: true
+    mutatingAdmissionWebhook:
+      enabled: true
+    validatingAdmissionWebhook
+      enabled: true
   auditLog:
     enabled: true
     maxage: 100
@@ -1293,6 +1303,12 @@ worker:
 								Enabled: true,
 							},
 							Priority: controlplane_config.Priority{
+								Enabled: true,
+							},
+							MutatingAdmissionWebhook: controlplane_config.MutatingAdmissionWebhook{
+								Enabled: true,
+							},
+							ValidatingAdmissionWebhook: controlplane_config.ValidatingAdmissionWebhook{
 								Enabled: true,
 							},
 						},

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1232,9 +1232,9 @@ experimental:
       enabled: true
     priority:
       enabled: true
-    mutatingAdmissionWebhook
+    mutatingAdmissionWebhook:
       enabled: true
-    validatingAdmissionWebhook
+    validatingAdmissionWebhook:
       enabled: true
   auditLog:
     enabled: true


### PR DESCRIPTION
In order to support Istio automatic sidecar injection in Kubernetes 1.9, these two experimental admission controllers are required.

https://kubernetes.io/docs/admin/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use

https://istio.io/docs/setup/kubernetes/sidecar-injection.html#automatic-sidecar-injection