### PR TITLE
Make CoreOS AMI ID mandatory in cluster YAML

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -11,13 +11,8 @@ s3URI: {{.S3URI}}
 #releaseChannel: stable
 
 # The AMI ID of CoreOS.
-# If omitted, the latest AMI for the releaseChannel is used.
-# This happens every time 'kube-aws update' is run, potentially replacing all instances with a newer version
-{{if .AmiId -}}
 amiId: "{{.AmiId}}"
-{{else -}}
-#amiId: ""
-{{- end}}
+
 # The ID of hosted zone to add the externalDNSName to.
 # Either specify hostedZoneId or hostedZone, but not both
 #hostedZoneId: ""

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3044,7 +3044,7 @@ worker:
 				hasDefaultExperimentalFeatures,
 				func(c *config.Config, t *testing.T) {
 					if len(c.NodePools[0].IAMConfig.Role.ManagedPolicies) < 2 {
-						t.Errorf("iam.role.managedPolicies: incorrect number of policies expected=2 actual=%s", len(c.NodePools[0].IAMConfig.Role.ManagedPolicies))
+						t.Errorf("iam.role.managedPolicies: incorrect number of policies expected=2 actual=%d", len(c.NodePools[0].IAMConfig.Role.ManagedPolicies))
 					}
 					if c.NodePools[0].IAMConfig.Role.ManagedPolicies[0].Arn != "arn:aws:iam::aws:policy/AdministratorAccess" {
 						t.Errorf("iam.role.managedPolicies: expected=arn:aws:iam::aws:policy/AdministratorAccess actual=%s", c.NodePools[0].IAMConfig.Role.ManagedPolicies[0].Arn)


### PR DESCRIPTION
Fixes #1106