### PR TITLE
Integrate s3-uri flag into cluster.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Generate `cluster.yaml`:
 $ mkdir my-cluster
 $ cd my-cluster
 $ kube-aws init --cluster-name=my-cluster \
+--s3-uri=s3://examplebucket/mydir \
 --external-dns-name=<my-cluster-endpoint> \
 --region=us-west-1 \
 --availability-zone=us-west-1c \
@@ -51,16 +52,16 @@ $ kube-aws render stack
 Validate configuration:
 
 ```
-$ kube-aws validate --s3-uri s3://<your-bucket>/<optional-prefix>
+$ kube-aws validate
 ```
 
 Launch:
 
 ```
-$ kube-aws up --s3-uri s3://<your-bucket>/<optional-prefix>
+$ kube-aws up 
 
 # Or export your cloudformation stack and dependent assets into the `exported/` directory
-$ kube-aws up --s3-uri s3://<your-bucket>/<optional-prefix> --export
+$ kube-aws up --export
 
 # Access the cluster
 $ KUBECONFIG=kubeconfig kubectl get nodes --show-labels
@@ -71,7 +72,7 @@ Update:
 ```
 $ $EDITOR cluster.yaml
 # Update all the cfn stacks including the one for control-plane and the ones for worker node pools
-$ kube-aws update --s3-uri s3://<your-bucket>/<optional-prefix>
+$ kube-aws update 
 ```
 
 Destroy:

--- a/cmd/calculator.go
+++ b/cmd/calculator.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/kubernetes-incubator/kube-aws/core/root"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 //TODO this is a first step to calculate the stack cost
@@ -21,23 +22,17 @@ var (
 
 	calculatorOpts = struct {
 		awsDebug bool
-		s3URI    string
 	}{}
 )
 
 func init() {
 	RootCmd.AddCommand(cmdCalculator)
 	cmdCalculator.Flags().BoolVar(&calculatorOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
-	cmdCalculator.Flags().StringVar(&calculatorOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3. S3 location expressed as s3://<bucket>/path/to/dir")
 }
 
 func runCmdCalculator(cmd *cobra.Command, args []string) error {
 
-	if err := validateRequired(flag{"--s3-uri", calculatorOpts.s3URI}); err != nil {
-		return err
-	}
-
-	opts := root.NewOptions(calculatorOpts.s3URI, false, false)
+	opts := root.NewOptions(false, false)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, calculatorOpts.awsDebug)
 	if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -23,6 +23,7 @@ var (
 
 func init() {
 	RootCmd.AddCommand(cmdInit)
+	cmdInit.Flags().StringVar(&initOpts.S3URI, "s3-uri", "", "The URI of the S3 bucket")
 	cmdInit.Flags().StringVar(&initOpts.ClusterName, "cluster-name", "", "The name of this cluster. This will be the name of the cloudformation stack")
 	cmdInit.Flags().StringVar(&initOpts.ExternalDNSName, "external-dns-name", "", "The hostname that will route to the api server")
 	cmdInit.Flags().StringVar(&initOpts.HostedZoneID, "hosted-zone-id", "", "The hosted zone in which a Route53 record set for a k8s API endpoint is created")
@@ -37,6 +38,7 @@ func init() {
 func runCmdInit(cmd *cobra.Command, args []string) error {
 	// Validate flags.
 	if err := validateRequired(
+		flag{"--s3-uri", initOpts.S3URI},
 		flag{"--cluster-name", initOpts.ClusterName},
 		flag{"--external-dns-name", initOpts.ExternalDNSName},
 		flag{"--region", initOpts.Region.Name},

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -27,19 +27,11 @@ func init() {
 	cmdUp.Flags().BoolVar(&upOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
 	cmdUp.Flags().BoolVar(&upOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
 	cmdUp.Flags().BoolVar(&upOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
-	cmdUp.Flags().StringVar(&upOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3. S3 location expressed as s3://<bucket>/path/to/dir")
 	cmdUp.Flags().BoolVar(&upOpts.skipWait, "skip-wait", false, "Don't wait for the cluster components be ready")
 }
 
 func runCmdUp(cmd *cobra.Command, args []string) error {
-	// s3URI is required in order to render stack templates because the URI is parsed, combined and then included in the stack templates as
-	// (1) URLs to actual worker/controller cloud-configs in S3 and
-	// (2) URLs to nested stack templates referenced from the root stack template
-	if err := validateRequired(flag{"--s3-uri", upOpts.s3URI}); err != nil {
-		return err
-	}
-
-	opts := root.NewOptions(upOpts.s3URI, upOpts.prettyPrint, upOpts.skipWait)
+	opts := root.NewOptions(upOpts.prettyPrint, upOpts.skipWait)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, upOpts.awsDebug)
 	if err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -26,16 +26,11 @@ func init() {
 	RootCmd.AddCommand(cmdUpdate)
 	cmdUpdate.Flags().BoolVar(&updateOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
 	cmdUpdate.Flags().BoolVar(&updateOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
-	cmdUpdate.Flags().StringVar(&updateOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3. S3 location expressed as s3://<bucket>/path/to/dir")
 	cmdUpdate.Flags().BoolVar(&updateOpts.skipWait, "skip-wait", false, "Don't wait the resources finish")
 }
 
 func runCmdUpdate(cmd *cobra.Command, args []string) error {
-	if err := validateRequired(flag{"--s3-uri", updateOpts.s3URI}); err != nil {
-		return err
-	}
-
-	opts := root.NewOptions(updateOpts.s3URI, updateOpts.prettyPrint, updateOpts.skipWait)
+	opts := root.NewOptions(updateOpts.prettyPrint, updateOpts.skipWait)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, updateOpts.awsDebug)
 	if err != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -32,16 +32,10 @@ func init() {
 		false,
 		"Log debug information from aws-sdk-go library",
 	)
-	cmdValidate.Flags().StringVar(
-		&validateOpts.s3URI,
-		"s3-uri",
-		"",
-		"When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3. S3 location expressed as s3://<bucket>/path/to/dir",
-	)
 }
 
 func runCmdValidate(cmd *cobra.Command, args []string) error {
-	opts := root.NewOptions(validateOpts.s3URI, validateOpts.awsDebug, validateOpts.skipWait)
+	opts := root.NewOptions(validateOpts.awsDebug, validateOpts.skipWait)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, validateOpts.awsDebug)
 	if err != nil {

--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -124,7 +124,7 @@ func (c *ClusterRef) validateExistingVPCState(ec2Svc ec2Service) error {
 func NewCluster(cfg *config.Cluster, opts config.StackTemplateOptions, plugins []*pluginmodel.Plugin, awsDebug bool) (*Cluster, error) {
 	clusterRef := NewClusterRef(cfg, awsDebug)
 	// TODO Do this in a cleaner way e.g. in config.go
-	clusterRef.KubeResourcesAutosave.S3Path = model.NewS3Folders(opts.S3URI, clusterRef.ClusterName).ClusterBackups().Path()
+	clusterRef.KubeResourcesAutosave.S3Path = model.NewS3Folders(cfg.DeploymentSettings.S3URI, clusterRef.ClusterName).ClusterBackups().Path()
 
 	stackConfig, err := clusterRef.StackConfig(opts, plugins)
 	if err != nil {

--- a/core/controlplane/cluster/cluster_test.go
+++ b/core/controlplane/cluster/cluster_test.go
@@ -30,6 +30,7 @@ func defaultConfigValues(t *testing.T, configYaml string) string {
 	defaultYaml := `
 externalDNSName: test.staging.core-os.net
 keyName: test-key-name
