### PR TITLE
1316/kiam kube2iam with kube net selfhosting

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4959,10 +4959,9 @@ write_files:
                   - "--auto-discover-default-role"
                   - "--iptables=true"
                   - "--host-ip=$(HOST_IP)"
-           {{/* if (NOT KNSelfHosting.Enabled AND UseCali) OR (KNSelfHosting.Enabled AND KNSelfHosting.Type="canal") */}}
            {{- if (or (and (not .Kubernetes.Networking.SelfHosting.Enabled) .UseCalico) (and .Kubernetes.Networking.SelfHosting.Enabled (eq .Kubernetes.Networking.SelfHosting.Type "canal"))) }}
                   - "--host-interface=cali+"
-           {{- else}}
+           {{- else }}
                   - "--host-interface=cni0"
            {{- end }}
                 env:
@@ -5354,7 +5353,6 @@ write_files:
                   - /agent
                 args:
                   - --iptables
-           {{/* if (NOT KNSelfHosting.Enabled AND UseCali) OR (KNSelfHosting.Enabled AND KNSelfHosting.Type="canal") */}}
            {{- if (or (and (not .Kubernetes.Networking.SelfHosting.Enabled) .UseCalico) (and .Kubernetes.Networking.SelfHosting.Enabled (eq .Kubernetes.Networking.SelfHosting.Type "canal"))) }}
                   - --host-interface=cali+
            {{- else}}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4959,9 +4959,10 @@ write_files:
                   - "--auto-discover-default-role"
                   - "--iptables=true"
                   - "--host-ip=$(HOST_IP)"
-           {{- if .UseCalico }}
+           {{/* if (NOT KNSelfHosting.Enabled AND UseCali) OR (KNSelfHosting.Enabled AND KNSelfHosting.Type="canal") */}}
+           {{- if (or (and (not .Kubernetes.Networking.SelfHosting.Enabled) .UseCalico) (and .Kubernetes.Networking.SelfHosting.Enabled (eq .Kubernetes.Networking.SelfHosting.Type "canal"))) }}
                   - "--host-interface=cali+"
-           {{else}}
+           {{- else}}
                   - "--host-interface=cni0"
            {{- end }}
                 env:
@@ -5353,10 +5354,11 @@ write_files:
                   - /agent
                 args:
                   - --iptables
-           {{- if .UseCalico }}
-                  - "--host-interface=cali+"
-           {{else}}
-                  - "--host-interface=cni0"
+           {{/* if (NOT KNSelfHosting.Enabled AND UseCali) OR (KNSelfHosting.Enabled AND KNSelfHosting.Type="canal") */}}
+           {{- if (or (and (not .Kubernetes.Networking.SelfHosting.Enabled) .UseCalico) (and .Kubernetes.Networking.SelfHosting.Enabled (eq .Kubernetes.Networking.SelfHosting.Type "canal"))) }}
+                  - --host-interface=cali+
+           {{- else}}
+                  - --host-interface=cni0
            {{- end }}
                   - --json-log
                   - --port=8181


### PR DESCRIPTION
Allow migration from use of UseCalico setting to resolve issue https://github.com/kubernetes-incubator/kube-aws/issues/1316 and allow migration of Kubernetes->Networking->Selfhosting by default.