### PR TITLE
Fix flannel traffic among controllers

### DIFF
--- a/core/network/config/templates/stack-template.json
+++ b/core/network/config/templates/stack-template.json
@@ -351,6 +351,20 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    "SecurityGroupControllerIngressFromControllerToFlannel": {
+      "Properties": {
+        "FromPort": 8472,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "udp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 8472
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
     "SecurityGroupWorkerIngressFromWorkerToFlannel": {
       "Properties": {
         "FromPort": 8472,


### PR DESCRIPTION
It appears flannel traffic is not permissible among controllers. This pull
request fix this by adding a security group ingress which allows 8472/udp
from other controllers.

When kiam support is enabled, kiam-server tries to discover grpclb by querying
DNS. If kube-dns is running on controllers and there are multiple controllers,
the DNS name may not be resolved becuase kiam-server cannot contact kube-dns
running on the other controller.