### PR TITLE
Automatically enable EBS optimization

### DIFF
--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -266,6 +266,9 @@
         {{else}}
         "PlacementTenancy": "{{.Tenancy}}",
         {{end}}
+        {{if EbsOptimized .InstanceType }}
+        "EbsOptimized": "true",
+        {{end}}
         "UserData": {{ .UserDataWorker.Parts.instance.Template }}
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration"

--- a/filereader/texttemplate/texttemplate.go
+++ b/filereader/texttemplate/texttemplate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig"
@@ -41,6 +42,25 @@ var funcs2 = template.FuncMap{
 	"toLabel": func(data string) string {
 		reg := regexp.MustCompile("[^a-z0-9A-Z_.-]")
 		return reg.ReplaceAllString(data, "_")
+	},
+	"EbsOptimized": func(instanceType string) bool {
+		// Amazon instance series that do not support EBS optimize
+		nonSupportedSeries := map[string]bool{"t1": true, "t2": true}
+		// Amazon instance types that do not support EBS optimize
+		nonSupportedTypes := map[string]bool{
+			"c1.medium": true,
+			"c3.large":  true, "c3.8xlarge": true,
+			"cc2.8xlarge": true,
+			"cr1.8xlarge": true,
+			"g2.8xlarge":  true,
+			"i2.8xlarge":  true,
+			"m1.small":    true, "m1.medium": true,
+			"m2.xlarge": true,
+			"m3.medium": true, "m3.large": true,
+			"r3.large": true, "r3.8xlarge": true}
+		series := strings.Split(instanceType, ".")
+
+		return !nonSupportedSeries[series[0]] && !nonSupportedTypes[instanceType]
 	},
 }
 


### PR DESCRIPTION
Feature done by looking for instance types that do NOT support EBS optimisation from the AWS page https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html and few extra instances I found from AWS console.

PR for https://github.com/kubernetes-incubator/kube-aws/issues/1252