### PR TITLE
Networking DaemonSets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _book
 *.mobi
 *.pdf
 node_modules
+kube-aws

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -493,9 +493,6 @@ type DeploymentSettings struct {
 	PauseImage                         model.Image `yaml:"pauseImage,omitempty"`
 	FlannelImage                       model.Image `yaml:"flannelImage,omitempty"`
 	JournaldCloudWatchLogsImage        model.Image `yaml:"journaldCloudWatchLogsImage,omitempty"`
-	EtcdlessCalicoNodeImage            model.Image `yaml:"etcdlessCalicoNodeImage,omitempty"`
-	EtcdlessCalicoCniImage             model.Image `yaml:"etcdlessCalicoCniImage,omitempty"`
-	EtcdlessFlannelCniImage            model.Image `yaml:"etcdlessFlannelCniImage,omitempty"`
 }
 
 // Part of configuration which is specific to worker nodes

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -114,6 +114,15 @@ func NewDefaultCluster() *Cluster {
 			UsernameClaim: "email",
 			GroupsClaim:   "groups",
 		},
+		NetworkingDaemonSets: NetworkingDaemonSets{
+			Enabled:         false,
+			Typha:           false,
+			CalicoNodeImage: model.Image{Repo: "quay.io/calico/node", Tag: "v3.0.3", RktPullDocker: false},
+			CalicoCniImage:  model.Image{Repo: "quay.io/calico/cni", Tag: "v2.0.1", RktPullDocker: false},
+			FlannelImage:    model.Image{Repo: "quay.io/coreos/flannel", Tag: "v0.9.1", RktPullDocker: false},
+			FlannelCniImage: model.Image{Repo: "quay.io/coreos/flannel-cni", Tag: "v0.3.0", RktPullDocker: false},
+			TyphaImage:      model.Image{Repo: "quay.io/calico/typha", Tag: "v0.6.2", RktPullDocker: false},
+		},
 	}
 
 	ipvsMode := IPVSMode{
@@ -458,9 +467,11 @@ type DeploymentSettings struct {
 	KubeDns                 `yaml:"kubeDns,omitempty"`
 	KubernetesDashboard     `yaml:"kubernetesDashboard,omitempty"`
 	// Images repository
-	HyperkubeImage                     model.Image `yaml:"hyperkubeImage,omitempty"`
-	AWSCliImage                        model.Image `yaml:"awsCliImage,omitempty"`
-	CalicoNodeImage                    model.Image `yaml:"calicoNodeImage,omitempty"`
+	HyperkubeImage model.Image `yaml:"hyperkubeImage,omitempty"`
+	AWSCliImage    model.Image `yaml:"awsCliImage,omitempty"`
+
+	CalicoNodeImage model.Image `yaml:"calicoNodeImage,omitempty"`
+
 	CalicoCniImage                     model.Image `yaml:"calicoCniImage,omitempty"`
 	CalicoCtlImage                     model.Image `yaml:"calicoCtlImage,omitempty"`
 	CalicoKubeControllersImage         model.Image `yaml:"calicoKubeControllersImage,omitempty"`
@@ -482,6 +493,9 @@ type DeploymentSettings struct {
 	PauseImage                         model.Image `yaml:"pauseImage,omitempty"`
 	FlannelImage                       model.Image `yaml:"flannelImage,omitempty"`
 	JournaldCloudWatchLogsImage        model.Image `yaml:"journaldCloudWatchLogsImage,omitempty"`
+	EtcdlessCalicoNodeImage            model.Image `yaml:"etcdlessCalicoNodeImage,omitempty"`
+	EtcdlessCalicoCniImage             model.Image `yaml:"etcdlessCalicoCniImage,omitempty"`
+	EtcdlessFlannelCniImage            model.Image `yaml:"etcdlessFlannelCniImage,omitempty"`
 }
 
 // Part of configuration which is specific to worker nodes
@@ -561,6 +575,7 @@ type Experimental struct {
 	DisableSecurityGroupIngress bool                           `yaml:"disableSecurityGroupIngress"`
 	NodeMonitorGracePeriod      string                         `yaml:"nodeMonitorGracePeriod"`
 	model.UnknownKeys           `yaml:",inline"`
+	NetworkingDaemonSets        NetworkingDaemonSets `yaml:"networkingDaemonSets"`
 }
 
 type Admission struct {
@@ -673,6 +688,16 @@ type LocalStreaming struct {
 	Enabled  bool   `yaml:"enabled"`
 	Filter   string `yaml:"filter"`
 	interval int    `yaml:"interval"`
+}
+
+type NetworkingDaemonSets struct {
+	Enabled         bool        `yaml:"enabled"`
+	Typha           bool        `yaml:"typha"`
+	CalicoNodeImage model.Image `yaml:"calico-node-image"`
+	CalicoCniImage  model.Image `yaml:"calico-cni-image"`
+	FlannelImage    model.Image `yaml:"flannel-image"`
+	FlannelCniImage model.Image `yaml:"flannel-cni-image"`
+	TyphaImage      model.Image `yaml:"typha-image"`
 }
 
 func (c *LocalStreaming) Interval() int64 {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3166,9 +3166,7 @@ write_files:
           - /hyperkube
           - apiserver
           - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .ControllerCount }}{{end}}
-{{/* RUN 935 start up with bind address of 127.0.0.1 until SA keys have been properly updated */}}
-          - --bind-address=127.0.0.1
-{{/* RUN 935 start up with bind address of 127.0.0.1 until SA keys have been properly updated */}}
+          - --bind-address=0.0.0.0
           - --etcd-servers=#ETCD_ENDPOINTS#
           - --etcd-cafile=/etc/kubernetes/ssl/etcd-trusted-ca.pem
           - --etcd-certfile=/etc/kubernetes/ssl/etcd-client.pem

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -27,12 +27,13 @@ exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE
 coreos:
   update:
     reboot-strategy: "off"
+  {{ if not .Experimental.NetworkingDaemonSets.Enabled -}} 
   flannel:
     interface: $private_ipv4
     etcd_cafile: /etc/kubernetes/ssl/etcd-trusted-ca.pem
     etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
-
+  {{- end }}
   units:
 {{- range $u := .Controller.CustomSystemdUnits}}
     - name: {{$u.Name}}
@@ -129,7 +130,6 @@ coreos:
         RemainAfterExit=true
         ExecStartPre=/opt/bin/cfn-etcd-environment
         ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
-
 {{if .Experimental.AwsEnvironment.Enabled}}
     - name: set-aws-environment.service
       enable: true
@@ -146,6 +146,7 @@ coreos:
         ExecStartPre=/bin/touch /etc/aws-environment
         ExecStart=/opt/bin/set-aws-environment
 {{end}}
+
     - name: docker.service
       drop-ins:
 {{if .Experimental.EphemeralImageStorage.Enabled}}
@@ -161,6 +162,12 @@ coreos:
             RestartSec=10
             ExecStartPost=/usr/bin/docker pull {{.PauseImage.RepoWithTag}}
 
+        - name: 60-logfilelimit.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
+
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
         - name: 40-flannel.conf
           content: |
             [Unit]
@@ -168,12 +175,25 @@ coreos:
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
             ExecStartPre=/usr/bin/systemctl is-active flanneld.service
+        {{- end}}
 
-        - name: 60-logfilelimit.conf
-          content: |
-            [Service]
-            Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
+    {{ if .Experimental.NetworkingDaemonSets.Enabled -}}
+    - name: flanneld.service
+      enable: false
+    {{ if .AssetsEncryptionEnabled -}}
+    - name: decrypt-assets.service
+      enable: true
+      command: start
+      content: |
+        [Unit]
+        Description=Convert encrypted credentials
 
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/opt/bin/decrypt-assets
+    {{- end }}
+    {{- else -}}
     - name: flanneld.service
       drop-ins:
         - name: 10-etcd.conf
@@ -222,13 +242,22 @@ coreos:
             Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
             Environment="RKT_RUN_ARGS={{.FlannelImage.Options}} --uuid-file-save=/var/lib/coreos/flannel-wrapper2.uuid"
 {{end}}
+    {{- end }}
+
     - name: kubelet.service
       command: start
       runtime: true
       content: |
         [Unit]
-        Wants=flanneld.service cfn-etcd-environment.service
+        Wants=cfn-etcd-environment.service
         After=cfn-etcd-environment.service
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
+        Wants=flanneld.service
+        {{ else -}}
+        Wants=decrypt-assets.service
+        After=decrypt-assets.service
+        {{- end }}
+
         [Service]
         # EnvironmentFile=/etc/environment allows the reading of COREOS_PRIVATE_IPV4
         EnvironmentFile=/etc/environment
@@ -236,9 +265,11 @@ coreos:
         Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
         Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
         Environment="RKT_RUN_ARGS=--volume dns,kind=host,source=/etc/resolv.conf {{.HyperkubeImage.Options}}\
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
         --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd-trusted-ca.pem \
         --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
         --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
+        {{ end -}}
         --mount volume=dns,target=/etc/resolv.conf \
         {{ if eq .ContainerRuntime "rkt" -}}
         --volume rkt,kind=host,source=/opt/bin/host-rkt \
@@ -251,29 +282,33 @@ coreos:
         --volume var-lib-cni,kind=host,source=/var/lib/cni \
         --mount volume=var-lib-cni,target=/var/lib/cni \
         --volume var-log,kind=host,source=/var/log \
-        --mount volume=var-log,target=/var/log{{ if .UseCalico }} \
+        --mount volume=var-log,target=/var/log \
         --volume cni-bin,kind=host,source=/opt/cni/bin \
-        --mount volume=cni-bin,target=/opt/cni/bin{{ end }} \
+        --mount volume=cni-bin,target=/opt/cni/bin \
         --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
         --mount volume=etc-kubernetes,target=/etc/kubernetes"
-        ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
+        ExecStartPre=/usr/bin/etcdctl \
+          --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
+          --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
+          --cert-file /etc/kubernetes/ssl/etcd-client.pem \
+          --endpoints "${ETCD_ENDPOINTS}" \
+          cluster-health
+        ExecStartPre=/usr/bin/systemctl is-active flanneld.service
+        {{ end -}}
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/usr/bin/etcdctl \
-                       --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
-                       --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
-                       --cert-file /etc/kubernetes/ssl/etcd-client.pem \
-                       --endpoints "${ETCD_ENDPOINTS}" \
-                       cluster-health
-
+        ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /srv/kubernetes/manifests  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
-        {{if .UseCalico -}}
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
+        {{ if .UseCalico -}}
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/cni/net.d/ -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
         ExecStartPre=/usr/bin/docker run --rm -e SLEEP=false -e KUBERNETES_SERVICE_HOST= -e KUBERNETES_SERVICE_PORT= -v /opt/cni/bin:/host/opt/cni/bin {{ .CalicoCniImage.RepoWithTag }} /install-cni.sh
-        {{end -}}
+        {{- end }}
+        {{- end }}
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --kubeconfig=/etc/kubernetes/kubeconfig/controller.yaml \
         --require-kubeconfig \
@@ -284,8 +319,7 @@ coreos:
         --container-runtime={{.ContainerRuntime}} \
         --rkt-path=/usr/bin/rkt \
         --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
-        --node-labels node-role.kubernetes.io/master{{if .NodeLabels.Enabled}},{{.NodeLabels.String}} \
-        {{end}} \
+        --node-labels=node-role.kubernetes.io/master="",kubernetes.io/role=master,{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-with-taints=node.alpha.kubernetes.io/role=master:NoSchedule \
         --allow-privileged=true \
         --pod-manifest-path=/etc/kubernetes/manifests \
@@ -347,7 +381,7 @@ coreos:
         ExecStartPre=/usr/bin/bash -c "until /usr/bin/systemctl is-active kubelet.service; do echo waiting until kubelet starts; sleep 10; done"
         ExecStartPre=/usr/bin/bash -c "until /usr/bin/systemctl is-active docker.service; do echo waiting until docker starts; sleep 10; done"
         ExecStartPre=/usr/bin/bash -c "until /usr/bin/curl -s -f http://127.0.0.1:8080/version; do echo waiting until apiserver starts; sleep 10; done"
-        ExecStart=/opt/bin/retry 3 /opt/bin/install-kube-system
+        ExecStart=/opt/bin/retry 10 /opt/bin/install-kube-system
 
     - name: apply-kube-aws-plugins.service
       command: start
@@ -399,9 +433,9 @@ coreos:
         ExecStartPre=/usr/bin/systemctl is-active install-kube-system.service
         ExecStartPre=/usr/bin/systemctl is-active apply-kube-aws-plugins.service
         ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl -s -m 20 -f  http://127.0.0.1:8080/healthz > /dev/null &&  /usr/bin/curl -s -m 20 -f  http://127.0.0.1:10252/healthz > /dev/null && /usr/bin/curl -s -m 20 -f  http://127.0.0.1:10251/healthz > /dev/null &&  /usr/bin/curl --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null && /usr/bin/curl -s -m 20 -f http://127.0.0.1:10256/healthz > /dev/null; then break ; fi;  done"
-        {{ if .UseCalico }}
+        {{ if (and (not .Experimental.NetworkingDaemonSets.Enabled) .UseCalico) -}}
         ExecStartPre=/usr/bin/bash -c "until /usr/bin/docker run --net=host --pid=host --rm {{ .CalicoCtlImage.RepoWithTag }} node status > /dev/null; do sleep 3; done && echo Calico running"
-        {{ end }}
+        {{- end }}
         {{if .Experimental.AuditLog.Enabled -}}
         ExecStartPre=/opt/bin/check-worker-communication
         {{end -}}
@@ -802,6 +836,11 @@ write_files:
         kubectl apply -f $(echo "$@" | tr ' ' ',')
       }
 
+      # Manage the deletion of services
+      ensuredelete() {
+        kubectl delete --cascade=true --ignore-not-found=true -f $(echo "$@" | tr ' ' ',')
+      }
+
       while ! kubectl get ns kube-system; do
         echo Waiting until kube-system created.
         sleep 3
@@ -841,10 +880,27 @@ write_files:
       mfdir=/srv/kubernetes/manifests
       rbac=/srv/kubernetes/rbac
 
-      {{ if .UseCalico }}
+      {{- if .Experimental.NetworkingDaemonSets.Enabled }}
+      # When using NetworkingDeamonSets ensure that all nodes
+      # have a podCIDR attribute
+      /opt/bin/nds-add-node-cidrs
+      ensuredelete "${mfdir}/calico.yaml"
+      applyall "${rbac}/network-daemonsets.yaml"
+      {{- if .UseCalico }}
+      ensuredelete "${mfdir}/flannel.yaml"
+      applyall "${mfdir}/canal.yaml"
+      {{- else }}
+      ensuredelete "${mfdir}/canal.yaml"
+      applyall "${mfdir}/flannel.yaml"
+      {{- end }}
+      {{- else }}
+      ensuredelete "${mfdir}/flannel.yaml"
+      ensuredelete "${mfdir}/canal.yaml"
+      {{- if .UseCalico }}
       /bin/bash /opt/bin/populate-tls-calico-etcd
       applyall "${mfdir}/calico.yaml"
-      {{ end }}
+      {{- end }}
+      {{- end }}
 
       {{ if .Addons.MetricsServer.Enabled -}}
       applyall \
@@ -939,7 +995,1035 @@ write_files:
       # https://github.com/coreos/rkt/issues/2878
       exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
 
-{{ if .UseCalico }}
+  - path: /srv/kubernetes/manifests/canal.yaml
+    content: |
+      # Canal Version v3.0.3
+      # https://docs.projectcalico.org/v3.0/releases#v3.0.3
+      # This manifest includes the following component versions:
+      #   calico/node:v3.0.3
+      #   calico/cni:v2.0.1
+      #   coreos/flannel:
+
+      # This ConfigMap can be used to configure a self-hosted Canal installation.
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: nds-canal-config
+        namespace: kube-system
+      data:
+        # The interface used by canal for host <-> host communication.
+        # If left blank, then the interface is chosen using the node's
+        # default route.
+        canal_iface: ""
+
+        # Whether or not to masquerade traffic to destinations not within
+        # the pod network.
+        masquerade: "true"
+
+        # To enable Typha, set this to "calico-typha" *and* set a non-zero value for Typha replicas
+        # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
+        # essential.
+        {{ if .Experimental.NetworkingDaemonSets.Typha -}}
+        typha_service_name: "calico-typha"
+        {{ else -}}
+        typha_service_name: "none"
+        {{- end }}
+
+        # The CNI network configuration to install on each node.
+        cni_network_config: |-
+          {
+              "name": "k8s-pod-network",
+              "cniVersion": "0.3.0",
+              "plugins": [
+                  {
+                      "type": "calico",
+                      "log_level": "info",
+                      "datastore_type": "kubernetes",
+                      "nodename": "__KUBERNETES_NODE_NAME__",
+                      "ipam": {
+                          "type": "host-local",
+                          "subnet": "usePodCidr"
+                      },
+                      "policy": {
+                          "type": "k8s",
+                          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+                      },
+                      "kubernetes": {
+                          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+                          "kubeconfig": "__KUBECONFIG_FILEPATH__"
+                      }
+                  },
+                  {
+                      "type": "portmap",
+                      "capabilities": {"portMappings": true},
+                      "snat": true
+                  }
+              ]
+          }
+
+        # Flannel network configuration. Mounted into the flannel container.
+        net-conf.json: |
+          {
+            "Network": "{{ .PodCIDR }}",
+            "Backend": {
+              "Type": "vxlan"
+            }
+          }
+
+{{- if .Experimental.NetworkingDaemonSets.Typha }}
+      ---
+      # This manifest creates a Service, which will be backed by Calico's Typha daemon.
+      # Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: calico-typha
+        namespace: kube-system
+        labels:
+          k8s-app: calico-typha
+      spec:
+        ports:
+          - port: 5473
+            protocol: TCP
+            targetPort: calico-typha
+            name: calico-typha
+        selector:
+          k8s-app: calico-typha
+      
+      ---
+      # This manifest creates a Deployment of Typha to back the above service.
+
+      apiVersion: apps/v1beta1
+      kind: Deployment
+      metadata:
+        name: calico-typha
+        namespace: kube-system
+        labels:
+          k8s-app: calico-typha
+      spec:
+        # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
+        # typha_service_name variable in the calico-config ConfigMap above.
+        #
+        # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
+        # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
+        # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
+        replicas: 3
+        revisionHistoryLimit: 2
+        template:
+          metadata:
+            labels:
+              k8s-app: calico-typha
+            annotations:
+              # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
+              # add-on, ensuring it gets priority scheduling and that its resources are reserved
+              # if it ever gets evicted.
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+            # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+            # as a host-networked pod.
+            hostNetwork: true
+            serviceAccountName: nds-canal
+            initContainers:
+            - name: wait-for-default-clusterinformation
+              image: {{.HyperkubeImage.RepoWithTag}}
+              command: ["/bin/sh", "-c" ]
+              args:
+                - |
+                    set -x ;
+                    while true; do
+                      if /kubectl get clusterinformation default; then
+                        echo "Calcio clusterinformation default exists, can continue..."
+                        exit 0
+                      fi
+                      echo "Waiting for Calcio clusterinformation default..."
+                      sleep 5
+                    done
+            containers:
+            - image: {{ .Experimental.NetworkingDaemonSets.TyphaImage.RepoWithTag }}
+              name: typha
+              ports:
+              - containerPort: 5473
+                name: calico-typha
+                protocol: TCP
+              env:
+                # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
+                - name: TYPHA_LOGSEVERITYSCREEN
+                  value: "info"
+                # Disable logging to file and syslog since those don't make sense in Kubernetes.
+                - name: TYPHA_LOGFILEPATH
+                  value: "none"
+                - name: TYPHA_LOGSEVERITYSYS
+                  value: "none"
+                # Monitor the Kubernetes API to find the number of running instances and rebalance
+                # connections.
+                - name: TYPHA_CONNECTIONREBALANCINGMODE
+                  value: "kubernetes"
+                - name: TYPHA_DATASTORETYPE
+                  value: "kubernetes"
+                - name: TYPHA_HEALTHENABLED
+                  value: "true"
+                # Uncomment these lines to enable prometheus metrics.  Since Typha is host-networked,
+                # this opens a port on the host, which may need to be secured.
+                #- name: TYPHA_PROMETHEUSMETRICSENABLED
+                #  value: "true"
+                #- name: TYPHA_PROMETHEUSMETRICSPORT
+                #  value: "9093"
+              livenessProbe:
+                httpGet:
+                  path: /liveness
+                  port: 9098
+                periodSeconds: 30
+                initialDelaySeconds: 30
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: 9098
+                periodSeconds: 10
+{{- end }}
+      # Canal Daemonset targetting masters/controllers
+      # They will never use Typha to proxy the kube-apiserver.
+      # Resolves Two bugs when Typha is enabled:
+      # 1. Masters depend on Typha to start on the nodes for their networking.
+      # 2. Typha will not start up without existing calico api objects.
+      ---
+      # This manifest installs the calico/node container, as well
+      # as the Calico CNI plugins and network config on
+      # each master and worker node in a Kubernetes cluster.
+      kind: DaemonSet
+      apiVersion: extensions/v1beta1
+      metadata:
+        name: nds-canal-master
+        namespace: kube-system
+        labels:
+          k8s-app: nds-canal-master
+      spec:
+        selector:
+          matchLabels:
+            k8s-app: nds-canal-master
+        updateStrategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 1
+        template:
+          metadata:
+            labels:
+              k8s-app: nds-canal-master
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            # Ensure that canal-master only targets our masters.
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: node-role.kubernetes.io/master
+                      operator: Exists
+            hostNetwork: true
+            serviceAccountName: nds-canal
+            tolerations:
+              # Tolerate this effect so the pods will be schedulable at all times
+              - effect: NoSchedule
+                operator: Exists
+              # Mark the pod as a critical add-on for rescheduling.
+              - key: CriticalAddonsOnly
+                operator: Exists
+              - effect: NoExecute
+                operator: Exists
+            # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+            # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+            terminationGracePeriodSeconds: 0
+            initContainers:
+              - name: disable-flannelds-cni
+                image: alpine:latest
+                command:
+                - /bin/rm
+                - -rf
+                - /etc/kubernetes/cni/net.d/10-flannel.conflist
+                volumeMounts:
+                - mountPath: /etc/kubernetes/cni/net.d
+                  name: cni-net-dir
+              - name: disable-legacycalico-cni
+                image: alpine:latest
+                command:
+                - /bin/rm
+                - -rf
+                - /etc/kubernetes/cni/net.d/10-calico.conf
+                volumeMounts:
+                - mountPath: /etc/kubernetes/cni/net.d
+                  name: cni-net-dir
+            containers:
+              # Runs calico/node container on each Kubernetes node.  This
+              # container programs network policy and routes on each
+              # host.
+              - name: calico-node
+                image: {{ .Experimental.NetworkingDaemonSets.CalicoNodeImage.RepoWithTag }}
+                env:
+                  # Use Kubernetes API as the backing datastore.
+                  - name: DATASTORE_TYPE
+                    value: "kubernetes"
+                  # Enable felix logging.
+                  - name: FELIX_LOGSEVERITYSYS
+                    value: "info"
+                  # Don't enable BGP.
+                  - name: CALICO_NETWORKING_BACKEND
+                    value: "none"
+                  # Cluster type to identify the deployment type
+                  - name: CLUSTER_TYPE
+                    value: "k8s,canal"
+                  # Disable file logging so `kubectl logs` works.
+                  - name: CALICO_DISABLE_FILE_LOGGING
+                    value: "true"
+                  # Period, in seconds, at which felix re-applies all iptables state
+                  - name: FELIX_IPTABLESREFRESHINTERVAL
+                    value: "60"
+                  # Disable IPV6 support in Felix.
+                  - name: FELIX_IPV6SUPPORT
+                    value: "false"
+                  # Wait for the datastore.
+                  - name: WAIT_FOR_DATASTORE
+                    value: "true"
+                  # No IP address needed.
+                  - name: IP
+                    value: ""
+                  # Typha support: is never enabled on masters
+                  - name: FELIX_TYPHAK8SSERVICENAME
+                    value: "none"
+                  - name: NODENAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  # Set Felix endpoint to host default action to ACCEPT.
+                  - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+                    value: "ACCEPT"
+                  - name: FELIX_HEALTHENABLED
+                    value: "true"
+                securityContext:
+                  privileged: true
+                resources:
+                  requests:
+                    cpu: 250m
+                livenessProbe:
+                  httpGet:
+                    path: /liveness
+                    port: 9099
+                  periodSeconds: 10
+                  initialDelaySeconds: 10
+                  failureThreshold: 6
+                readinessProbe:
+                  httpGet:
+                    path: /readiness
+                    port: 9099
+                  periodSeconds: 10
+                volumeMounts:
+                  - mountPath: /lib/modules
+                    name: lib-modules
+                    readOnly: true
+                  - mountPath: /var/run/calico
+                    name: var-run-calico
+                    readOnly: false
+              # This container installs the Calico CNI binaries
+              # and CNI network config file on each node.
+              - name: install-cni
+                image: {{ .Experimental.NetworkingDaemonSets.CalicoCniImage.RepoWithTag }}
+                command: ["/install-cni.sh"]
+                env:
+                  - name: CNI_NET_DIR
+                    value: "/etc/kubernetes/cni/net.d"
+                  - name: CNI_CONF_NAME
+                    value: "10-calico.conflist"
+                  # The CNI network config to install on each node.
+                  - name: CNI_NETWORK_CONFIG
+                    valueFrom:
+                      configMapKeyRef:
+                        name: nds-canal-config
+                        key: cni_network_config
+                  - name: KUBERNETES_NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                volumeMounts:
+                  - mountPath: /host/opt/cni/bin
+                    name: cni-bin-dir
+                  - mountPath: /host/etc/cni/net.d
+                    name: cni-net-dir
+              # This container runs flannel using the kube-subnet-mgr backend
+              # for allocating subnets.
+              - name: flannel
+                image: {{ .FlannelImage.RepoWithTag }}
+                command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
+                securityContext:
+                  privileged: true
+                env:
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: POD_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: FLANNELD_IFACE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: nds-canal-config
+                        key: canal_iface
+                  - name: FLANNELD_IP_MASQ
+                    valueFrom:
+                      configMapKeyRef:
+                        name: nds-canal-config
+                        key: masquerade
+                volumeMounts:
+                - name: run
+                  mountPath: /run
+                - name: flannel-cfg
+                  mountPath: /etc/kube-flannel/
+            volumes:
+              # Used by calico/node.
+              - name: lib-modules
+                hostPath:
+                  path: /lib/modules
+              - name: var-run-calico
+                hostPath:
+                  path: /var/run/calico
+              # Used to install CNI.
+              - name: cni-bin-dir
+                hostPath:
+                  path: /opt/cni/bin
+              - name: cni-net-dir
+                hostPath:
+                  path: /etc/kubernetes/cni/net.d
+              # Used by flannel.
+              - name: run
+                hostPath:
+                  path: /run
+              - name: flannel-cfg
+                configMap:
+                  name: nds-canal-config
+      
+      # Canal DaemonSet for Nodes - Typha can be enabled.
+      ---
+      # This manifest installs the calico/node container, as well 
+      # as the Calico CNI plugins and network config on
+      # each master and worker node in a Kubernetes cluster.
+      kind: DaemonSet
+      apiVersion: extensions/v1beta1
+      metadata:
+        name: nds-canal-node
+        namespace: kube-system
+        labels:
+          k8s-app: nds-canal-node
+      spec:
+        selector:
+          matchLabels:
+            k8s-app: nds-canal-node
+        updateStrategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 1
+        template:
+          metadata:
+            labels:
+              k8s-app: nds-canal-node
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            hostNetwork: true
+            serviceAccountName: nds-canal
+            # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+            # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+            terminationGracePeriodSeconds: 0
+            initContainers:
+              - name: disable-flannelds-cni
+                image: alpine:latest
+                command:
+                - /bin/rm
+                - -rf
+                - /etc/kubernetes/cni/net.d/10-flannel.conflist
+                volumeMounts:
+                - mountPath: /etc/kubernetes/cni/net.d
+                  name: cni-net-dir
+              - name: disable-legacycalico-cni
+                image: alpine:latest
+                command:
+                - /bin/rm
+                - -rf
+                - /etc/kubernetes/cni/net.d/10-calico.conf
+                volumeMounts:
+                - mountPath: /etc/kubernetes/cni/net.d
+                  name: cni-net-dir
+            containers:
+              # Runs calico/node container on each Kubernetes node.  This
+              # container programs network policy and routes on each
+              # host.
+              - name: calico-node
+                image: {{ .Experimental.NetworkingDaemonSets.CalicoNodeImage.RepoWithTag }}
+                env:
+                  # Use Kubernetes API as the backing datastore.
+                  - name: DATASTORE_TYPE
+                    value: "kubernetes"
+                  # Enable felix logging.
+                  - name: FELIX_LOGSEVERITYSYS
+                    value: "info"
+                  # Don't enable BGP.
+                  - name: CALICO_NETWORKING_BACKEND
+                    value: "none"
+                  # Cluster type to identify the deployment type
+                  - name: CLUSTER_TYPE
+                    value: "k8s,canal"
+                  # Disable file logging so `kubectl logs` works.
+                  - name: CALICO_DISABLE_FILE_LOGGING
+                    value: "true"
+                  # Period, in seconds, at which felix re-applies all iptables state
+                  - name: FELIX_IPTABLESREFRESHINTERVAL
+                    value: "60"
+                  # Disable IPV6 support in Felix.
+                  - name: FELIX_IPV6SUPPORT
+                    value: "false"
+                  # Wait for the datastore.
+                  - name: WAIT_FOR_DATASTORE
+                    value: "true"
+                  # No IP address needed.
+                  - name: IP
+                    value: ""
+                  # Typha support: controlled by the ConfigMap.
+                  - name: FELIX_TYPHAK8SSERVICENAME
+                    valueFrom:
+                      configMapKeyRef:
+                        name: nds-canal-config
+                        key: typha_service_name
+                  - name: NODENAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  # Set Felix endpoint to host default action to ACCEPT.
+                  - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+                    value: "ACCEPT"
+                  - name: FELIX_HEALTHENABLED
+                    value: "true"
+                securityContext:
+                  privileged: true
+                resources:
+                  requests:
+                    cpu: 250m
+                livenessProbe:
+                  httpGet:
+                    path: /liveness
+                    port: 9099
+                  periodSeconds: 10
+                  initialDelaySeconds: 10
+                  failureThreshold: 6
+                readinessProbe:
+                  httpGet:
+                    path: /readiness
+                    port: 9099
+                  periodSeconds: 10
+                volumeMounts:
+                  - mountPath: /lib/modules
+                    name: lib-modules
+                    readOnly: true
+                  - mountPath: /var/run/calico
+                    name: var-run-calico
+                    readOnly: false
+              # This container installs the Calico CNI binaries
+              # and CNI network config file on each node.
+              - name: install-cni
+                image: {{ .Experimental.NetworkingDaemonSets.CalicoCniImage.RepoWithTag }}
+                command: ["/install-cni.sh"]
+                env:
+                  - name: CNI_NET_DIR
+                    value: "/etc/kubernetes/cni/net.d"
+                  - name: CNI_CONF_NAME
+                    value: "10-calico.conflist"
+                  # The CNI network config to install on each node.
+                  - name: CNI_NETWORK_CONFIG
+                    valueFrom:
+                      configMapKeyRef:
+                        name: nds-canal-config
+                        key: cni_network_config
+                  - name: KUBERNETES_NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                volumeMounts:
+                  - mountPath: /host/opt/cni/bin
+                    name: cni-bin-dir
+                  - mountPath: /host/etc/cni/net.d
+                    name: cni-net-dir
+              # This container runs flannel using the kube-subnet-mgr backend
+              # for allocating subnets.
+              - name: flannel
+                image: {{ .FlannelImage.RepoWithTag }}
+                command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
+                securityContext:
+                  privileged: true
+                env:
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: POD_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: FLANNELD_IFACE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: nds-canal-config
+                        key: canal_iface
+                  - name: FLANNELD_IP_MASQ
+                    valueFrom:
+                      configMapKeyRef:
+                        name: nds-canal-config
+                        key: masquerade
+                volumeMounts:
+                - name: run
+                  mountPath: /run
+                - name: flannel-cfg
+                  mountPath: /etc/kube-flannel/
+            volumes:
+              # Used by calico/node.
+              - name: lib-modules
+                hostPath:
+                  path: /lib/modules
+              - name: var-run-calico
+                hostPath:
+                  path: /var/run/calico
+              # Used to install CNI.
+              - name: cni-bin-dir
+                hostPath:
+                  path: /opt/cni/bin
+              - name: cni-net-dir
+                hostPath:
+                  path: /etc/kubernetes/cni/net.d
+              # Used by flannel.
+              - name: run
+                hostPath:
+                  path: /run
+              - name: flannel-cfg
+                configMap:
+                  name: nds-canal-config
+
+      # Create all the CustomResourceDefinitions needed for
+      # Calico policy-only mode.
+      ---
+
+      apiVersion: apiextensions.k8s.io/v1beta1
+      description: Calico Felix Configuration
+      kind: CustomResourceDefinition
+      metadata:
+        name: felixconfigurations.crd.projectcalico.org
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: FelixConfiguration
+          plural: felixconfigurations
+          singular: felixconfiguration
+
+      ---
+
+      apiVersion: apiextensions.k8s.io/v1beta1
+      description: Calico BGP Configuration
+      kind: CustomResourceDefinition
+      metadata:
+        name: bgpconfigurations.crd.projectcalico.org
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: BGPConfiguration
+          plural: bgpconfigurations
+          singular: bgpconfiguration
+
+      ---
+
+      apiVersion: apiextensions.k8s.io/v1beta1
+      description: Calico IP Pools
+      kind: CustomResourceDefinition
+      metadata:
+        name: ippools.crd.projectcalico.org
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: IPPool
+          plural: ippools
+          singular: ippool
+
+      ---
+
+      apiVersion: apiextensions.k8s.io/v1beta1
+      description: Calico Cluster Information
+      kind: CustomResourceDefinition
+      metadata:
+        name: clusterinformations.crd.projectcalico.org
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: ClusterInformation
+          plural: clusterinformations
+          singular: clusterinformation
+
+      ---
+
+      apiVersion: apiextensions.k8s.io/v1beta1
+      description: Calico Global Network Policies
+      kind: CustomResourceDefinition
+      metadata:
+        name: globalnetworkpolicies.crd.projectcalico.org
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: GlobalNetworkPolicy
+          plural: globalnetworkpolicies
+          singular: globalnetworkpolicy
+
+      ---
+
+      apiVersion: apiextensions.k8s.io/v1beta1
+      description: Calico Network Policies
+      kind: CustomResourceDefinition
+      metadata:
+        name: networkpolicies.crd.projectcalico.org
+      spec:
+        scope: Namespaced
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: NetworkPolicy
+          plural: networkpolicies
+          singular: networkpolicy
+  
+  - path: /srv/kubernetes/rbac/network-daemonsets.yaml
+    content: |
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: nds-canal
+        namespace: kube-system
+
+      ---
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: nds-flannel
+        namespace: kube-system
+
+      ---
+      # Calico Version v3.0.2
+      # https://docs.projectcalico.org/v3.0/releases#v3.0.2
+      kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      metadata:
+        name: nds-calico
+      rules:
+        - apiGroups: [""]
+          resources:
+            - namespaces
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups: [""]
+          resources:
+            - pods/status
+          verbs:
+            - update
+        - apiGroups: [""]
+          resources:
+            - pods
+          verbs:
+            - get
+            - list
+            - watch
+            - patch
+        - apiGroups: [""]
+          resources:
+            - services
+          verbs:
+            - get
+        - apiGroups: [""]
+          resources:
+            - endpoints
+          verbs:
+            - get
+        - apiGroups: [""]
+          resources:
+            - nodes
+          verbs:
+            - get
+            - list
+            - update
+            - watch
+        - apiGroups: ["extensions"]
+          resources:
+            - networkpolicies
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - globalfelixconfigs
+            - felixconfigurations
+            - bgppeers
+            - globalbgpconfigs
+            - bgpconfigurations
+            - ippools
+            - globalnetworkpolicies
+            - networkpolicies
+            - clusterinformations
+          verbs:
+            - create
+            - get
+            - list
+            - update
+            - watch
+
+      ---
+      # Flannel roles
+      # Pulled from https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel-rbac.yml
+      kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      metadata:
+        name: nds-flannel
+      rules:
+        - apiGroups:
+            - ""
+          resources:
+            - pods
+          verbs:
+            - get
+        - apiGroups:
+            - ""
+          resources:
+            - nodes
+          verbs:
+            - list
+            - watch
+        - apiGroups:
+            - ""
+          resources:
+            - nodes/status
+          verbs:
+            - patch
+      
+      ---
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      metadata:
+        name: nds-flannel
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: nds-flannel
+      subjects:
+      - kind: ServiceAccount
+        name: nds-flannel
+        namespace: kube-system
+
+      ---
+      # Bind the flannel ClusterRole to the canal ServiceAccount.
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      metadata:
+        name: nds-canal-flannel
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: nds-flannel
+      subjects:
+      - kind: ServiceAccount
+        name: nds-canal
+        namespace: kube-system
+
+      ---
+      # Bind the calico ClusterRole to the canal ServiceAccount.
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: ClusterRoleBinding
+      metadata:
+        name: nds-canal-calico
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: nds-calico
+      subjects:
+      - kind: ServiceAccount
+        name: nds-canal
+        namespace: kube-system
+
+  - path: /srv/kubernetes/manifests/flannel.yaml
+    content: |
+      ---
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: nds-flannel-cfg
+        namespace: kube-system
+        labels:
+          tier: node
+          app: flannel
+      data:
+        cni-conf.json: |
+          {
+            "name": "cbr0",
+            "plugins": [
+              {
+                "type": "flannel",
+                "delegate": {
+                  "hairpinMode": true,
+                  "isDefaultGateway": true
+                }
+              },
+              {
+                "type": "portmap",
+                "capabilities": {
+                  "portMappings": true
+                }
+              }
+            ]
+          }
+        net-conf.json: |
+          {
+            "Network": "{{ .PodCIDR }}",
+            "Backend": {
+              "Type": "vxlan"
+            }
+          }
+      ---
+      apiVersion: extensions/v1beta1
+      kind: DaemonSet
+      metadata:
+        name: nds-flannel
+        namespace: kube-system
+        labels:
+          tier: node
+          app: nds-flannel
+      spec:
+        updateStrategy:
+          type: RollingUpdate
+        template:
+          metadata:
+            labels:
+              tier: node
+              app: nds-flannel
+          spec:
+            hostNetwork: true
+            nodeSelector:
+              beta.kubernetes.io/arch: amd64
+            tolerations:
+            - key: node-role.kubernetes.io/master
+              operator: Exists
+              effect: NoSchedule
+            - key: node.alpha.kubernetes.io/role
+              value: "master"
+              effect: NoSchedule
+            serviceAccountName: nds-flannel
+            # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+            # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+            terminationGracePeriodSeconds: 0
+            initContainers:
+              - name: disable-canalds-cni
+                image: alpine:latest
+                command:
+                - /bin/rm
+                - -rf
+                - /etc/kubernetes/cni/net.d/10-calico.conflist
+                volumeMounts:
+                - mountPath: /etc/kubernetes/cni/net.d
+                  name: cni-net-dir
+              - name: disable-legacycalico-cni
+                image: alpine:latest
+                command:
+                - /bin/rm
+                - -rf
+                - /etc/kubernetes/cni/net.d/10-calico.conf
+                volumeMounts:
+                - mountPath: /etc/kubernetes/cni/net.d
+                  name: cni-net-dir
+                {{/* # Signal restart of kubelet on nodes (re-register with apiserver)
+              - name: migration-helper
+                image: alpine:latest
+                command: 
+                - /bin/touch
+                - /etc/kubernetes/cni/net.d/nds-migration
+                volumeMounts:
+                - mountPath: /etc/kubernetes/cni/net.d
+                  name: cni-net-dir */}}
+            containers:
+            # This container installs the Flannel CNI binaries
+            # and CNI network config file on each node.
+            - name: install-cni
+              image: {{ .Experimental.NetworkingDaemonSets.FlannelCniImage.RepoWithTag }}
+              command: ["/install-cni.sh"]
+              env:
+                # The CNI network config to install on each node.
+                - name: CNI_NETWORK_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: nds-flannel-cfg
+                      key: cni-conf.json
+              volumeMounts:
+                - mountPath: /host/opt/cni/bin
+                  name: cni-bin-dir
+                - mountPath: /host/etc/cni/net.d
+                  name: cni-net-dir
+            - name: flannel
+              image: {{ .FlannelImage.RepoWithTag }}
+              command:
+              - /opt/bin/flanneld
+              args:
+              - --ip-masq
+              - --kube-subnet-mgr
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "50Mi"
+                limits:
+                  cpu: "100m"
+                  memory: "50Mi"
+              securityContext:
+                privileged: true
+              env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              volumeMounts:
+              - name: run
+                mountPath: /run
+              - name: flannel-cfg
+                mountPath: /etc/kube-flannel/
+            volumes:
+              - name: run
+                hostPath:
+                  path: /run
+              - name: cni-net-dir
+                hostPath:
+                  path: /etc/kubernetes/cni/net.d
+              - name: cni-bin-dir
+                hostPath:
+                  path: /opt/cni/bin
+              - name: flannel-cfg
+                configMap:
+                  name: nds-flannel-cfg
+
   - path: /srv/kubernetes/manifests/calico.yaml
     content: |
       kind: ConfigMap
@@ -1021,6 +2105,28 @@ write_files:
             - operator: Exists
               key: CriticalAddonsOnly
             hostNetwork: true
+            # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+            # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+            terminationGracePeriodSeconds: 0
+            initContainers:
+              - name: disable-canalds-cni
+                image: alpine:latest
+                command:
+                - /bin/rm
+                - -rf
+                - /etc/kubernetes/cni/net.d/10-calico.conflist
+                volumeMounts:
+                - mountPath: /etc/kubernetes/cni/net.d
+                  name: cni-net-dir
+              - name: disable-flannelds-cni
+                image: alpine:latest
+                command:
+                - /bin/rm
+                - -rf
+                - /etc/kubernetes/cni/net.d/10-flannel.conflist
+                volumeMounts:
+                - mountPath: /etc/kubernetes/cni/net.d
+                  name: cni-net-dir
             containers:
               - name: calico-node
                 image: {{ .CalicoNodeImage.RepoWithTag }}
@@ -1168,8 +2274,7 @@ write_files:
       sed -i -e "s#\$ETCDCA#$etcd_ca#g" /srv/kubernetes/manifests/calico.yaml
       sed -i -e "s#\$ETCDCERT#$etcd_cert#g" /srv/kubernetes/manifests/calico.yaml
       sed -i -e "s#\$ETCDKEY#$etcd_key#g" /srv/kubernetes/manifests/calico.yaml
-
-{{ end }}
+  
 {{ if .KubeResourcesAutosave.Enabled }}
   - path: /srv/kubernetes/manifests/kube-resources-autosave-de.yaml
     content: |
@@ -2061,7 +3166,9 @@ write_files:
           - /hyperkube
           - apiserver
           - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .ControllerCount }}{{end}}
