### PR TITLE
Fix etcd startup

### DIFF
--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -151,6 +151,7 @@ coreos:
         Wants=cfn-etcd-environment.service
         After=cfn-etcd-environment.service
         After=network.target
+        After=var-lib-etcd2.mount
 
         [Service]
         Type=oneshot
@@ -158,7 +159,7 @@ coreos:
         RestartSec=5
         EnvironmentFile=-/etc/etcd-environment
         EnvironmentFile=-/var/run/coreos/etcdadm-environment
-        ExecStartPre=/usr/bin/systemctl is-active format-etcd2-volume.service
+        ExecStartPre=/usr/bin/systemctl is-active var-lib-etcd2.mount
         ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
         ExecStartPre=/usr/bin/mkdir -p /var/run/coreos/etcdadm/snapshots
         ExecStart=/opt/bin/etcdadm reconfigure

--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -168,9 +168,6 @@ coreos:
         {{end -}}
         TimeoutStartSec=120
 
-        [Install]
-        WantedBy=cfn-etcd-environment.service
-
     - name: etcdadm-update-status.service
       enable: true
       content: |


### PR DESCRIPTION
After applying the fix for issue #1206, timing/race  issues were still showing when creating etcd clusters with more than 1 instance.

This patch fixes the race condition by having `etcdadm-reconfigure.service` depend on service `var-lib-etcd2.mount` instead of `format-etcd2-volume.service` (`var-lib-etcd2.mount` already depends on that service).

Also a potential circulair dependency on `cfn-etcd-environment.service` has been eliminated.
