### PR TITLE
Enable DescribeLaunchConfigurations

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -252,7 +252,7 @@
                     "autoscaling:DescribeAutoScalingGroups",
                     "autoscaling:DescribeAutoScalingInstances",
                     "autoscaling:DescribeTags",
-                    "autoscaling:DescribeAutoScalingGroups"
+                    "autoscaling:DescribeLaunchConfigurations"
                   ],
                   "Effect": "Allow",
                   "Resource": "*"


### PR DESCRIPTION
core/controleplane/config/templates

When scaling from 0 -> n nodes we require DescribeAutoscalingGroups in order to scale up based on docs: https://github.com/kubernetes/autoscaler/blob/5302c37d6d6e89a2eeac0c74b4afe6caadfa3340/cluster-autoscaler/cloudprovider/aws/README.md#scaling-a-node-group-to-0

fixes: https://github.com/kubernetes-incubator/kube-aws/issues/1169
