### PR TITLE
Fix validation failure on gp2 volume type for node pools

### DIFF
--- a/core/nodepool/cluster/cluster.go
+++ b/core/nodepool/cluster/cluster.go
@@ -197,13 +197,7 @@ func (c *ClusterRef) validateKeyPair(ec2Svc ec2DescribeKeyPairsService) error {
 func (c *ClusterRef) validateWorkerRootVolume(ec2Svc ec2CreateVolumeService) error {
 
 	//Send a dry-run request to validate the worker root volume parameters
-	workerRootVolume := &ec2.CreateVolumeInput{
-		DryRun:           aws.Bool(true),
-		AvailabilityZone: aws.String(c.Subnets[0].AvailabilityZone),
-		Iops:             aws.Int64(int64(c.RootVolume.IOPS)),
-		Size:             aws.Int64(int64(c.RootVolume.Size)),
-		VolumeType:       aws.String(c.RootVolume.Type),
-	}
+	workerRootVolume := c.getWorkerRootVolumeConfig()
 
 	if _, err := ec2Svc.CreateVolume(workerRootVolume); err != nil {
 		operr, ok := err.(awserr.Error)
@@ -214,6 +208,44 @@ func (c *ClusterRef) validateWorkerRootVolume(ec2Svc ec2CreateVolumeService) err
 	}
 
 	return nil
+}
+
+func (c *ClusterRef) getWorkerRootVolumeConfig() *ec2.CreateVolumeInput {
+	var workerRootVolume = &ec2.CreateVolumeInput{}
+
+	switch c.RootVolume.Type {
+	case "standard":
+		workerRootVolume = &ec2.CreateVolumeInput{
+			DryRun:           aws.Bool(true),
+			AvailabilityZone: aws.String(c.Subnets[0].AvailabilityZone),
+			Size:             aws.Int64(int64(c.RootVolume.Size)),
+			VolumeType:       aws.String(c.RootVolume.Type),
+		}
+	case "io1":
+		workerRootVolume = &ec2.CreateVolumeInput{
+			DryRun:           aws.Bool(true),
+			AvailabilityZone: aws.String(c.Subnets[0].AvailabilityZone),
+			Iops:             aws.Int64(int64(c.RootVolume.IOPS)),
+			Size:             aws.Int64(int64(c.RootVolume.Size)),
+			VolumeType:       aws.String(c.RootVolume.Type),
+		}
+	case "gp2":
+		workerRootVolume = &ec2.CreateVolumeInput{
+			DryRun:           aws.Bool(true),
+			AvailabilityZone: aws.String(c.Subnets[0].AvailabilityZone),
+			Size:             aws.Int64(int64(c.RootVolume.Size)),
+			VolumeType:       aws.String(c.RootVolume.Type),
+		}
+	default:
+		workerRootVolume = &ec2.CreateVolumeInput{
+			DryRun:           aws.Bool(true),
+			AvailabilityZone: aws.String(c.Subnets[0].AvailabilityZone),
+			Size:             aws.Int64(int64(c.RootVolume.Size)),
+			VolumeType:       aws.String(c.RootVolume.Type),
+		}
+	}
+
+	return workerRootVolume
 }
 
 func (c *ClusterRef) Info() (*Info, error) {

--- a/core/nodepool/cluster/cluster.go
+++ b/core/nodepool/cluster/cluster.go
@@ -214,7 +214,7 @@ func (c *ClusterRef) getWorkerRootVolumeConfig() *ec2.CreateVolumeInput {
 	var workerRootVolume = &ec2.CreateVolumeInput{}
 
 	switch c.RootVolume.Type {
-	case "standard":
+	case "standard", "gp2":
 		workerRootVolume = &ec2.CreateVolumeInput{
 			DryRun:           aws.Bool(true),
 			AvailabilityZone: aws.String(c.Subnets[0].AvailabilityZone),
@@ -226,13 +226,6 @@ func (c *ClusterRef) getWorkerRootVolumeConfig() *ec2.CreateVolumeInput {
 			DryRun:           aws.Bool(true),
 			AvailabilityZone: aws.String(c.Subnets[0].AvailabilityZone),
 			Iops:             aws.Int64(int64(c.RootVolume.IOPS)),
-			Size:             aws.Int64(int64(c.RootVolume.Size)),
-			VolumeType:       aws.String(c.RootVolume.Type),
-		}
-	case "gp2":
-		workerRootVolume = &ec2.CreateVolumeInput{
-			DryRun:           aws.Bool(true),
-			AvailabilityZone: aws.String(c.Subnets[0].AvailabilityZone),
 			Size:             aws.Int64(int64(c.RootVolume.Size)),
 			VolumeType:       aws.String(c.RootVolume.Type),
 		}

--- a/core/nodepool/cluster/cluster_test.go
+++ b/core/nodepool/cluster/cluster_test.go
@@ -40,9 +40,14 @@ func (svc dummyEC2CreateVolumeService) CreateVolume(input *ec2.CreateVolumeInput
 		)
 	}
 
-	if aws.Int64Value(input.Iops) != aws.Int64Value(expected.Iops) {
+	if (input.Iops == nil && expected.Iops != nil) ||
+		(input.Iops != nil && expected.Iops == nil) ||
+		aws.Int64Value(input.Iops) != aws.Int64Value(expected.Iops) {
 		return nil, fmt.Errorf(
-			"unexpected root volume iops\nexpected=%v, observed=%v",
+			"unexpected root volume iops\n raw values expected=%v, observed=%v \n "+
+				"dereferenced values: expected=%v, observed=%v",
+			expected.Iops,
+			input.Iops,
 			aws.Int64Value(expected.Iops),
 			aws.Int64Value(input.Iops),
 		)
@@ -149,7 +154,6 @@ availabilityZone: dummy-az-0
 	}{
 		{
 			expectedRootVolume: &ec2.CreateVolumeInput{
-				Iops:       aws.Int64(0),
 				Size:       aws.Int64(30),
 				VolumeType: aws.String("gp2"),
 			},
@@ -159,7 +163,6 @@ availabilityZone: dummy-az-0
 		},
 		{
 			expectedRootVolume: &ec2.CreateVolumeInput{
-				Iops:       aws.Int64(0),
 				Size:       aws.Int64(30),
 				VolumeType: aws.String("standard"),
 			},
@@ -170,7 +173,6 @@ rootVolume:
 		},
 		{
 			expectedRootVolume: &ec2.CreateVolumeInput{
-				Iops:       aws.Int64(0),
 				Size:       aws.Int64(50),
 				VolumeType: aws.String("gp2"),
 			},


### PR DESCRIPTION
Improved tests and code to respect changes in EC2 validate volume API. We can no longer submit IOPS 0 as being synomous with unset field / null.

In `core/nodepool/cluster.go`, the function: `validateWorkerRootVolume` is changed to call an another function to generate EC2 volume parameters. Also tweaked tests around that.