-          - --bind-address=0.0.0.0
+{{/* RUN 935 start up with bind address of 127.0.0.1 until SA keys have been properly updated */}}
+          - --bind-address=127.0.0.1
+{{/* RUN 935 start up with bind address of 127.0.0.1 until SA keys have been properly updated */}}
           - --etcd-servers=#ETCD_ENDPOINTS#
           - --etcd-cafile=/etc/kubernetes/ssl/etcd-trusted-ca.pem
           - --etcd-certfile=/etc/kubernetes/ssl/etcd-client.pem
@@ -2122,6 +3229,11 @@ write_files:
               path: /healthz
             initialDelaySeconds: 15
             timeoutSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: 443
+            initialDelaySeconds: 5
+            periodSeconds: 10
           ports:
           - containerPort: 443
             hostPort: 443
@@ -2216,12 +3328,16 @@ write_files:
           {{ end }}
           - --root-ca-file=/etc/kubernetes/ssl/ca.pem
           - --cloud-provider=aws
-          {{if .Experimental.NodeMonitorGracePeriod}}
+          {{ if .Experimental.NodeMonitorGracePeriod }}
           - --node-monitor-grace-period={{ .Experimental.NodeMonitorGracePeriod }}
           {{end}}
-          {{if .Experimental.DisableSecurityGroupIngress}}
+          {{ if .Experimental.DisableSecurityGroupIngress }}
           - --cloud-config=/etc/kubernetes/additional-configs/cloud.config
