### PR TITLE
Inherit controlplane Kubenetes-Newtworking config in node pools.

### DIFF
--- a/core/nodepool/config/deployment.go
+++ b/core/nodepool/config/deployment.go
@@ -131,5 +131,8 @@ func (c DeploymentSettings) WithDefaultsFrom(main cfg.DeploymentSettings) Deploy
 	//Inherit main KubeDns config
 	c.KubeDns.MergeIfEmpty(main.KubeDns)
 
+	//Inherit main Kubernetes config (e.g. for Kubernetes.Networking.SelfHosting etc.)
+	c.Kubernetes = main.Kubernetes
+
 	return c
 }


### PR DESCRIPTION
Apologies, I found another bug with the Self Hosting Networking, this one does not cause any failures, but it does prevent nodes from rolling (and the local flannel becoming de-activated).  When I moved the feature from Experimental to Kubernetes.Networking.SelfHosting, I didn't realise that the settings from the Controlplane do not automatically propagate down to the nodes.

This change corrects this by ensuring that the Kubernetes top level object gets propagated from the control-plane to node.