### PR TITLE
autoscaler: update cloud-config-controller

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4049,6 +4049,7 @@ write_files:
                     - --stderrthreshold=info
                     - --cloud-provider=aws
                     - --skip-nodes-with-local-storage=false
+                    - --skip-nodes-with-system-pods=false
                     - --expander=least-waste
                     - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,kubernetes.io/cluster/{{.ClusterName}}
                   env:


### PR DESCRIPTION
modifies the behavior of the autoscaler to terminate worker and
controller nodes no longer needed when minSize is set manually.

Note that I had to delete the initial autoscaler pod after
deploying a new cluster with this modification in place.
After that initial autoscaler pod was deleted the second
pod functioned without errors and as expected.
I will update the issue comments with more details.

Fixes #1253