### PR TITLE
Promote compute reservation options [Small] 

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -52,6 +52,8 @@ func NewDefaultCluster() *Cluster {
 		RotateCerts: RotateCerts{
 			Enabled: false,
 		},
+		SystemReservedResources: "",
+		KubeReservedResources:   "",
 	}
 	experimental := Experimental{
 		Admission: Admission{
@@ -582,7 +584,9 @@ type Cluster struct {
 
 // Kubelet options
 type Kubelet struct {
-	RotateCerts RotateCerts `yaml:"rotateCerts"`
+	RotateCerts             RotateCerts `yaml:"rotateCerts"`
+	SystemReservedResources string      `yaml:"systemReserved"`
+	KubeReservedResources   string      `yaml:"kubeReserved"`
 }
 
 type Experimental struct {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -397,6 +397,12 @@ coreos:
         {{if or (.Experimental.Admission.Priority.Enabled) (.Experimental.Admission.PersistentVolumeClaimResize.Enabled) -}}
         --feature-gates=PodPriority={{.Experimental.Admission.Priority.Enabled}},ExpandPersistentVolumes={{.Experimental.Admission.PersistentVolumeClaimResize.Enabled}} \
         {{end -}}\
+        {{- if .Kubelet.SystemReservedResources }}
+        --system-reserved={{ .Kubelet.SystemReservedResources }} \
+        {{- end }}
+        {{- if .Kubelet.KubeReservedResources }}
+        --kube-reserved={{ .Kubelet.KubeReservedResources }} \
+        {{- end }}
         $KUBELET_OPTS
         Restart=always
         RestartSec=10

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -164,6 +164,8 @@ func (c *ProvidedConfig) Load(main *cfg.Config) error {
 	c.Experimental.NodeDrainer = main.DeploymentSettings.Experimental.NodeDrainer
 	c.Experimental.GpuSupport = main.DeploymentSettings.Experimental.GpuSupport
 	c.Kubelet.RotateCerts = main.DeploymentSettings.Kubelet.RotateCerts
+	c.Kubelet.SystemReservedResources = main.DeploymentSettings.Kubelet.SystemReservedResources
+	c.Kubelet.KubeReservedResources = main.DeploymentSettings.Kubelet.KubeReservedResources
 
 	if c.Experimental.ClusterAutoscalerSupport.Enabled {
 		if !main.Addons.ClusterAutoscaler.Enabled {

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -470,6 +470,12 @@ coreos:
         {{- if .FeatureGates.Enabled }}
         --feature-gates="{{.FeatureGates.String}}" \
         {{- end }}
+        {{- if .Kubelet.SystemReservedResources }}
+        --system-reserved={{ .Kubelet.SystemReservedResources }} \
+        {{- end }}
+        {{- if .Kubelet.KubeReservedResources }}
+        --kube-reserved={{ .Kubelet.KubeReservedResources }} \
+        {{- end }}
         --require-kubeconfig \
         $KUBELET_OPTS
         Restart=always

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1488,6 +1488,14 @@ kubelet:
   RotateCerts:
     enabled: true
 
+  # Currently CPU, memory and storage are supported.
+  # How resources are reserved: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
+  # How to size these limits: https://kubernetes.io/blog/2016/11/visualize-kubelet-performance-with-node-dashboard/
+  # kubeReserved is used to reserve capacity for kubernetes system daemons
+  #kubeReserved: "cpu=100m,memory=100Mi,storage=1Gi"
+  # systemReserved is used to reserve capacity for OS system daemons
+  #systemReserved: "cpu=100m,memory=100Mi,storage=1Gi"
+
 # AWS Tags for cloudformation stack resources
 #stackTags:
 #  Name: "Kubernetes"


### PR DESCRIPTION
### What
I decided to PR back support to [reserve resources](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/) to kube-aws.
If you want more background, the author of a related Kops PR does a fantastic job of documenting his journey/struggle with very similar issues to ours:
https://github.com/kubernetes/kops/pull/2982

I realise this is already been possible with $KUBELET_OPTS but believe the config options important enough to warrant being promoted to first class citizens to give them more visibility alongside the other kubelet config options.

### Why
We’ve had problems with Docker daemons locking with loads of orphaned/dead containers lying around not being cleaned up - this is most definitely a docker daemon problem caused by our usage of old AMIs. 
During these investigations we noticed that some of our apps appear badly sized and doing some weird things on the hosts - things that are interfering with kube daemons and OS daemons, and could be mitigated by reserving resources.

### Notes
#### Defaults
I thought I’d check Kops to see if they have any idea about sensible defaults but it appears they just took the values in the documentation (source: the author of the kops PR) - as such, I’ve chosen to
not set any default values, outside of just mentioning the kubernetes docs ones in the cluster.yaml comments.
Please shout if you feel like kube-aws should enforce some minimal ones.

#### cgroups & enforcement
I haven’t included —kube-reserved-cgroup or —system-reserved-cgroup options since I’m unsure if they apply right now to the way kube-aws's systemd units are structure. I’ve also left out —enforce-node-allocatable as that relies on the cgroup options being set.
Please shout If you’d like me to add them. 