### PR TITLE
[Canal] Support tainted worker

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1434,6 +1434,15 @@ write_files:
           spec:
             hostNetwork: true
             serviceAccountName: canal
+            tolerations:
+              # Tolerate this effect so the pods will be schedulable at all times
+              - effect: NoSchedule
+                operator: Exists
+              # Mark the pod as a critical add-on for rescheduling.
+              - key: CriticalAddonsOnly
+                operator: Exists
+              - effect: NoExecute
+                operator: Exists
             # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
             # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
             terminationGracePeriodSeconds: 0


### PR DESCRIPTION
When tainting worker in cluster.yaml, canal daemonset cannot be scheduled on
tainted worker