### PR TITLE
Cluster autoscaler docs/tests

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1161,9 +1161,13 @@ func (c Cluster) APIAccessAllowedSourceCIDRsForControllerSG() []string {
 	return cidrs
 }
 
+func (c Cluster) ClusterAutoscalerSupportEnabled() bool {
+	return c.Addons.ClusterAutoscaler.Enabled && c.Experimental.ClusterAutoscalerSupport.Enabled
+}
+
 func (c Cluster) NodeLabels() model.NodeLabels {
 	labels := c.NodeSettings.NodeLabels
-	if c.Addons.ClusterAutoscaler.Enabled {
+	if c.ClusterAutoscalerSupportEnabled() {
 		labels["kube-aws.coreos.com/cluster-autoscaler-supported"] = "true"
 	}
 	return labels

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -1468,5 +1468,81 @@ kmsKeyArn: "arn:aws:kms:eu-west-1:xxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
 	if err == nil || !strings.Contains(err.Error(), "same region") {
 		t.Errorf("Expecting validation error for mismatching KMS key ARN and region config: %s\n%s", err, confBody)
 	}
+}
+func TestClusterAutoscalerDisabled(t *testing.T) {
+	disabledConfigs := []string{
+		`
+addons:
+  clusterAutoscaler:
+    enabled: false
+experimental:
+  clusterAutoscalerSupport:
+    enabled: true
+`,
+		`
+addons:
+  clusterAutoscaler:
+    enabled: true
+experimental:
+  clusterAutoscalerSupport:
+    enabled: false
+`}
 
+	for _, testCase := range disabledConfigs {
+		confBody := singleAzConfigYaml + testCase
+		c, err := ClusterFromBytes([]byte(confBody))
+		if err != nil {
+			t.Errorf("failed to parse config %s: %v", confBody, err)
+		}
+
+		for label, _ := range c.NodeLabels() {
+			if label == "kube-aws.coreos.com/cluster-autoscaler-supported" {
+				t.Errorf("Controllers should not be labelled for autoscaler with config: %s", confBody)
+			}
+		}
+
+		if c.ClusterAutoscalerSupportEnabled() {
+			t.Errorf("Controllers should not have autoscaling enabled with config: %s", confBody)
+		}
+	}
+}
+
+func TestClusterAutoscalerEnabled(t *testing.T) {
+	enabledConfigs := []string{
+		`
+addons:
+  clusterAutoscaler:
+    enabled: true
+experimental:
+  clusterAutoscalerSupport:
+    enabled: true
+`,
+		// `experimental.clusterAutoscalerSupport.enabled` should default to true
+		`
+addons:
+  clusterAutoscaler:
+    enabled: true
+`}
+
+	for _, testCase := range enabledConfigs {
+		confBody := singleAzConfigYaml + testCase
+		c, err := ClusterFromBytes([]byte(confBody))
+		if err != nil {
+			t.Errorf("failed to parse config %s: %v", confBody, err)
+		}
+
+		found := false
+		for label, _ := range c.NodeLabels() {
+			if label == "kube-aws.coreos.com/cluster-autoscaler-supported" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Controllers should be labelled for autoscaler with config: %s", confBody)
+		}
+
+		if !c.ClusterAutoscalerSupportEnabled() {
+			t.Errorf("Controllers should have autoscaling enabled with config: %s", confBody)
+		}
+	}
 }

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -473,8 +473,7 @@ worker:
 #      awsNodeLabels:
 #        enabled: true
 #
-#      # Will provision worker nodes with IAM permissions to run cluster-autoscaler and add node labels so that
-#      # cluster-autoscaler pods are scheduled to nodes in this node pool
+#      # Provision worker nodes with IAM permissions and node labels to run cluster-autoscaler (assuming `addons.clusterAutoscaler.enabled` is true)
 #      clusterAutoscalerSupport:
 #        enabled: true
 #
@@ -1275,10 +1274,9 @@ kubeProxy:
 
 # Addon features
 addons:
-  # Will provision controller nodes with IAM permissions to run cluster-autoscaler and
-  # create a cluster-autoscaler deployment in the cluster
-  # CA runs only on controller nodes by default. Turn on `worker.nodePools[].clusterAutoscalerSupport.enabled` to
-  # add nodes from a node pool to be where CA runs
+  # Will create a cluster-autoscaler (CA) deployment in the cluster.
+  # CA runs only on controller nodes by default, to turn this off set `experimental.clusterAutoscalerSupport.enabled` to false.
+  # If you want to run CA on worker nodes, turn on `worker.nodePools[].clusterAutoscalerSupport.enabled` for the node pool.
   clusterAutoscaler:
     enabled: false
 
@@ -1352,6 +1350,10 @@ experimental:
   # The set includes names of launch configurations and autoscaling groups
   awsNodeLabels:
     enabled: false
+
+  # Provision controller nodes with IAM permissions and node labels to run cluster-autoscaler (assuming `addons.clusterAutoscaler.enabled` is true)
+  clusterAutoscalerSupport:
+    enabled: true
 
   # If enabled, instructs the controller manager to automatically issue TLS certificates to worker nodes via
   # certificate signing requests (csr) made to the API server using the bootstrap token. It's recommended to

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -253,7 +253,7 @@
                   "Resource": [ "*" ]
                 },
                 {{end}}
-                {{if (and .Addons.ClusterAutoscaler.Enabled .Experimental.ClusterAutoscalerSupport.Enabled) }}
+                {{if .ClusterAutoscalerSupportEnabled }}
                 {
                   "Action": [
                     "autoscaling:DescribeAutoScalingGroups",


### PR DESCRIPTION
Basic tests for cluster autoscaler config.

Bug fix also found during testing - only label the controller nodes if `experimental.clusterAutoscalerSupport.enabled` is set to true (which is the default).

Improved cluster autoscaler documentation as well which will fix https://github.com/kubernetes-incubator/kube-aws/issues/1045