### PR TITLE
Bump Calico/Typha Versions now Typha Issue resolved.

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -30,11 +30,11 @@ const (
 	userDataDir    = "userdata"
 
 	// Experimental SelfHosting feature default images.
-	kubeNetworkingSelfHostingDefaultCalicoNodeImageTag = "v3.0.3"
-	kubeNetworkingSelfHostingDefaultCalicoCniImageTag  = "v2.0.1"
+	kubeNetworkingSelfHostingDefaultCalicoNodeImageTag = "v3.0.6"
+	kubeNetworkingSelfHostingDefaultCalicoCniImageTag  = "v2.0.5"
 	kubeNetworkingSelfHostingDefaultFlannelImageTag    = "v0.9.1"
 	kubeNetworkingSelfHostingDefaultFlannelCniImageTag = "v0.3.0"
-	kubeNetworkingSelfHostingDefaultTyphaImageTag      = "v0.6.2"
+	kubeNetworkingSelfHostingDefaultTyphaImageTag      = "v0.6.4"
 )
 
 func NewDefaultCluster() *Cluster {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1127,21 +1127,6 @@ write_files:
             # as a host-networked pod.
             hostNetwork: true
             serviceAccountName: canal
-            initContainers:
-            - name: wait-for-default-clusterinformation
-              image: {{.HyperkubeImage.RepoWithTag}}
-              command: ["/bin/sh", "-c" ]
-              args:
-                - |
-                    set -x ;
-                    while true; do
-                      if /kubectl get clusterinformation default; then
-                        echo "Calcio clusterinformation default exists, can continue..."
-                        exit 0
-                      fi
-                      echo "Waiting for Calcio clusterinformation default..."
-                      sleep 5
-                    done
             containers:
             - image: {{ .Kubernetes.Networking.SelfHosting.TyphaImage.RepoWithTag }}
               name: typha


### PR DESCRIPTION
In the present implementation of Kubernetes.Networking.SelfHosting, I have had to work around an issue where if Typha came up before any Calico nodes that it would write a bad global cluster information record which would prevent calico/typha from subsequently correctly starting.

I raised an upstream issue, https://github.com/projectcalico/typha/issues/118, which has now been resolved with the latest releases.  Given that the issue is resolved, this change bumps Calico and Typha to the latest releases and removes my work-around for Typha bug (which was polling for the record via an init container).