-          {{end}}
+          {{ end }}
+          {{ if .Experimental.NetworkingDaemonSets.Enabled -}}
+          - --allocate-node-cidrs=true
+          - --cluster-cidr={{.PodCIDR}}
+          {{- end }}
           resources:
             requests:
               cpu: 200m
@@ -3295,6 +4411,7 @@ write_files:
           name: kubelet-context
         current-context: kubelet-context
 
+{{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
 {{ if not .UseCalico }}
   - path: /etc/kubernetes/cni/net.d/10-flannel.conf
     content: |
@@ -3328,6 +4445,161 @@ write_files:
       }
 
 {{ end }}
+{{- end }}
+
+{{- if .Experimental.NetworkingDaemonSets.Enabled }}
+  - path: /opt/bin/nds-add-node-cidrs
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      set -u
+
+      # NDS Migration helper script - patch missing podcidrs
+      # Legacy nodes do not have a podcidr allocated (it is just received through docker) so when
+      # migrating to the flannel deamonset we need to make sure that all nodes have the podcidr set
+      # that they are actually using.  This can be found by looking at existing pods on the node or
+      # we will run our own pod in order to work out the cidr (always assumed to be a /24).
+
+      pod_cidr="{{.PodCIDR}}"
+      cidr_match="^${pod_cidr%%\.*}.*" # Match just the first IP tuple
+      temporary_podlist="/tmp/podlist"
+      retries=5
+
+      kubectl() {
+        docker run --rm -i --net=host -v /etc/kubernetes:/etc/kubernetes:ro -v /etc/resolv.conf:/etc/resolv.conf:ro quay.io/coreos/hyperkube:v1.8.7_coreos.0 /kubectl "$@"
+      }
+
+      log() {
+        >&2 echo "$@"
+      }
+
+      generate_running_pod_list() {
+          kubectl get pods -o wide --all-namespaces | awk '($4 == "Running"){print}' >$temporary_podlist
+      }
+
+      match_running_pods() {
+        local node=$1
+        log "Trying to match a running pod on node ${node}..."
+        cat $temporary_podlist | awk "(\$7 ~ \"${cidr_match}\" && \$8 == \"$node\"){print \$7}" | head -1
+      }
+
+      run_pod() {
+        local node=$1
+        local ipaddress
+
+        log "Running a pod on node ${node} to determine pod ip address..."
+        local selector="{ \"apiVersion\": \"v1\", \"spec\": { \"nodeSelector\": { \"kubernetes.io/hostname\": \"${node}\" }, \"tolerations\": [ { \"effect\": \"NoSchedule\", \"operator\": \"Exists\" }, { \"effect\": \"NoExecute\", \"operator\": \"Exists\" } ] } }"
+        ipaddress=$(kubectl -n kube-system run find-pod-ip-${node%%.*} --pod-running-timeout=1m -i -t --image=alpine:latest --restart=Never --overrides="${selector}" -- /bin/sh -c "cat /proc/net/fib_trie | awk '/32 host/ {print f} {f=\$2}' | grep -v 127.0.0.1 | uniq") || return 1
+        kubectl -n kube-system delete pod find-pod-ip-${node%%.*} 2>&1 >/dev/null
+
+        if [[ -n "${ipaddress}" ]]; then
+          echo "${ipaddress}"
+          return 0
+        else
+          log "Running pod did not return an ip address"
+          return 1
+        fi
+      }
+
+      find_node_cidr() {
+        local node=$1
+        local found
+
+        log "Finding cidrs on node ${node}"
+        if ! node_ready "${node}"; then
+          log "Aborting lookup of cidr, node is not ready."
+          return 1
+        fi
+
+        found=$(match_running_pods "${node}")
+        if [[ -n "${found}" ]]; then
+          log "Found a running pod with ip ${found}"
+        else
+          log "No suitable pods running on node, starting our own..."
+          if ! found=$(run_pod "${node}"); then
+            log "Running pod failed."
+            return 1
+          fi
+        fi
+
+        if [[ -n "$found" ]]; then
+          echo "${found%\.*}.0/24"
+          return 0
+        else
+          log "Found ip address was empty!"
+          return 1
+        fi
+      }
+
+      patch_node() {
+        local node=$1
+        local podcidr=$2
+        local tries=0
+
+        while [ "$tries" -lt "$retries" ]; do
+          kubectl patch node "${node}" -p "{\"spec\":{\"podCIDR\":\"${podcidr}\"}}" && return 0
+          log "Patch failed, wait 20s and retry"
+          sleep 20
+          $((tries += 1))
+        done
+      }
+
+      list_ready_nodes() {
+        kubectl get nodes | awk '($2 == "Ready" && $3 != "master"){print $1}' || log "Failed to list running pods" && exit 1
+      }
+
+      read_node() {
+        local node=$1
+        local tries=0
+
+        while [ "$tries" -lt "$retries" ]; do
+          kubectl get node $node -o jsonpath='{.spec.podCIDR}' && return 0
+          log "Failed to read node ${node}, sleep and try again"
+          sleep 20
+          $((tries += 1))
+        done
+        return 1
+      }
+
+      node_ready() {
+        local node=$1
+        local tries=0
+        local ready
+
+        while [ "$tries" -lt "$retries" ]; do
+          ready=$(kubectl get nodes | awk "(\$1 == \"${node}\" && \$2 == \"Ready\"){print}") && break
+          log "Failed to list nodes, sleep and try again"
+          sleep 20
+          $((tries += 1))
+        done
+        [[ -n "$ready" ]]
+      }
+
+      # MAIN
+
+      log "Finding and setting all missing podCIDRs..."
+      generate_running_pod_list
+      nodes=$(list_ready_nodes)
+      for node in $nodes
+      do
+        if ! pod_cidr=$(read_node ${node}); then
+          log "Failed to read node ${node}, skipping."
+          continue
+        fi
+        if [[ -n "${pod_cidr}" ]]; then
+            log "Node ${node} already has podcidr: ${pod_cidr}"
+        else
+          log "Node ${node} does not have a pod_cidr!"
+          if cidr=$(find_node_cidr "${node}"); then
+            log "Patching node ${node} with CIDR ${cidr}"
+            patch_node "${node}" "${cidr}"
+          else
+            log "Could not find the pod_cidr for node ${node}, skipping"
+          fi
+        fi
+      done
+
+{{- end }}
 
 # AdvancedAuditing is enabled by default since K8S v1.8.
 # With AdvancedAuditing, you have to provide a audit policy file.
@@ -3860,7 +5132,7 @@ write_files:
           if (( attempt_num == max_attempts ))
           then
               echo "Attempt $attempt_num failed and there are no more attempts left!"
-              return 1
+              exit 1
           else
               echo "Attempt $attempt_num failed! Trying again in $attempt_interval_sec seconds..."
               ((attempt_num++))

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4466,7 +4466,7 @@ write_files:
       retries=5
 
       kubectl() {
-        docker run --rm -i --net=host -v /etc/kubernetes:/etc/kubernetes:ro -v /etc/resolv.conf:/etc/resolv.conf:ro quay.io/coreos/hyperkube:v1.8.7_coreos.0 /kubectl "$@"
+        docker run --rm -i --net=host -v /etc/kubernetes:/etc/kubernetes:ro -v /etc/resolv.conf:/etc/resolv.conf:ro {{.HyperkubeImage.RepoWithTag}} /kubectl "$@"
       }
 
       log() {

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -37,12 +37,13 @@ exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE
 coreos:
   update:
     reboot-strategy: "off"
+  {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
   flannel:
     interface: $private_ipv4
     etcd_cafile: /etc/kubernetes/ssl/etcd-trusted-ca.pem
     etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
-
+  {{- end }}
   units:
 {{- range $u := .CustomSystemdUnits}}
     - name: {{$u.Name}}
@@ -150,6 +151,7 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 {{end}}
+    {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
     - name: cfn-etcd-environment.service
       enable: true
       command: start
@@ -165,7 +167,7 @@ coreos:
         RemainAfterExit=true
         ExecStartPre=/opt/bin/cfn-etcd-environment
         ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
-
+    {{ end }}
     - name: docker.service
       drop-ins:
 {{if .Experimental.EphemeralImageStorage.Enabled}}
@@ -181,6 +183,12 @@ coreos:
             RestartSec=10
             ExecStartPost=/usr/bin/docker pull {{.PauseImage.RepoWithTag}}
 
+        - name: 60-logfilelimit.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
+
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
         - name: 40-flannel.conf
           content: |
             [Unit]
@@ -188,12 +196,25 @@ coreos:
             [Service]
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
             ExecStartPre=/usr/bin/systemctl is-active flanneld.service
+        {{- end }}
+    
+    {{ if .Experimental.NetworkingDaemonSets.Enabled -}}
+    - name: flanneld.service
+      enable: false
+    {{ if .AssetsEncryptionEnabled -}}
+    - name: decrypt-assets.service
+      enable: true
+      command: start
+      content: |
+        [Unit]
+        Description=Convert encrypted credentials
 
-        - name: 60-logfilelimit.conf
-          content: |
-            [Service]
-            Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
-
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/opt/bin/decrypt-assets
+    {{ end -}}
+    {{ else -}}
     - name: flanneld.service
       drop-ins:
         - name: 10-etcd.conf
@@ -236,27 +257,38 @@ coreos:
             Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
             Environment="RKT_RUN_ARGS={{.FlannelImage.Options}} --uuid-file-save=/var/lib/coreos/flannel-wrapper2.uuid"
 {{end}}
+    {{- end}}
     - name: kubelet.service
       command: start
       runtime: true
       content: |
         [Unit]
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
         Wants=flanneld.service cfn-etcd-environment.service
         After=cfn-etcd-environment.service
+        {{ else -}}
+        Wants=decrypt-assets.service
+        After=decrypt-assets.service
+        {{- end }}
         {{- if .Gpu.Nvidia.IsEnabledOn .InstanceType }}
         Requires=nvidia-start.service
         After=nvidia-start.service
         {{- end }}
+        
         [Service]
         EnvironmentFile=/etc/environment
-        EnvironmentFile=-/etc/etcd-environment
         EnvironmentFile=-/etc/default/kubelet
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
+        EnvironmentFile=-/etc/etcd-environment
+        {{- end }}
         Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
         Environment=KUBELET_IMAGE_URL={{.HyperkubeImage.RktRepoWithoutTag}}
         Environment="RKT_RUN_ARGS=--volume dns,kind=host,source=/etc/resolv.conf {{.HyperkubeImage.Options}}\
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
         --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd-trusted-ca.pem \
         --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
         --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
+        {{ end -}}
         --mount volume=dns,target=/etc/resolv.conf \
         {{ if eq .ContainerRuntime "rkt" -}}
         --volume rkt,kind=host,source=/opt/bin/host-rkt \
@@ -269,15 +301,25 @@ coreos:
         --volume var-lib-cni,kind=host,source=/var/lib/cni \
         --mount volume=var-lib-cni,target=/var/lib/cni \
         --volume var-log,kind=host,source=/var/log \
-        --mount volume=var-log,target=/var/log{{ if .UseCalico }} \
+        --mount volume=var-log,target=/var/log \
         --volume cni-bin,kind=host,source=/opt/cni/bin \
-        --mount volume=cni-bin,target=/opt/cni/bin{{ end }}"
+        --mount volume=cni-bin,target=/opt/cni/bin"
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
         ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
+        ExecStartPre=/usr/bin/etcdctl \
+                --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
+                --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
+                --cert-file /etc/kubernetes/ssl/etcd-client.pem \
+                --endpoints "${ETCD_ENDPOINTS}" \
+                cluster-health
+        {{ end -}}
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
+        ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
+        {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /etc/kubernetes/cni/net.d/  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
         ExecStartPre=/usr/bin/etcdctl \
                        --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
@@ -287,7 +329,8 @@ coreos:
                        cluster-health
         {{if .UseCalico -}}
         ExecStartPre=/usr/bin/docker run --rm -e SLEEP=false -e KUBERNETES_SERVICE_HOST= -e KUBERNETES_SERVICE_PORT= -v /opt/cni/bin:/host/opt/cni/bin {{ .CalicoCniImage.RepoWithTag }} /install-cni.sh
-        {{end -}}
+        {{ end -}}
+        {{- end }}
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
         {{/* Work-around until https://github.com/kubernetes/kubernetes/issues/43967 is fixed via https://github.com/kubernetes/kubernetes/pull/43995 */ -}}
@@ -296,7 +339,7 @@ coreos:
         --container-runtime={{.ContainerRuntime}} \
         --rkt-path=/usr/bin/rkt \
         --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
-        --node-labels kubernetes.io/role=node{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
+        --node-labels=kubernetes.io/role=node{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-node=true \
         {{if .Taints}}--register-with-taints={{.Taints.String}}\
         {{end}}--allow-privileged=true \
@@ -454,9 +497,9 @@ coreos:
         Type=oneshot
         EnvironmentFile={{.StackNameEnvFileName}}
         ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl  --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null ; then break ; fi;  done"
-        {{ if .UseCalico }}
+        {{ if (and (not .Experimental.NetworkingDaemonSets.Enabled) .UseCalico) -}}
         ExecStartPre=/usr/bin/bash -c "until /usr/bin/docker run --net=host --pid=host --rm {{ .CalicoCtlImage.RepoWithTag }} node status > /dev/null; do sleep 3; done && echo Calico running"
-        {{ end }}
+        {{- end }}
         ExecStart=/opt/bin/cfn-signal
 {{end}}
 
@@ -754,6 +797,7 @@ write_files:
 
       rkt rm --uuid-file=/var/run/coreos/cfn-signal.uuid || :
 
+  {{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
   - path: /opt/bin/cfn-etcd-environment
     owner: root:root
     permissions: 0700
@@ -775,6 +819,7 @@ write_files:
           '
 
       rkt rm --uuid-file=/var/run/coreos/cfn-etcd-environment.uuid || :
+  {{- end }}
 
   - path: /etc/default/kubelet
     permissions: 0755
@@ -1054,6 +1099,7 @@ write_files:
         current-context: kubelet-context
 {{ end }}
 
+{{ if not .Experimental.NetworkingDaemonSets.Enabled -}}
 {{ if not .UseCalico }}
   - path: /etc/kubernetes/cni/net.d/10-flannel.conf
     content: |
@@ -1094,6 +1140,7 @@ write_files:
         }
       }
 {{ end }}
+{{- end }}
 
 {{ if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}
   - path: /etc/kubernetes/auth/kubelet-tls-bootstrap-token.tmp{{if .AssetsEncryptionEnabled}}.enc{{end}}

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1331,7 +1331,37 @@ experimental:
   # Command line flag passed to the controller-manager. (default 40s)
   # This is the amount of time which we allow running Node to be unresponsive before marking it unhealthy.
   # Must be N times more than kubelet's nodeStatusUpdateFrequency (default 10s).
-#   nodeMonitorGracePeriod: "40s"
+  # nodeMonitorGracePeriod: "40s"
+
+  # Configure Calico and Flannel networking to deployed as daemonseta which use the kubernetes API as their backing stores.
+  # This removes the need for nodes (except controllers) to connect to etcd for managing cluster networking and
+  # addresses cluster role issue: https://github.com/coreos/flannel/issues/954
+  # Use the top level cluster.yaml setting 'useCalico' to switch between calico+flannel or flannel.
+  # Consider enabling Typha if you have more than 50 Kubernetes nodes in your cluster. 
+  # Without Typha, the load on the API server and Felix’s CPU usage increases substantially as the number of nodes is increased.
+  # WARNING: Migration to networking daemonsets can be deployed to an existing cluster with no more disruption than a regular
+  # cluster role where worker nodes are rolled, but rolling back or susequently disabling networkingDaemonSets will cause 
+  # a major disruption of services until all of the existing nodes have been rolled/replaced.
+  
+  # Settings with their default values: -
+  #networkingDaemonSets:
+  #  enabled: false
+  #  typha: false
+  #  calico-node-image:
+  #    repo: quay.io/calico/node
+  #    tag: v3.0.3
+  #  calico-cni-image:
+  #    repo: quay.io/calico/cni
+  #    tag: v2.0.1
+  #  flannel-image:
+  #    repo: quay.io/coreos/flannel
+  #    tag: v0.9.1
+  #  flannel-cni-image:
+  #    repo: quay.io/coreos/flannel-cni
+  #    tag: v0.3.0
+  # typha-image:
+  #    repo: quay.io/calico/typha
+  #    tag: v0.6.2
 
 kubelet:
   # Tell Kubelet to renew its certificate as its expiration time is approaching

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1333,15 +1333,15 @@ experimental:
   # Must be N times more than kubelet's nodeStatusUpdateFrequency (default 10s).
   # nodeMonitorGracePeriod: "40s"
 
-  # Configure Calico and Flannel networking to deployed as daemonset which use the kubernetes API as their backing stores.
-  # This removes the need for nodes (except controllers) to connect to etcd for managing cluster networking and
-  # addresses cluster role issue: https://github.com/coreos/flannel/issues/954
+  # Configure Calico and Flannel networking to deployed as a daemonset with kubernetes API as their backing stores.
+  # This removes the need for nodes (except controllers) connecting to etcd and frees up node podCIDR leases faster -
+  # addressing cluster role issue: https://github.com/coreos/flannel/issues/954.
   # Use the top level cluster.yaml setting 'useCalico' to switch between calico+flannel or flannel.
   # Consider enabling Typha if you have more than 50 Kubernetes nodes in your cluster. 
   # Without Typha, the load on the API server and Felix’s CPU usage increases substantially as the number of nodes is increased.
-  # WARNING: Migration to networking daemonsets can be deployed to an existing cluster with no more disruption than a regular
-  # cluster role where worker nodes are rolled, but rolling back or susequently disabling networkingDaemonSets will cause 
-  # a major disruption of services until all of the existing nodes have been rolled/replaced.
+  # WARNING: Migration to networking daemonsets can be cleanly deployed into an existing cluster with no more disruption than a regular
+  # cluster role, but rolling back or susequently disabling networkingDaemonSets will cause a major disruption of services until 
+  # all of the nodes have been rolled/replaced.
   
   # Settings with their default values: -
   #networkingDaemonSets:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1333,7 +1333,7 @@ experimental:
   # Must be N times more than kubelet's nodeStatusUpdateFrequency (default 10s).
   # nodeMonitorGracePeriod: "40s"
 
-  # Configure Calico and Flannel networking to deployed as daemonseta which use the kubernetes API as their backing stores.
+  # Configure Calico and Flannel networking to deployed as daemonset which use the kubernetes API as their backing stores.
   # This removes the need for nodes (except controllers) to connect to etcd for managing cluster networking and
   # addresses cluster role issue: https://github.com/coreos/flannel/issues/954
   # Use the top level cluster.yaml setting 'useCalico' to switch between calico+flannel or flannel.

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1295,6 +1295,34 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
+    "SecurityGroupWorkerIngressFromControllerToTypha": {
+      "Properties": {
+        "FromPort": 5473,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 5473
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToTypha": {
+      "Properties": {
+        "FromPort": 5473,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 5473
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
     "SecurityGroupWorkerIngressFromControllerToFlannel": {
       "Properties": {
         "FromPort": 8472,

--- a/core/controlplane/config/user_data_config_test.go
+++ b/core/controlplane/config/user_data_config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/coreos/coreos-cloudinit/config/validate"
 	"github.com/kubernetes-incubator/kube-aws/model"

--- a/model/userdata.go
+++ b/model/userdata.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"log"
+
 	"github.com/coreos/coreos-cloudinit/config/validate"
 	"github.com/kubernetes-incubator/kube-aws/filereader/texttemplate"
 	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
@@ -8,6 +10,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"strings"
 	"text/template"
 )
@@ -67,6 +70,9 @@ func NewUserData(templateFile string, context interface{}, opts ...UserDataOptio
 
 	tmpl, err := texttemplate.ParseFile(templateFile, funcs)
 	if err != nil {
+		if tf, e := ioutil.ReadFile(templateFile); e == nil {
+			log.Printf("Bad Template:-\n%s\n", tf)
+		}
 		return UserData{}, err
 	}
 
@@ -139,6 +145,7 @@ func validateCoreosCloudInit(content []byte) error {
 		errors = append(errors, fmt.Sprintf("%+v", entry))
 	}
 	if len(errors) > 0 {
+		log.Printf("Bad cloud-config:-\n%s\n", content)
 		return fmt.Errorf("cloud-config validation errors:\n%s\n", strings.Join(errors, "\n"))
 	}
 	return nil

--- a/model/userdata.go
+++ b/model/userdata.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"text/template"
 )
@@ -70,9 +69,6 @@ func NewUserData(templateFile string, context interface{}, opts ...UserDataOptio
 
 	tmpl, err := texttemplate.ParseFile(templateFile, funcs)
 	if err != nil {
-		if tf, e := ioutil.ReadFile(templateFile); e == nil {
-			log.Printf("Bad Template:-\n%s\n", tf)
-		}
 		return UserData{}, err
 	}
 


### PR DESCRIPTION
Deploy Calico and Flannel networking as a daemonset with kubernetes API as backing store. Removes the need for nodes connecting to etcd and frees up node podCIDR leases faster -addressing cluster role issue: https://github.com/coreos/flannel/issues/954.

- Experimental feature, disabled by default.
- Kubernetes Controllers become responsible for allocating node cidrs.
- Switch between calico+flannel (canal) or flannel.
- Fast roll out into existing clusters with minimal disruption.
- Optional calico typha service for easing load on apiservers in large clusters.

