### PR TITLE
Normalize audit log attribute names in cluster.yaml + add support for missing attributes

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -74,9 +74,11 @@ func NewDefaultCluster() *Cluster {
 			},
 		},
 		AuditLog: AuditLog{
-			Enabled: false,
-			MaxAge:  30,
-			LogPath: "/var/log/kube-apiserver-audit.log",
+			Enabled:   false,
+			LogPath:   "/var/log/kube-apiserver-audit.log",
+			MaxAge:    30,
+			MaxBackup: 1,
+			MaxSize:   100,
 		},
 		Authentication: Authentication{
 			Webhook{
@@ -648,9 +650,11 @@ type PersistentVolumeClaimResize struct {
 }
 
 type AuditLog struct {
-	Enabled bool   `yaml:"enabled"`
-	MaxAge  int    `yaml:"maxage"`
-	LogPath string `yaml:"logpath"`
+	Enabled   bool   `yaml:"enabled"`
+	LogPath   string `yaml:"logPath"`
+	MaxAge    int    `yaml:"maxAge"`
+	MaxBackup int    `yaml:"maxBackup"`
+	MaxSize   int    `yaml:"maxSize"`
 }
 
 type Authentication struct {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3176,8 +3176,9 @@ write_files:
           {{ end }}
           {{if .Experimental.AuditLog.Enabled}}
           - --audit-log-maxage={{.Experimental.AuditLog.MaxAge}}
+          - --audit-log-maxsize={{.Experimental.AuditLog.MaxSize}}
           - --audit-log-path={{.Experimental.AuditLog.LogPath}}
-          - --audit-log-maxbackup=1
+          - --audit-log-maxbackup={{.Experimental.AuditLog.MaxBackup}}
           - --audit-policy-file=/etc/kubernetes/apiserver/audit-policy.yaml
           {{ end }}
           - --authorization-mode={{if .Experimental.NodeAuthorizer.Enabled}}Node,{{end}}RBAC

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1311,8 +1311,10 @@ experimental:
   # Enable audit log for apiserver. Recommended when `rbac` is enabled.
   auditLog:
     enabled: false
-    maxage: 30
-    logpath: /dev/stdout
+    logPath: /dev/stdout
+    maxAge: 30
+    maxBackup: 1
+    maxSize: 100
 
   # See https://kubernetes.io/docs/admin/authentication/#webhook-token-authentication for more information
   authentication:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1311,7 +1311,7 @@ experimental:
   # Enable audit log for apiserver. Recommended when `rbac` is enabled.
   auditLog:
     enabled: false
-    logPath: /dev/stdout
+    logPath: /var/log/kube-apiserver-audit.log
     maxAge: 30
     maxBackup: 1
     maxSize: 100

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -106,9 +106,11 @@ func TestMainClusterConfig(t *testing.T) {
 				},
 			},
 			AuditLog: controlplane_config.AuditLog{
-				Enabled: false,
-				MaxAge:  30,
-				LogPath: "/var/log/kube-apiserver-audit.log",
+				Enabled:   false,
+				LogPath:   "/var/log/kube-apiserver-audit.log",
+				MaxAge:    30,
+				MaxBackup: 1,
+				MaxSize:   100,
 			},
 			Authentication: controlplane_config.Authentication{
 				Webhook: controlplane_config.Webhook{
@@ -1252,8 +1254,10 @@ experimental:
       enabled: true
   auditLog:
     enabled: true
-    maxage: 100
-    logpath: "/var/log/audit.log"
+    logPath: "/var/log/audit.log"
+    maxAge: 100
+    maxBackup: 10
+    maxSize: 5
   authentication:
     webhook:
       enabled: true
@@ -1336,9 +1340,11 @@ worker:
 							},
 						},
 						AuditLog: controlplane_config.AuditLog{
-							Enabled: true,
-							MaxAge:  100,
-							LogPath: "/var/log/audit.log",
+							Enabled:   true,
+							LogPath:   "/var/log/audit.log",
+							MaxAge:    100,
+							MaxBackup: 10,
+							maxSize:   5,
 						},
 						Authentication: controlplane_config.Authentication{
 							Webhook: controlplane_config.Webhook{

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1344,7 +1344,7 @@ worker:
 							LogPath:   "/var/log/audit.log",
 							MaxAge:    100,
 							MaxBackup: 10,
-							maxSize:   5,
+							MaxSize:   5,
 						},
 						Authentication: controlplane_config.Authentication{
 							Webhook: controlplane_config.Webhook{


### PR DESCRIPTION
The `auditLog.(logpath|maxage)` attribute names were normalized to `auditLog.(logPath|maxAge)`, and added support for the `maxBackup` (which was hard-coded to `1`) and `maxSize` flags.

Also, the `cluster.yaml` now uses the same default value for `auditLog.logPath` as the one defined in the struct.