+s3URI: s3://mybucket/mydir
 region: us-west-1
 clusterName: test-cluster-name
 kmsKeyArn: "arn:aws:kms:us-west-1:xxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
@@ -748,6 +749,7 @@ func newDefaultClusterWithDeps(opts config.StackTemplateOptions) (*Cluster, erro
 	}
 	cluster.ExternalDNSName = "foo.example.com"
 	cluster.KeyName = "mykey"
+	cluster.S3URI = "s3://mybucket/mydir"
 	cluster.KMSKeyARN = "mykmskey"
 	if err := cluster.Load(); err != nil {
 		return &Cluster{}, err

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -429,6 +429,7 @@ type DeploymentSettings struct {
 	ComputedDeploymentSettings
 	CloudFormation              model.CloudFormation  `yaml:"cloudformation,omitempty"`
 	ClusterName                 string                `yaml:"clusterName,omitempty"`
+	S3URI                       string                `yaml:"s3URI,omitempty"`
 	KeyName                     string                `yaml:"keyName,omitempty"`
 	Region                      model.Region          `yaml:",inline"`
 	AvailabilityZone            string                `yaml:"availabilityZone,omitempty"`
@@ -946,6 +947,7 @@ type InitialConfig struct {
 	KeyName          string
 	NoRecordSet      bool
 	Region           model.Region
+	S3URI            string
 }
 
 // Config contains configuration parameters available when rendering userdata injected into a controller or an etcd node from golang text templates
@@ -1226,6 +1228,9 @@ func (c DeploymentSettings) Validate() (*DeploymentValidationResult, error) {
 	}
 	if c.ClusterName == "" {
 		return nil, errors.New("clusterName must be set")
+	}
+	if c.S3URI == "" {
+		return nil, errors.New("s3URI must be set")
 	}
 	if c.KMSKeyARN == "" && c.AssetsEncryptionEnabled() {
 		return nil, errors.New("kmsKeyArn must be set")

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -18,12 +18,14 @@ const availabilityZoneConfig = `availabilityZone: us-west-1c
 
 const apiEndpointMinimalConfigYaml = `keyName: test-key-name
 region: us-west-1
+s3URI: s3://mybucket/mydir
 clusterName: test-cluster-name
 kmsKeyArn: "arn:aws:kms:us-west-1:xxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
 `
 
 const chinaAPIEndpointMinimalConfigYaml = `keyName: test-key-name
 region: cn-north-1
+s3URI: s3://mybucket/mydir
 availabilityZone: cn-north-1a
 clusterName: test-cluster-name
 `

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -3,6 +3,9 @@
 # name must not conflict with an existing cluster.
 clusterName: {{.ClusterName}}
 
+# The URI of the S3 bucket for the cluster
+s3URI: {{.S3URI}}
+
 # CoreOS release channel to use. Currently supported options: alpha, beta, stable
 # See coreos.com/releases for more information
 #releaseChannel: stable

--- a/core/nodepool/cluster/cluster_test.go
+++ b/core/nodepool/cluster/cluster_test.go
@@ -94,6 +94,7 @@ func (svc dummyEC2DescribeKeyPairsService) DescribeKeyPairs(input *ec2.DescribeK
 
 func TestValidateKeyPair(t *testing.T) {
 	main, err := controlplane.ConfigFromBytes([]byte(`clusterName: test-cluster
+s3URI: s3://mybucket/mydir
 apiEndpoints:
 - name: public
   dnsName: test-cluster.example.com
@@ -134,6 +135,7 @@ const minimalYaml = `name: pool1
 
 func TestValidateWorkerRootVolume(t *testing.T) {
 	main, err := controlplane.ConfigFromBytes([]byte(`clusterName: test-cluster
+s3URI: s3://mybucket/mydir
 apiEndpoints:
 - name: public
   dnsName: test-cluster.example.com
@@ -224,6 +226,7 @@ apiEndpoints:
 keyName: test-key-name
 region: us-west-1
 clusterName: test-cluster-name
+s3URI: s3://mybucket/mydir
 kmsKeyArn: "arn:aws:kms:us-west-1:xxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
 availabilityZone: us-west-1a
 `

--- a/core/nodepool/config/config_test.go
+++ b/core/nodepool/config/config_test.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	cfg "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	"testing"
+
+	cfg "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 )
 
 const cluster_config = `
@@ -10,6 +11,7 @@ availabilityZone: us-west-1c
 keyName: test-key-name
 region: us-west-1
 clusterName: test-cluster-name
+s3URI: s3://bucket/demo
 kmsKeyArn: "arn:aws:kms:us-west-1:xxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
 apiEndpoints:
 - name: public

--- a/core/root/options.go
+++ b/core/root/options.go
@@ -10,12 +10,11 @@ type options struct {
 	RootStackTemplateTmplFile         string
 	ControlPlaneStackTemplateTmplFile string
 	NodePoolStackTemplateTmplFile     string
-	S3URI                             string
 	SkipWait                          bool
 	PrettyPrint                       bool
 }
 
-func NewOptions(s3URI string, prettyPrint bool, skipWait bool) options {
+func NewOptions(prettyPrint bool, skipWait bool) options {
 	return options{
 		AssetsDir:                         defaults.AssetsDir,
 		ControllerTmplFile:                defaults.ControllerTmplFile,
@@ -24,8 +23,7 @@ func NewOptions(s3URI string, prettyPrint bool, skipWait bool) options {
 		ControlPlaneStackTemplateTmplFile: defaults.ControlPlaneStackTemplateTmplFile,
 		NodePoolStackTemplateTmplFile:     defaults.NodePoolStackTemplateTmplFile,
 		RootStackTemplateTmplFile:         defaults.RootStackTemplateTmplFile,
-		S3URI:       s3URI,
-		SkipWait:    skipWait,
-		PrettyPrint: prettyPrint,
+		SkipWait:                          skipWait,
+		PrettyPrint:                       prettyPrint,
 	}
 }

--- a/docs/cli-reference/README.md
+++ b/docs/cli-reference/README.md
@@ -73,8 +73,7 @@ Validate cluster assets prior to deployment.
 ### `validate` example
 
 ```bash
-$ kube-aws validate \
-  --s3-uri=s3://my-kube-aws-assets-bucket
+$ kube-aws validate
 ```
 
 # `up`
@@ -92,8 +91,7 @@ Deploy a new Kubernetes cluster.
 ### `up` example
 
 ```bash
-$ kube-aws up \
-  --s3-uri=s3://my-kube-aws-assets-bucket
+$ kube-aws up 
 ```
 
 # `update`
@@ -110,8 +108,7 @@ Update an existing Kubernetes cluster that was created by kube-aws.
 ### `update` example
 
 ```bash
-$ kube-aws update \
-  --s3-uri=s3://my-kube-aws-assets-bucket
+$ kube-aws update
 ```
 
 # `destroy`

--- a/docs/getting-started/step-2-render.md
+++ b/docs/getting-started/step-2-render.md
@@ -384,7 +384,7 @@ The `validate` command check the validity of your changes to the cloud-config us
 This is an important step to make sure your stack will launch successfully:
 
 ```sh
-$ kube-aws validate --s3-uri s3://<your-bucket-name>/<prefix>
+$ kube-aws validate
 ```
 
 If your files are valid, you are ready to [launch your cluster][getting-started-step-3].

--- a/docs/getting-started/step-3-launch.md
+++ b/docs/getting-started/step-3-launch.md
@@ -7,7 +7,7 @@ This is the [third step of running Kubernetes on AWS](README.md). We're ready to
 Now for the exciting part, creating your cluster:
 
 ```sh
-$ kube-aws up --s3-uri s3://<your-bucket-name>/<prefix>
+$ kube-aws up
 ```
 
 **NOTE**: It can take some time after `kube-aws up` completes before the cluster is available. When the cluster is first being launched, it must download all container images for the cluster components (Kubernetes, dns, heapster, etc). Depending on the speed of your connection, it can take a few minutes before the Kubernetes api-server is available.

--- a/docs/getting-started/step-4-update.md
+++ b/docs/getting-started/step-4-update.md
@@ -6,7 +6,7 @@ There are two distinct categories of cluster update.
 * **Parameter-level update**: Only changes to `cluster.yaml` and/or TLS assets in `credentials/` folder are reflected. To enact this type of update. Modifications to CloudFormation or cloud-config userdata templates will not be reflected. In this case, you do not have to re-render:
 
 ```sh
-kube-aws update --s3-uri s3://<your-bucket-name>/<prefix>
+kube-aws update
 ```
 
 * **Full update**: Any change (besides changes made to the etcd cluster- more on that later) will be enacted, including structural changes to CloudFormation and cloudinit templates. This is the type of upgrade that must be run on installing a new version of kube-aws, or more generally when cloudinit or CloudFormation templates are modified:
@@ -15,7 +15,7 @@ kube-aws update --s3-uri s3://<your-bucket-name>/<prefix>
 kube-aws render stack
 kube-aws render credentials
 git diff # view changes to rendered assets
-kube-aws update --s3-uri s3://<your-bucket-name>/<prefix>
+kube-aws update
 ```
 
 ## Certificate and access token rotation
@@ -34,7 +34,7 @@ More concretely, steps should be taken in order to rotate your certs on nodes ar
 * Execute the update command like:
 
   ```sh
-  kube-aws update --s3-uri s3://<your-bucket-name>/<prefix>
+  kube-aws update
   ```
 
 ## The etcd caveat

--- a/docs/getting-started/step-5-add-node-pool.md
+++ b/docs/getting-started/step-5-add-node-pool.md
@@ -56,8 +56,7 @@ worker:
 Launch the secondary node pool by running `kube-aws update`:
 
 ```
-$ kube-aws update \
-  --s3-uri s3://<my-bucket>/<optional-prefix>
+$ kube-aws update
 ```
 
 Beware that you have to associate only 1 AZ to a node pool or cluster-autoscaler may end up failing to reliably add nodes on demand due to the fact

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -61,7 +61,7 @@ The files generated form the basis of the deployment.
 Before we move onto deploying, let's run `validate` to check the work above using the S3 bucket name from the pre-requisites section. For example:
 
 ```bash
-➜ kube-aws validate --s3-uri=s3://kube-aws-assets/
+➜ kube-aws validate
 ```
 
 # Step 3: Launch
@@ -69,7 +69,7 @@ Before we move onto deploying, let's run `validate` to check the work above usin
 Now you've generated and validated the various assets needed to launch a new cluster, let's run the deploy! Run `up` using the S3 bucket name from the pre-requisites section. For example:
 
 ```bash
-➜ kube-aws up --s3-uri=s3://kube-aws-assets/
+➜ kube-aws up
 ```
 
 # Step 4: Deploy an Application

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -27,7 +27,7 @@ func TestMainClusterConfig(t *testing.T) {
 	s3URI, s3URIExists := os.LookupEnv("KUBE_AWS_S3_DIR_URI")
 
 	if !s3URIExists || s3URI == "" {
-		s3URI = "s3://examplebucket/exampledir"
+		s3URI = "s3://mybucket/mydir"
 		t.Logf(`Falling back s3URI to a stub value "%s" for tests of validating stack templates. No assets will actually be uploaded to S3`, s3URI)
 	}
 
@@ -399,7 +399,6 @@ func TestMainClusterConfig(t *testing.T) {
 
 	mainClusterYaml := kubeAwsSettings.mainClusterYaml()
 	minimalValidConfigYaml := kubeAwsSettings.minimumValidClusterYamlWithAZ("c")
-
 	configYamlWithoutExernalDNSName := kubeAwsSettings.mainClusterYamlWithoutAPIEndpoint() + `
 availabilityZone: us-west-1c
 `
@@ -3408,7 +3407,7 @@ worker:
 			})
 
 			helper.WithDummyCredentials(func(dummyAssetsDir string) {
-				var stackTemplateOptions = root.NewOptions(s3URI, false, false)
+				var stackTemplateOptions = root.NewOptions(false, false)
 				stackTemplateOptions.AssetsDir = dummyAssetsDir
 				stackTemplateOptions.ControllerTmplFile = "../../core/controlplane/config/templates/cloud-config-controller"
 				stackTemplateOptions.WorkerTmplFile = "../../core/controlplane/config/templates/cloud-config-worker"

--- a/test/integration/nodepool_test.go
+++ b/test/integration/nodepool_test.go
@@ -68,6 +68,7 @@ apiEndpoints:
 sshAuthorizedKeys:
 - mydummysshpublickey
 kmsKeyArn: mykmskeyarn
+s3URI: s3//bucket/emptyDir
 `
 	mainCluster, err := cfg.ClusterFromBytes([]byte(mainClusterYaml))
 	if err != nil {

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -19,7 +19,7 @@ func TestPlugin(t *testing.T) {
 	s3URI, s3URIExists := os.LookupEnv("KUBE_AWS_S3_DIR_URI")
 
 	if !s3URIExists || s3URI == "" {
-		s3URI = "s3://examplebucket/exampledir"
+		s3URI = "s3://mybucket/mydir"
 		t.Logf(`Falling back s3URI to a stub value "%s" for tests of validating stack templates. No assets will actually be uploaded to S3`, s3URI)
 	}
 
@@ -484,7 +484,7 @@ spec:
 				})
 
 				helper.WithDummyCredentials(func(dummyAssetsDir string) {
-					var stackTemplateOptions = root.NewOptions(s3URI, false, false)
+					var stackTemplateOptions = root.NewOptions(false, false)
 					stackTemplateOptions.AssetsDir = dummyAssetsDir
 					stackTemplateOptions.ControllerTmplFile = "../../core/controlplane/config/templates/cloud-config-controller"
 					stackTemplateOptions.WorkerTmplFile = "../../core/controlplane/config/templates/cloud-config-worker"


### PR DESCRIPTION
Integrates `--s3-uri` flag into the cluster.yaml. Only `init` command require this flag now.

I'm not a go expert, so, help wanted here ;)