### PR TITLE
Fix issue with tiller having to restrictive permissions

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3191,16 +3191,6 @@ write_files:
           loadBalancer: {}
 
   - path: /srv/kubernetes/manifests/tiller-rbac.yaml
-    content: |
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRole
-        metadata:
-          name: tiller
-        rules:
-          - apiGroups: ["", "extensions", "apps"]
-            resources: ["deployments", "replicasets", "pods", "configmaps", "secrets", "namespaces"]
-            verbs: ["*"]
-        ---
         apiVersion: v1
         kind: ServiceAccount
         metadata:
@@ -3217,7 +3207,7 @@ write_files:
           namespace: kube-system
         roleRef:
           kind: ClusterRole
-          name: tiller
+          name: cluster-admin
           apiGroup: rbac.authorization.k8s.io
 
   - path: {{.KubernetesManifestPlugin.ManifestListFile.Path}}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3191,6 +3191,7 @@ write_files:
           loadBalancer: {}
 
   - path: /srv/kubernetes/manifests/tiller-rbac.yaml
+    content: |
         apiVersion: v1
         kind: ServiceAccount
         metadata:


### PR DESCRIPTION
## Background
This is a modification of #1202. Originally tiller ran with the default service account bound to cluster-admin which is quite bad when you consider that everything that is created without a specified service account will be assigned the default and thus be able to do ANYTHING with the cluster. That's no longer the case.

## New problem.
I ran into an issue when attempting to install the prometheus-operator chart with these new permissions. These permissions are too restrictive and thus don't allow for the creation of service-accounts and cluster role bindings, which it will need when installing these kind of charts.

The easy fix is to bind the new tiller service account added in #1202 to cluster-admin. Ideally, I'd like this to prompt a discussion about what exactly tiller should have permission to do by default.

For instance, cluster-admins are able to create namespaces. Does tiller really need to do this?

Resolves #1212
