### PR TITLE
Consolidate kiam configuration

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -119,6 +119,11 @@ func NewDefaultCluster() *Cluster {
 			Disk:       "xvdb",
 			Filesystem: "xfs",
 		},
+		KIAMSupport: KIAMSupport{
+			Enabled:         false,
+			Image:           model.Image{Repo: "quay.io/uswitch/kiam", Tag: "v2.7", RktPullDocker: false},
+			ServerAddresses: KIAMServerAddresses{ServerAddress: "localhost:443", AgentAddress: "kiam-server:443"},
+		},
 		Kube2IamSupport: Kube2IamSupport{
 			Enabled: false,
 		},
@@ -227,7 +232,6 @@ func NewDefaultCluster() *Cluster {
 			ClusterAutoscalerImage:             model.Image{Repo: "k8s.gcr.io/cluster-autoscaler", Tag: "v1.1.0", RktPullDocker: false},
 			ClusterProportionalAutoscalerImage: model.Image{Repo: "k8s.gcr.io/cluster-proportional-autoscaler-amd64", Tag: "1.1.2", RktPullDocker: false},
 			CoreDnsImage:                       model.Image{Repo: "coredns/coredns", Tag: "1.1.3", RktPullDocker: false},
-			KIAMImage:                          model.Image{Repo: "quay.io/uswitch/kiam", Tag: "v2.6", RktPullDocker: false},
 			Kube2IAMImage:                      model.Image{Repo: "jtblin/kube2iam", Tag: "0.9.0", RktPullDocker: false},
 			KubeDnsImage:                       model.Image{Repo: "k8s.gcr.io/k8s-dns-kube-dns-amd64", Tag: "1.14.7", RktPullDocker: false},
 			KubeDnsMasqImage:                   model.Image{Repo: "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64", Tag: "1.14.7", RktPullDocker: false},
@@ -522,7 +526,6 @@ type DeploymentSettings struct {
 	ClusterAutoscalerImage             model.Image `yaml:"clusterAutoscalerImage,omitempty"`
 	ClusterProportionalAutoscalerImage model.Image `yaml:"clusterProportionalAutoscalerImage,omitempty"`
 	CoreDnsImage                       model.Image `yaml:"coreDnsImage,omitempty"`
-	KIAMImage                          model.Image `yaml:"kiamImage,omitempty"`
 	Kube2IAMImage                      model.Image `yaml:"kube2iamImage,omitempty"`
 	KubeDnsImage                       model.Image `yaml:"kubeDnsImage,omitempty"`
 	KubeDnsMasqImage                   model.Image `yaml:"kubeDnsMasqImage,omitempty"`
@@ -714,7 +717,14 @@ type EphemeralImageStorage struct {
 }
 
 type KIAMSupport struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled         bool                `yaml:"enabled"`
+	Image           model.Image         `yaml:"image,omitempty"`
+	ServerAddresses KIAMServerAddresses `yaml:"serverAddresses,omitempty"`
+}
+
+type KIAMServerAddresses struct {
+	ServerAddress string `yaml:"serverAddress,omitempty"`
+	AgentAddress  string `yaml:"agentAddress,omitempty"`
 }
 
 type Kube2IamSupport struct {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -5492,7 +5492,7 @@ write_files:
                   secretName: kiam-server-tls
             containers:
               - name: kiam
-                image: {{.KIAMImage.RepoWithTag}}
+                image: {{.Experimental.KIAMSupport.Image.RepoWithTag}}
                 imagePullPolicy: Always
                 command:
                   - /server
@@ -5518,7 +5518,7 @@ write_files:
                     - --cert=/etc/kiam/tls/server.pem
                     - --key=/etc/kiam/tls/server-key.pem
                     - --ca=/etc/kiam/tls/ca.pem
-                    - --server-address=localhost:443
+                    - --server-address={{.Experimental.KIAMSupport.ServerAddresses.ServerAddress}}
                     - --server-address-refresh=2s
                     - --timeout=5s
                   initialDelaySeconds: 10
@@ -5531,7 +5531,7 @@ write_files:
                     - --cert=/etc/kiam/tls/server.pem
                     - --key=/etc/kiam/tls/server-key.pem
                     - --ca=/etc/kiam/tls/ca.pem
-                    - --server-address=localhost:443
+                    - --server-address={{.Experimental.KIAMSupport.ServerAddresses.ServerAddress}}
                     - --server-address-refresh=2s
                     - --timeout=5s
                   initialDelaySeconds: 3
@@ -5632,7 +5632,7 @@ write_files:
               - name: kiam
                 securityContext:
                   privileged: true
-                image: {{.KIAMImage.RepoWithTag}}
+                image: {{.Experimental.KIAMSupport.Image.RepoWithTag}}
                 command:
                   - /agent
                 args:
@@ -5647,7 +5647,7 @@ write_files:
                   - --cert=/etc/kiam/tls/agent.pem
                   - --key=/etc/kiam/tls/agent-key.pem
                   - --ca=/etc/kiam/tls/ca.pem
-                  - --server-address=kiam-server:443
+                  - --server-address={{.Experimental.KIAMSupport.ServerAddresses.AgentAddress}}
                   - --prometheus-listen-addr=0.0.0.0:9620
                   - --prometheus-sync-interval=5s
                 env:

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1037,12 +1037,6 @@ worker:
 #  tag: 1.1.2
 #  rktPullDocker: false
 
-# kiam image repository to use.
-kiamImage:
-  repo: quay.io/uswitch/kiam
-  tag: v2.7
-  rktPullDocker: false
-
 # kube2iam image repository to use.
 #kube2iamImage:
 #  repo: jtblin/kube2iam
@@ -1453,6 +1447,13 @@ experimental:
   # This is intended to be used in combination with .controller.iam.role.name. See #297 for more information.
   kiamSupport:
     enabled: false
+    image: 
+      repo: quay.io/uswitch/kiam
+      tag: v2.7
+      rktPullDocker: false
+    serverAddresses:
+      serverAddress: localhost:443
+      agentAddress: kiam-server:443
 
   # When enabled this will install the kube2iam daemon set using the repo from `kube2iamImage`
   # It will also grant sts:assumeRole permission to the IAM role for controller nodes.

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -137,7 +137,9 @@ func TestMainClusterConfig(t *testing.T) {
 				Filesystem: "xfs",
 			},
 			KIAMSupport: controlplane_config.KIAMSupport{
-				Enabled: false,
+				Enabled:         false,
+				Image:           model.Image{Repo: "quay.io/uswitch/kiam", Tag: "v2.7", RktPullDocker: false},
+				ServerAddresses: controlplane_config.KIAMServerAddresses{ServerAddress: "localhost:443", AgentAddress: "kiam-server:443"},
 			},
 			Kube2IamSupport: controlplane_config.Kube2IamSupport{
 				Enabled: false,
@@ -1374,7 +1376,9 @@ worker:
 							Filesystem: "xfs",
 						},
 						KIAMSupport: controlplane_config.KIAMSupport{
-							Enabled: false,
+							Enabled:         false,
+							Image:           model.Image{Repo: "quay.io/uswitch/kiam", Tag: "v2.7", RktPullDocker: false},
+							ServerAddresses: controlplane_config.KIAMServerAddresses{ServerAddress: "localhost:443", AgentAddress: "kiam-server:443"},
 						},
 						Kube2IamSupport: controlplane_config.Kube2IamSupport{
 							Enabled: true,
@@ -1568,6 +1572,12 @@ worker:
 experimental:
   kiamSupport:
     enabled: true
+    image:
+      repo: quay.io/uswitch/kiam
+      tag: v2.6
+    serverAddresses:
+      serverAddress: localhost
+      agentAddress: kiam-server
 worker:
   nodePools:
   - name: pool1
@@ -1575,7 +1585,9 @@ worker:
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
 					expected := controlplane_config.KIAMSupport{
-						Enabled: true,
+						Enabled:         true,
+						Image:           model.Image{Repo: "quay.io/uswitch/kiam", Tag: "v2.6", RktPullDocker: false},
+						ServerAddresses: controlplane_config.KIAMServerAddresses{ServerAddress: "localhost", AgentAddress: "kiam-server"},
 					}
 
 					actual := c.Experimental
@@ -1604,7 +1616,9 @@ worker:
 				func(c *config.Config, t *testing.T) {
 					expected := controlplane_config.Experimental{
 						KIAMSupport: controlplane_config.KIAMSupport{
-							Enabled: true,
+							Enabled:         true,
+							Image:           model.Image{Repo: "quay.io/uswitch/kiam", Tag: "v2.7", RktPullDocker: false},
+							ServerAddresses: controlplane_config.KIAMServerAddresses{ServerAddress: "localhost:443", AgentAddress: "kiam-server:443"},
 						},
 					}
 					p := c.NodePools[0]


### PR DESCRIPTION
This is a consolidation of kiam parts into the kiamSupport configuration
It adds the listeners for server and agent as configurable options
The previously KIAMImage type is now underneath kiamSupport, so this is a possible breaking change to existing cluster.yaml files

Now looks like this
```
  kiamSupport:
    enabled: true
    image:
      repo: quay.io/uswitch/kiam
      tag: v2.8
    server: localhost
    agent: kiam-server
```

The original DNS health check/server settings are preserved as defaults
The kiam image is bumped to v2.8