### PR TITLE
Allow new etcd clusters to boot with recovery enabled

### DIFF
--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -270,6 +270,7 @@ coreos:
             {{end -}}
 
             [Service]
+            Type=simple
             EnvironmentFile=-/etc/etcd-environment
             EnvironmentFile=-/var/run/coreos/etcdadm/etcd-member.env
 


### PR DESCRIPTION
When I tried to launch new clusters with the following etcd config: 

```
etcd:
  snapshot:
    automated: true
  disasterRecovery:
    automated: true
```

The rollout stalls at etcd0 because cfn-signal service doesn't start.  It doesn't start because the etcdadm-check service hasn't started and the etcdadm-check wont start until the etcd server, i.e. the etcd-member service signals that it has started up via the systemd notify mechanism.

The issue seems to be that etcd-member will not indicate that it has started unless all of the members are healthy - which is a problem, we have only started the first one.  So, unless we take intervention then the etcd0 will time out after 15mins and we don't get our cluster.

This behaviour can be changed by changing the etcd-member service from type notify to type simple instead.  Then out etcdadm-check service can start even though it will report that the cluster is unhealthy and subsequently cfn-signal can run and so we move on to launching etcd1.  By changing the /etc/systemd/system/etcd-member.service.d/20-aws-cluster.conf which we are already creating we can override the systemd type as required.