### PR TITLE
KIAMImage should affect server as well as client.

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -5061,7 +5061,7 @@ write_files:
                   secretName: kiam-server-tls
             containers:
               - name: kiam
-                image: quay.io/uswitch/kiam:v2.5
+                image: {{.KIAMImage.RepoWithTag}}
                 imagePullPolicy: Always
                 command:
                   - /server


### PR DESCRIPTION
We want to change the version of the KIAMServer but found that the image is hardcoded whereas the client isn't.  Both the client and server should use the same image.