### PR TITLE
cobra cmd errors use logger error instead of default std err

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ var (
 )
 
 func init() {
+	RootCmd.SetOutput(logger.Writer(logger.StdErrOutput))
 	RootCmd.PersistentFlags().BoolVarP(
 		&logger.Silent,
 		"silent",

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -17,6 +17,22 @@ var (
 	stdErrLogger     = log.New(os.Stderr, "ERROR: ", 0)
 )
 
+func StdErrOutput(b []byte) (n int, err error) {
+	if Color {
+		b = append([]byte(ColorRed), b...)
+		b = append(b, ColorNC...)
+	}
+	return os.Stderr.Write([]byte(b))
+}
+
+// io.Writer interface implementation. To use with error logs, pass StdErrOutput func:
+// Writer(StdErrOutput) <- implements io.Writer
+type Writer func(b []byte) (n int, err error)
+
+func (w Writer) Write(b []byte) (n int, err error) {
+	return w(b)
+}
+
 func Error(v ...interface{}) {
 	Log(stdErrLogger, ColorRed, v...)
 }


### PR DESCRIPTION
This is more to start a discussion. Basically I would prefer changing cobra command field `RunE` to `Run` and handle errors (using logger.Error) inside command. The reason is that cobra uses default std err for all outputs, even for help. (try `kube-aws --help 2> /dev/null`). So by overriding output (there is no option for err and out), help will be in red if `color=true` option is set.
Let me know what you think.