### PR TITLE
handle kubectl apply failures by trying delete+create

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -819,6 +819,7 @@ write_files:
 
       # Try to batch as many files as possible to reduce the total amount of delay due to wilderness in the API aggregation
       # See https://github.com/kubernetes-incubator/kube-aws/issues/1039
+      # Use --force to ensure immutable objects are deleted+added if can not be applied.
       applyall() {
         kubectl apply --force -f $(echo "$@" | tr ' ' ',')
       }

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -820,7 +820,13 @@ write_files:
       # Try to batch as many files as possible to reduce the total amount of delay due to wilderness in the API aggregation
       # See https://github.com/kubernetes-incubator/kube-aws/issues/1039
       applyall() {
-        kubectl apply -f $(echo "$@" | tr ' ' ',')
+        set +e
+        if ! kubectl apply -f $(echo "$@" | tr ' ' ','); then
+          set -e
+          kubectl delete --ignore-not-found=true -f $(echo "$@" | tr ' ' ',')
+          kubectl create -f $(echo "$@" | tr ' ' ',')
+        fi
+        set -e
       }
 
       # Manage the deletion of services

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -820,13 +820,7 @@ write_files:
       # Try to batch as many files as possible to reduce the total amount of delay due to wilderness in the API aggregation
       # See https://github.com/kubernetes-incubator/kube-aws/issues/1039
       applyall() {
-        set +e
-        if ! kubectl apply -f $(echo "$@" | tr ' ' ','); then
-          set -e
-          kubectl delete --ignore-not-found=true -f $(echo "$@" | tr ' ' ',')
-          kubectl create -f $(echo "$@" | tr ' ' ',')
-        fi
-        set -e
+        kubectl apply --force -f $(echo "$@" | tr ' ' ',')
       }
 
       # Manage the deletion of services


### PR DESCRIPTION
We have seen an issue where an attempted update to tiller roll bindings is causing a cluster roll/update to fail.

There are some objects and fields in kubernetes that you can not update with a kubectl apply, for example ClusterRoleBindings.  I've added a little logic to handle the failure of kubectl apply by attempting a delete followed by a create when an apply fails.  If the create also fails then the unit will go into a failed state which will prevent cfn-signal from firing and therefore a roll-back.

This change add resilience to the install-kube-system script and will prevent cluster update failures.