### PR TITLE
Fix failing etcd volume attach when upgrading etcd instances

### DIFF
--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -520,14 +520,15 @@ write_files:
         )
 
         if [ "$candidate_vol_id" = "" ]; then
-          echo "[bug] no etcd volume found" 1>&2
-          exit 1
+          echo "no etcd volume found yet, retrying in 10 secs" 1>&2
+          sleep 10
+        else
+          # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html for device naming
+          if aws ec2 attach-volume --volume-id $candidate_vol_id --instance-id $instance_id --device "/dev/xvdf"; then
+            attached_vol_id=$candidate_vol_id
+          fi
         fi
 
-        # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html for device naming
-        if aws ec2 attach-volume --volume-id $candidate_vol_id --instance-id $instance_id --device "/dev/xvdf"; then
-          attached_vol_id=$candidate_vol_id
-        fi
       done
 
       # Wait until the volume attachment completes


### PR DESCRIPTION
**PROBLEM**
Running a `kube-aws upgrade` on a working cluster fails to properly restart `etcd` instances, causing a (again failing on the same issue) `UPDATE_ROLLBACK` of the CloudFormation stack.

**CAUSE**
When replacing `etcd` instances, the mounted volume is detached from the old instance and attached to the new one. This however can take a few minutes. `Systemd` service `cfn-etcd-environment.service` fails when the volume is not yet available and restarts itself.
Unfortunately depending services are failing because of `systemd` not capable of waiting for restarting failed services! (see snippet below).

After a while the attaching of the volume succeeds, but the depending services are not executed and the instance is not working properly.

```
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: cfn-etcd-environment.service: Control process exited, code=exited status=1
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: cfn-etcd-environment.service: Failed with result 'exit-code'.
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: Failed to start Configures EBS volume and R53 record set for this node and derives env
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: Dependency failed for Formats etcd2 ebs volume.
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: Dependency failed for /var/lib/etcd2.
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: Dependency failed for etcd (System Application Container).
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: Dependency failed for etcdadm update status.
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: etcdadm-update-status.service: Job etcdadm-update-status.service/start failed with res
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: Dependency failed for etcdadm reconfigure runner.
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: etcdadm-reconfigure.service: Job etcdadm-reconfigure.service/start failed with result
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: etcd-member.service: Job etcd-member.service/start failed with result 'dependency'.
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: var-lib-etcd2.mount: Job var-lib-etcd2.mount/start failed with result 'dependency'.
May 04 15:00:48 ip-10-55-21-187.eu-central-1.compute.internal systemd[1]: format-etcd2-volume.service: Job format-etcd2-volume.service/start failed with result
```

**SOLUTION**
Don't fail service `cfn-etcd-environment.service` when a volume cannot be attached (yet), but retry in a loop.
