### PR TITLE
Fix the `init` command example

### DIFF
--- a/docs/getting-started/step-2-render.md
+++ b/docs/getting-started/step-2-render.md
@@ -84,8 +84,7 @@ $ kube-aws init \
 --region=us-west-1 \
 --availability-zone=us-west-1c \
 --key-name=key-pair-name \
---kms-key-arn="arn:aws:kms:us-west-1:xxxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx" \
---s3-uri=s3://my-kube-aws-assets-bucket
+--kms-key-arn="arn:aws:kms:us-west-1:xxxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
 ```
 
 Here `us-west-1c` is used for parameter `--availability-zone`, but supported availability zone varies among AWS accounts.


### PR DESCRIPTION
The `init` command does not take an `--s3-uri` argument:

```
kube-aws init --help
Initialize default node pool configuration

Usage:
  kube-aws init [flags]

Flags:
      --ami-id string              The AMI ID of CoreOS
      --availability-zone string   The AWS availability-zone to deploy to
      --cluster-name string        The name of this cluster. This will be the name of the cloudformation stack
      --external-dns-name string   The hostname that will route to the api server
  -h, --help                       help for init
      --hosted-zone-id string      The hosted zone in which a Route53 record set for a k8s API endpoint is created
      --key-name string            The AWS key-pair for ssh access to nodes
      --kms-key-arn string         The ARN of the AWS KMS key for encrypting TLS assets
      --no-record-set              Instruct kube-aws to not manage Route53 record sets for your K8S API endpoints
      --region string              The AWS region to deploy to
```

```
λ kube-aws version
kube-aws version 0.9.9
```
Trying to add the `--s3-uri` as per the example, I get this error:

```
Error: unknown flag: --s3-uri
```