### PR TITLE
Dedicated Service account / Cluster Role for Tiller Deploy

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -870,6 +870,9 @@ write_files:
       # Service Accounts
       applyall "${mfdir}"/{kube-dns,heapster,kube-proxy,kubernetes-dashboard}"-sa.yaml"
 
+      # Tiller RBAC rules
+      applyall "${mfdir}/tiller-rbac.yaml"
+
       # Install tiller by default
       applyall "${mfdir}/tiller.yaml"
 
@@ -2565,7 +2568,7 @@ write_files:
                - key: "node.alpha.kubernetes.io/role"
                  operator: "Equal"
                  value: "master"
-                 effect: "NoSchedule" 
+                 effect: "NoSchedule"
               {{ else -}}
               tolerations:
               - key: "CriticalAddonsOnly"
@@ -3123,6 +3126,7 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
             spec:
+              serviceAccountName: tiller
               {{if .Experimental.Admission.Priority.Enabled -}}
               priorityClassName: system-node-critical
               {{ end -}}
@@ -3182,6 +3186,36 @@ write_files:
           type: ClusterIP
         status:
           loadBalancer: {}
+
+  - path: /srv/kubernetes/manifests/tiller-rbac.yaml
+    content: |
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: tiller
+        rules:
+          - apiGroups: ["", "extensions", "apps"]
+            resources: ["deployments", "replicasets", "pods", "configmaps", "secrets", "namespaces"]
+            verbs: ["*"]
+        ---
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: tiller
+          namespace: kube-system
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: tiller
+        subjects:
+        - kind: ServiceAccount
+          name: tiller
+          namespace: kube-system
+        roleRef:
+          kind: ClusterRole
+          name: tiller
+          apiGroup: rbac.authorization.k8s.io
 
   - path: {{.KubernetesManifestPlugin.ManifestListFile.Path}}
     encoding: gzip+base64


### PR DESCRIPTION
Currently Tiller Deploy is running as a cluster admin through the default service account.
This PR gives the tiller deploy its own service account binded to a cluster role with only the correct permission scope (taken from here).

Resolves #878

For the future, it would be worth checking if anything else is running with the default service account binded to a role with more permissions than it needs.