### PR TITLE
Bring etcd's up in parallel on new cluster / Fail-fast to update 0.10.x clusters with newer kube-aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _book
 *.pdf
 node_modules
 kube-aws
+.DS_Store

--- a/cfnstack/cfnstack.go
+++ b/cfnstack/cfnstack.go
@@ -61,18 +61,18 @@ func StackEventErrMsgs(events []*cloudformation.StackEvent) []string {
 }
 
 func NestedStackExists(cf CFInterrogator, parentStackName, stackName string) (bool, error) {
-	logger.Debugf("Testing whether nested stack '%s' is present in parent stack '%s'", stackName, parentStackName)
+	logger.Debugf("testing whether nested stack '%s' is present in parent stack '%s'", stackName, parentStackName)
 	parentExists, err := StackExists(cf, parentStackName)
 	if err != nil {
 		return false, err
 	}
 	if !parentExists {
-		logger.Debugf("Parent stack '%s' does not exist, so nested stack can not exist either", parentStackName)
+		logger.Debugf("parent stack '%s' does not exist, so nested stack can not exist either", parentStackName)
 		return false, nil
 	}
 
 	req := &cloudformation.ListStackResourcesInput{StackName: &parentStackName}
-	logger.Debugf("Calling AWS cloudformation ListStackResources for stack %s ->", parentStackName)
+	logger.Debugf("calling AWS cloudformation ListStackResources for stack %s ->", parentStackName)
 	out, err := cf.ListStackResources(req)
 	if err != nil {
 		return false, fmt.Errorf("Could not read cf stack %s: %v", parentStackName, err)
@@ -83,21 +83,21 @@ func NestedStackExists(cf CFInterrogator, parentStackName, stackName string) (bo
 	logger.Debugf("<- AWS responded with %d stack resources", len(out.StackResourceSummaries))
 	for _, resource := range out.StackResourceSummaries {
 		if *resource.LogicalResourceId == stackName {
-			logger.Debugf("Match! resource id '%s' exists", stackName)
+			logger.Debugf("match! resource id '%s' exists", stackName)
 			return true, nil
 		}
 	}
-	logger.Debugf("No match! resource id '%s' does not exist", stackName)
+	logger.Debugf("no match! resource id '%s' does not exist", stackName)
 	return false, nil
 }
 
 func StackExists(cf CFInterrogator, stackName string) (bool, error) {
-	logger.Debugf("Testing whether cf stack %s exits", stackName)
+	logger.Debugf("testing whether cf stack %s exits", stackName)
 	req := &cloudformation.ListStacksInput{}
-	logger.Debug("Calling AWS cloudformation ListStacks ->")
+	logger.Debug("calling AWS cloudformation ListStacks ->")
 	stacks, err := cf.ListStacks(req)
 	if err != nil {
-		return false, fmt.Errorf("Could not list cloudformation stacks: %v", err)
+		return false, fmt.Errorf("could not list cloudformation stacks: %v", err)
 	}
 	if stacks == nil {
 		return false, nil
@@ -105,15 +105,15 @@ func StackExists(cf CFInterrogator, stackName string) (bool, error) {
 	logger.Debugf("<- AWS Responded with %d stacks", len(stacks.StackSummaries))
 	for _, summary := range stacks.StackSummaries {
 		if *summary.StackName == stackName {
-			logger.Debugf("Found matching stack %s: %+v", *summary.StackName, *summary)
+			logger.Debugf("found matching stack %s: %+v", *summary.StackName, *summary)
 			if summary.DeletionTime == nil {
-				logger.Debugf("Stack is active - matched!")
+				logger.Debugf("stack is active - matched!")
 				return true, nil
 			} else {
-				logger.Debugf("Stack is not active, ignoring")
+				logger.Debugf("stack is not active, ignoring")
 			}
 		}
 	}
-	logger.Debugf("Found no active stacks with id %s", stackName)
+	logger.Debugf("found no active stacks with id %s", stackName)
 	return false, nil
 }

--- a/cfnstack/cfnstack.go
+++ b/cfnstack/cfnstack.go
@@ -1,10 +1,13 @@
 package cfnstack
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"strings"
+	"github.com/kubernetes-incubator/kube-aws/logger"
 )
 
 var CFN_TEMPLATE_SIZE_LIMIT = 51200
@@ -29,6 +32,11 @@ type S3ObjectPutterService interface {
 	PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error)
 }
 
+type cfInterrogator interface {
+	ListStacks(input *cloudformation.ListStacksInput) (*cloudformation.ListStacksOutput, error)
+	ListStackResources(input *cloudformation.ListStackResourcesInput) (*cloudformation.ListStackResourcesOutput, error)
+}
+
 func StackEventErrMsgs(events []*cloudformation.StackEvent) []string {
 	var errMsgs []string
 
@@ -49,4 +57,56 @@ func StackEventErrMsgs(events []*cloudformation.StackEvent) []string {
 	}
 
 	return errMsgs
+}
+
+func NestedStackExists(cf cfInterrogator, parentStackName, stackName string) (bool, error) {
+	logger.Debugf("Testing whether nested stack '%s' is present in parent stack '%s'", stackName, parentStackName)
+	parentExists, err := StackExists(cf, parentStackName)
+	if err != nil {
+		return false, err
+	}
+	if !parentExists {
+		logger.Debugf("Parent stack '%s' does not exist, so nested stack can not exist either", parentStackName)
+		return false, nil
+	}
+
+	req := &cloudformation.ListStackResourcesInput{StackName: &parentStackName}
+	logger.Debugf("Calling AWS cloudformation ListStackResources for stack %s ->", parentStackName)
+	out, err := cf.ListStackResources(req)
+	if err != nil {
+		return false, fmt.Errorf("Could not read cf stack %s: %v", parentStackName, err)
+	}
+	logger.Debugf("<- AWS responded with %d stack resources", len(out.StackResourceSummaries))
+	for _, resource := range out.StackResourceSummaries {
+		if *resource.LogicalResourceId == stackName {
+			logger.Debugf("Match! resource id '%s' exists", stackName)
+			return true, nil
+		}
+	}
+	logger.Debugf("No match! resource id '%s' does not exist", stackName)
+	return false, nil
+}
+
+func StackExists(cf cfInterrogator, stackName string) (bool, error) {
+	logger.Debugf("Testing whether cf stack %s exits", stackName)
+	req := &cloudformation.ListStacksInput{}
+	logger.Debug("Calling AWS cloudformation ListStacks ->")
+	stacks, err := cf.ListStacks(req)
+	if err != nil {
+		return false, fmt.Errorf("Could not list cloudformation stacks: %v", err)
+	}
+	logger.Debugf("<- AWS Responded with %d stacks", len(stacks.StackSummaries))
+	for _, summary := range stacks.StackSummaries {
+		if *summary.StackName == stackName {
+			logger.Debugf("Found matching stack %s: %+v", *summary.StackName, *summary)
+			if summary.DeletionTime == nil {
+				logger.Debugf("Stack is active - matched!")
+				return true, nil
+			} else {
+				logger.Debugf("Stack is not active, ignoring")
+			}
+		}
+	}
+	logger.Debugf("Found no active stacks with id %s", stackName)
+	return false, nil
 }

--- a/cfnstack/cfnstack_test.go
+++ b/cfnstack/cfnstack_test.go
@@ -1,0 +1,226 @@
+package cfnstack
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackCreationErrorMessaging(t *testing.T) {
+	events := []*cloudformation.StackEvent{
+		&cloudformation.StackEvent{
+			// Failure with all fields set
+			ResourceStatus:       aws.String("CREATE_FAILED"),
+			ResourceType:         aws.String("Computer"),
+			LogicalResourceId:    aws.String("test_comp"),
+			ResourceStatusReason: aws.String("BAD HD"),
+		},
+		&cloudformation.StackEvent{
+			// Success, should not show up
+			ResourceStatus: aws.String("SUCCESS"),
+			ResourceType:   aws.String("Computer"),
+		},
+		&cloudformation.StackEvent{
+			// Failure due to cancellation should not show up
+			ResourceStatus:       aws.String("CREATE_FAILED"),
+			ResourceType:         aws.String("Computer"),
+			ResourceStatusReason: aws.String("Resource creation cancelled"),
+		},
+		&cloudformation.StackEvent{
+			// Failure with missing fields
+			ResourceStatus: aws.String("CREATE_FAILED"),
+			ResourceType:   aws.String("Computer"),
+		},
+	}
+
+	expectedMsgs := []string{
+		"CREATE_FAILED Computer test_comp BAD HD",
+		"CREATE_FAILED Computer",
+	}
+
+	outputMsgs := StackEventErrMsgs(events)
+	if len(expectedMsgs) != len(outputMsgs) {
+		t.Errorf("Expected %d stack error messages, got %d\n",
+			len(expectedMsgs),
+			len(StackEventErrMsgs(events)))
+	}
+
+	for i := range expectedMsgs {
+		if expectedMsgs[i] != outputMsgs[i] {
+			t.Errorf("Expected `%s`, got `%s`\n", expectedMsgs[i], outputMsgs[i])
+		}
+	}
+}
+
+// DummyCFInterrogator is used to prevent calls to AWS - always returns empty results.
+type DummyCFInterrogator struct {
+	ListStacksResult          *cloudformation.ListStacksOutput
+	ListStacksResourcesResult *cloudformation.ListStackResourcesOutput
+}
+
+func (cf DummyCFInterrogator) ListStacks(input *cloudformation.ListStacksInput) (*cloudformation.ListStacksOutput, error) {
+	return cf.ListStacksResult, nil
+}
+
+func (cf DummyCFInterrogator) ListStackResources(input *cloudformation.ListStackResourcesInput) (*cloudformation.ListStackResourcesOutput, error) {
+	return cf.ListStacksResourcesResult, nil
+}
+
+func TestStackDoesNotExist(t *testing.T) {
+	var stackname = "the-little-stack-on-the-prairie"
+	var summary = cloudformation.StackSummary{
+		StackName:    &stackname,
+		DeletionTime: nil,
+	}
+	cf := DummyCFInterrogator{
+		ListStacksResult: &cloudformation.ListStacksOutput{
+			StackSummaries: []*cloudformation.StackSummary{&summary},
+		},
+	}
+	exists, err := StackExists(cf, "Elvis")
+
+	require.NoError(t, err, "Looking up aws stacks should not fail when mocked out")
+	assert.False(t, exists, "StackExists thinks that the stack 'Elvis' exists, even though no stacks were returned")
+}
+
+func TestStackDoesExist(t *testing.T) {
+	var stackname = "the-little-stack-on-the-prairie"
+	var summary = cloudformation.StackSummary{
+		StackName:    &stackname,
+		DeletionTime: nil,
+	}
+	cf := DummyCFInterrogator{
+		ListStacksResult: &cloudformation.ListStacksOutput{
+			StackSummaries: []*cloudformation.StackSummary{&summary},
+		},
+	}
+
+	exists, err := StackExists(cf, "the-little-stack-on-the-prairie")
+	require.NoError(t, err, "Looking up aws stacks should not fail when mocked out")
+	assert.True(t, exists, "The response includes a non deleted stack and so we should get a positive exists")
+}
+
+func TestStackExistsIgnoresDeletedStacks(t *testing.T) {
+	testtime := time.Now()
+	var stackname = "the-little-stack-on-the-prairie"
+	var summary = cloudformation.StackSummary{
+		StackName:    &stackname,
+		DeletionTime: &testtime,
+	}
+	cf := DummyCFInterrogator{
+		ListStacksResult: &cloudformation.ListStacksOutput{
+			StackSummaries: []*cloudformation.StackSummary{&summary, &summary},
+		},
+	}
+
+	exists, err := StackExists(cf, "the-little-stack-on-the-prairie")
+	require.NoError(t, err, "Looking up aws stacks should not fail when mocked out")
+	assert.False(t, exists, "We should only return true if an active/not-deleted stack is found")
+}
+
+func TestStackExistsWithMultipleNameMatches(t *testing.T) {
+	testtime := time.Now()
+	var stackname = "the-little-stack-on-the-prairie"
+	var deletedstack = cloudformation.StackSummary{
+		StackName:    &stackname,
+		DeletionTime: &testtime,
+	}
+	var activestack = cloudformation.StackSummary{
+		StackName:    &stackname,
+		DeletionTime: nil,
+	}
+	cf := DummyCFInterrogator{
+		ListStacksResult: &cloudformation.ListStacksOutput{
+			StackSummaries: []*cloudformation.StackSummary{&deletedstack, &deletedstack, &deletedstack, &activestack},
+		},
+	}
+
+	exists, err := StackExists(cf, "the-little-stack-on-the-prairie")
+	require.NoError(t, err, "Looking up aws stacks should not fail when mocked out")
+	assert.True(t, exists, "An active stack exists and so we should be returning true")
+}
+
+func TestANestedCantExistWithoutItsParent(t *testing.T) {
+	var stackname = "the-little-stack-on-the-prairie"
+	var summary = cloudformation.StackSummary{
+		StackName:    &stackname,
+		DeletionTime: nil,
+	}
+	cf := DummyCFInterrogator{
+		ListStacksResult: &cloudformation.ListStacksOutput{
+			StackSummaries: []*cloudformation.StackSummary{&summary},
+		},
+	}
+
+	exists, err := NestedStackExists(cf, "Elvis", "the-little-stack-on-the-prairie")
+	require.NoError(t, err, "NestedStackExists should not return an error when the parent does not exist")
+	assert.False(t, exists, "A stack can't exist as a nested stack unless the parent exists and has a resource reference to it")
+}
+
+func TestANestedStackHasToBeAResourceOfItsParent(t *testing.T) {
+	var stackname = "the-little-stack-on-the-prairie"
+	var parentname = "root-stack"
+	var summary = cloudformation.StackSummary{
+		StackName:    &stackname,
+		DeletionTime: nil,
+	}
+	var parentsummary = cloudformation.StackSummary{
+		StackName:    &parentname,
+		DeletionTime: nil,
+	}
+	cf := DummyCFInterrogator{
+		ListStacksResult: &cloudformation.ListStacksOutput{
+			StackSummaries: []*cloudformation.StackSummary{&parentsummary, &summary},
+		},
+		ListStacksResourcesResult: &cloudformation.ListStackResourcesOutput{
+			StackResourceSummaries: []*cloudformation.StackResourceSummary{},
+		},
+	}
+
+	exists, err := NestedStackExists(cf, "root-stack", "the-little-stack-on-the-prairie")
+	require.NoError(t, err, "NestedStackExists should not return an error")
+	assert.False(t, exists, "Although the parent exists it does not include a stack resource with our name (even if a top level stack shares the same name as us)")
+}
+
+func TestNestedStackExists(t *testing.T) {
+	var stackname = "the-little-stack-on-the-prairie"
+	var parentname = "root-stack"
+	var summary = cloudformation.StackSummary{
+		StackName:    &stackname,
+		DeletionTime: nil,
+	}
+	var parentsummary = cloudformation.StackSummary{
+		StackName:    &parentname,
+		DeletionTime: nil,
+	}
+	var parentresources = cloudformation.StackResourceSummary{
+		LogicalResourceId: &stackname,
+	}
+	cf := DummyCFInterrogator{
+		ListStacksResult: &cloudformation.ListStacksOutput{
+			StackSummaries: []*cloudformation.StackSummary{&parentsummary, &summary},
+		},
+		ListStacksResourcesResult: &cloudformation.ListStackResourcesOutput{
+			StackResourceSummaries: []*cloudformation.StackResourceSummary{&parentresources},
+		},
+	}
+
+	exists, err := NestedStackExists(cf, "root-stack", "the-little-stack-on-the-prairie")
+	require.NoError(t, err, "NestedStackExists should not return an error")
+	assert.True(t, exists, "A stack that is as a resource within its parent stack exists")
+}
+
+func TestEmptyCFInterrogator(t *testing.T) {
+	cf := DummyCFInterrogator{}
+
+	exists, err := StackExists(cf, "a-new-hope")
+	require.NoError(t, err, "StackExists should not return an error when the ListStacks response is empty")
+	assert.False(t, exists, "How does a stack exist in an empty set?")
+	exists, err = NestedStackExists(cf, "no-hope", "a-new-hope")
+	require.NoError(t, err, "NestedStackExists should not return an error when the ListStackResources response is empty")
+	assert.False(t, exists, "How does a stack exist in an empty set?")
+}

--- a/core/controlplane/cluster/cluster_test.go
+++ b/core/controlplane/cluster/cluster_test.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"github.com/kubernetes-incubator/kube-aws/cfnstack"
 	"github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	"github.com/kubernetes-incubator/kube-aws/model"
 	"github.com/kubernetes-incubator/kube-aws/test/helper"
@@ -514,52 +513,6 @@ stackTags:
 			assert.NoError(t, err)
 			assert.Equal(t, "test-bucket/foo/bar/kube-aws/clusters/test-cluster-name/exported/stacks/control-plane/userdata-controller", path, "UserDataController.S3Prefix returned an unexpected value")
 		})
-	}
-}
-
-func TestStackCreationErrorMessaging(t *testing.T) {
-	events := []*cloudformation.StackEvent{
-		&cloudformation.StackEvent{
-			// Failure with all fields set
-			ResourceStatus:       aws.String("CREATE_FAILED"),
-			ResourceType:         aws.String("Computer"),
-			LogicalResourceId:    aws.String("test_comp"),
-			ResourceStatusReason: aws.String("BAD HD"),
-		},
-		&cloudformation.StackEvent{
-			// Success, should not show up
-			ResourceStatus: aws.String("SUCCESS"),
-			ResourceType:   aws.String("Computer"),
-		},
-		&cloudformation.StackEvent{
-			// Failure due to cancellation should not show up
-			ResourceStatus:       aws.String("CREATE_FAILED"),
-			ResourceType:         aws.String("Computer"),
-			ResourceStatusReason: aws.String("Resource creation cancelled"),
-		},
-		&cloudformation.StackEvent{
-			// Failure with missing fields
-			ResourceStatus: aws.String("CREATE_FAILED"),
-			ResourceType:   aws.String("Computer"),
-		},
-	}
-
-	expectedMsgs := []string{
-		"CREATE_FAILED Computer test_comp BAD HD",
-		"CREATE_FAILED Computer",
-	}
-
-	outputMsgs := cfnstack.StackEventErrMsgs(events)
-	if len(expectedMsgs) != len(outputMsgs) {
-		t.Errorf("Expected %d stack error messages, got %d\n",
-			len(expectedMsgs),
-			len(cfnstack.StackEventErrMsgs(events)))
-	}
-
-	for i := range expectedMsgs {
-		if expectedMsgs[i] != outputMsgs[i] {
-			t.Errorf("Expected `%s`, got `%s`\n", expectedMsgs[i], outputMsgs[i])
-		}
 	}
 }
 

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-yaml/yaml"
 	"github.com/kubernetes-incubator/kube-aws/cfnresource"
+	"github.com/kubernetes-incubator/kube-aws/cfnstack"
 	"github.com/kubernetes-incubator/kube-aws/coreos/amiregistry"
 	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
 	"github.com/kubernetes-incubator/kube-aws/logger"
@@ -574,6 +575,7 @@ type Cluster struct {
 	HostedZoneID           string              `yaml:"hostedZoneId,omitempty"`
 	PluginConfigs          model.PluginConfigs `yaml:"kubeAwsPlugins,omitempty"`
 	ProvidedEncryptService EncryptService
+	ProvidedCFInterrogator cfnstack.CFInterrogator
 	// SSHAccessAllowedSourceCIDRs is network ranges of sources you'd like SSH accesses to be allowed from, in CIDR notation
 	SSHAccessAllowedSourceCIDRs model.CIDRRanges       `yaml:"sshAccessAllowedSourceCIDRs,omitempty"`
 	CustomSettings              map[string]interface{} `yaml:"customSettings,omitempty"`

--- a/core/etcd/cluster/cluster.go
+++ b/core/etcd/cluster/cluster.go
@@ -116,7 +116,9 @@ func (c *ClusterRef) validateExistingVPCState(ec2Svc ec2Service) error {
 func NewCluster(cfgRef *config.Cluster, opts config.StackTemplateOptions, plugins []*pluginmodel.Plugin, session *session.Session) (*Cluster, error) {
 	cfg := &config.Cluster{}
 	*cfg = *cfgRef
-	cf := cloudformation.New(session)
+	if cfg.ProvidedCFInterrogator == nil {
+		cfg.ProvidedCFInterrogator = cloudformation.New(session)
+	}
 
 	// Import all the managed subnets from the network stack
 	var err error
@@ -159,7 +161,7 @@ func NewCluster(cfgRef *config.Cluster, opts config.StackTemplateOptions, plugin
 	c.StackConfig.Etcd.CustomSystemdUnits = append(c.StackConfig.Etcd.CustomSystemdUnits, extraEtcd.SystemdUnits...)
 	c.StackConfig.Etcd.CustomFiles = append(c.StackConfig.Etcd.CustomFiles, extraEtcd.Files...)
 	c.StackConfig.Etcd.IAMConfig.Policy.Statements = append(c.StackConfig.Etcd.IAMConfig.Policy.Statements, extraEtcd.IAMPolicyStatements...)
-	c.StackConfig.Etcd.StackExists, err = cfnstack.NestedStackExists(cf, c.ClusterName, naming.FromStackToCfnResource(c.Etcd.LogicalName()))
+	c.StackConfig.Etcd.StackExists, err = cfnstack.NestedStackExists(cfg.ProvidedCFInterrogator, c.ClusterName, naming.FromStackToCfnResource(c.Etcd.LogicalName()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to check for existence of etcd cloud-formation stack: %v", err)
 	}

--- a/core/etcd/cluster/cluster.go
+++ b/core/etcd/cluster/cluster.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/kubernetes-incubator/kube-aws/cfnstack"
@@ -115,6 +116,7 @@ func (c *ClusterRef) validateExistingVPCState(ec2Svc ec2Service) error {
 func NewCluster(cfgRef *config.Cluster, opts config.StackTemplateOptions, plugins []*pluginmodel.Plugin, session *session.Session) (*Cluster, error) {
 	cfg := &config.Cluster{}
 	*cfg = *cfgRef
+	cf := cloudformation.New(session)
 
 	// Import all the managed subnets from the network stack
 	var err error
@@ -157,6 +159,10 @@ func NewCluster(cfgRef *config.Cluster, opts config.StackTemplateOptions, plugin
 	c.StackConfig.Etcd.CustomSystemdUnits = append(c.StackConfig.Etcd.CustomSystemdUnits, extraEtcd.SystemdUnits...)
 	c.StackConfig.Etcd.CustomFiles = append(c.StackConfig.Etcd.CustomFiles, extraEtcd.Files...)
 	c.StackConfig.Etcd.IAMConfig.Policy.Statements = append(c.StackConfig.Etcd.IAMConfig.Policy.Statements, extraEtcd.IAMPolicyStatements...)
+	c.StackConfig.Etcd.StackExists, err = cfnstack.NestedStackExists(cf, c.ClusterName, naming.FromStackToCfnResource(c.Etcd.LogicalName()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for existence of etcd cloud-formation stack: %v", err)
+	}
 
 	c.assets, err = c.buildAssets()
 

--- a/core/etcd/config/templates/stack-template.json
+++ b/core/etcd/config/templates/stack-template.json
@@ -451,7 +451,7 @@
       },
       "DependsOn": [
         {{if $etcdInstance.DependencyExists}}{{$etcdInstance.DependencyRef}},{{end}}
-        {{if $etcdIndex}}"{{$.Etcd.LogicalName}}{{sub $etcdIndex 1}}",{{end}}
+        {{if $.Etcd.StackExists}}{{if $etcdIndex}}"{{$.Etcd.LogicalName}}{{sub $etcdIndex 1}}",{{end}}{{end}}
         {{if $etcdInstance.EIPManaged}}
         "{{$etcdInstance.EIPLogicalName}}",
         {{end}}

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -471,6 +471,29 @@ func (c clusterImpl) tags() map[string]string {
 func (c clusterImpl) Update(targets OperationTargets) (string, error) {
 	cfSvc := cloudformation.New(c.session)
 
+	exists, err := cfnstack.StackExists(cfSvc, c.controlPlane.ClusterName)
+	if err != nil {
+		logger.Errorf("please check your AWS Credentials/Permissions")
+		return "", fmt.Errorf("can't lookup AWS CloudFormation stacks")
+	}
+	if !exists {
+		logger.Errorf("you can only 'update' clusters with a matching cloudformation stack")
+		return "", fmt.Errorf("missing cluster root stack %s", c.controlPlane.ClusterName)
+	}
+
+	exists, err = cfnstack.NestedStackExists(cfSvc, c.controlPlane.ClusterName, naming.FromStackToCfnResource(c.etcd.Etcd.LogicalName()))
+	if err != nil {
+		logger.Errorf("please check your AWS Credentials/Permissions")
+		return "", fmt.Errorf("can't lookup AWS CloudFormation stacks")
+	}
+	// fail fast if it looks like we are trying to update a legacy cluster.
+	if !exists {
+		logger.Errorf("the %s stack must exist in order to be able to update your cluster.", naming.FromStackToCfnResource(c.etcd.Etcd.LogicalName()))
+		logger.Error("we're sorry, but kube-aws can not presently upgrade your cluster to the new release with a separate ETCD Cloudformation stack.")
+		logger.Error("please update using the previous 0.9.x branch or consider backing up, destroying and recreating to upgrade.")
+		return "", fmt.Errorf("update not supported for clusters without a separate etcd cloudformation stack")
+	}
+
 	assets, err := c.generateAssets(c.operationTargetsFromUserInput([]OperationTargets{targets}))
 	if err != nil {
 		return "", err

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -490,7 +490,7 @@ func (c clusterImpl) Update(targets OperationTargets) (string, error) {
 	if !exists {
 		logger.Errorf("the %s stack must exist in order to be able to update your cluster.", naming.FromStackToCfnResource(c.etcd.Etcd.LogicalName()))
 		logger.Error("we're sorry, but kube-aws can not presently upgrade your cluster to the new release with a separate ETCD Cloudformation stack.")
-		logger.Error("please update using the previous 0.9.x branch or consider backing up, destroying and recreating to upgrade.")
+		logger.Error("please consider backing up, destroying and recreating to upgrade.")
 		return "", fmt.Errorf("update not supported for clusters without a separate etcd cloudformation stack")
 	}
 

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 
 	"github.com/go-yaml/yaml"
+	"github.com/kubernetes-incubator/kube-aws/cfnstack"
 	controlplane "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	nodepool "github.com/kubernetes-incubator/kube-aws/core/nodepool/config"
 	"github.com/kubernetes-incubator/kube-aws/model"
@@ -185,12 +186,13 @@ func failFastWhenUnknownKeysFound(vs []unknownKeyValidation) error {
 	return nil
 }
 
-func ConfigFromBytesWithEncryptService(data []byte, plugins []*pluginmodel.Plugin, encryptService controlplane.EncryptService) (*Config, error) {
+func ConfigFromBytesWithMocks(data []byte, plugins []*pluginmodel.Plugin, encryptService controlplane.EncryptService, cf cfnstack.CFInterrogator) (*Config, error) {
 	c, err := ConfigFromBytes(data, plugins)
 	if err != nil {
 		return nil, err
 	}
 	c.ProvidedEncryptService = encryptService
+	c.ProvidedCFInterrogator = cf
 
 	// Uses the same encrypt service for node pools for consistency
 	for _, p := range c.NodePools {

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -186,7 +186,7 @@ func failFastWhenUnknownKeysFound(vs []unknownKeyValidation) error {
 	return nil
 }
 
-func ConfigFromBytesWithMocks(data []byte, plugins []*pluginmodel.Plugin, encryptService controlplane.EncryptService, cf cfnstack.CFInterrogator) (*Config, error) {
+func ConfigFromBytesWithStubs(data []byte, plugins []*pluginmodel.Plugin, encryptService controlplane.EncryptService, cf cfnstack.CFInterrogator) (*Config, error) {
 	c, err := ConfigFromBytes(data, plugins)
 	if err != nil {
 		return nil, err

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -19,6 +19,7 @@ type Etcd struct {
 	SecurityGroupIds   []string     `yaml:"securityGroupIds"`
 	Snapshot           EtcdSnapshot `yaml:"snapshot,omitempty"`
 	Subnets            Subnets      `yaml:"subnets,omitempty"`
+	StackExists        bool
 	UnknownKeys        `yaml:",inline"`
 }
 
@@ -62,6 +63,7 @@ func NewDefaultEtcd() Etcd {
 			Type: "gp2",
 			IOPS: 0,
 		},
+		StackExists: false,
 	}
 }
 func (i Etcd) LogicalName() string {

--- a/test/helper/cfn.go
+++ b/test/helper/cfn.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
@@ -9,6 +10,20 @@ type DummyCloudformationService struct {
 	ExpectedTags []*cloudformation.Tag
 	StackEvents  []*cloudformation.StackEvent
 	StackStatus  string
+}
+
+// DummyCFInterrogator is used to prevent calls to AWS - always returns empty results.
+type DummyCFInterrogator struct {
+	ListStacksResult          *cloudformation.ListStacksOutput
+	ListStacksResourcesResult *cloudformation.ListStackResourcesOutput
+}
+
+func (cf DummyCFInterrogator) ListStacks(input *cloudformation.ListStacksInput) (*cloudformation.ListStacksOutput, error) {
+	return cf.ListStacksResult, nil
+}
+
+func (cf DummyCFInterrogator) ListStackResources(input *cloudformation.ListStackResourcesInput) (*cloudformation.ListStackResourcesOutput, error) {
+	return cf.ListStacksResourcesResult, nil
 }
 
 func (cfSvc *DummyCloudformationService) CreateStack(req *cloudformation.CreateStackInput) (*cloudformation.CreateStackOutput, error) {

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3475,7 +3475,7 @@ worker:
 			configBytes := validCase.configYaml
 			// TODO Allow including plugins in test data?
 			plugins := []*pluginmodel.Plugin{}
-			providedConfig, err := config.ConfigFromBytesWithEncryptService([]byte(configBytes), plugins, helper.DummyEncryptService{})
+			providedConfig, err := config.ConfigFromBytesWithMocks([]byte(configBytes), plugins, helper.DummyEncryptService{}, helper.DummyCFInterrogator{})
 			if err != nil {
 				t.Errorf("failed to parse config %s: %v", configBytes, err)
 				t.FailNow()

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3475,7 +3475,7 @@ worker:
 			configBytes := validCase.configYaml
 			// TODO Allow including plugins in test data?
 			plugins := []*pluginmodel.Plugin{}
-			providedConfig, err := config.ConfigFromBytesWithMocks([]byte(configBytes), plugins, helper.DummyEncryptService{}, helper.DummyCFInterrogator{})
+			providedConfig, err := config.ConfigFromBytesWithStubs([]byte(configBytes), plugins, helper.DummyEncryptService{}, helper.DummyCFInterrogator{})
 			if err != nil {
 				t.Errorf("failed to parse config %s: %v", configBytes, err)
 				t.FailNow()

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -495,7 +495,7 @@ spec:
 				}
 
 				configBytes := validCase.clusterYaml
-				providedConfig, err := config.ConfigFromBytesWithEncryptService([]byte(configBytes), plugins, helper.DummyEncryptService{})
+				providedConfig, err := config.ConfigFromBytesWithMocks([]byte(configBytes), plugins, helper.DummyEncryptService{}, helper.DummyCFInterrogator{})
 				if err != nil {
 					t.Errorf("failed to parse config %s: %v", configBytes, err)
 					t.FailNow()

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -495,7 +495,7 @@ spec:
 				}
 
 				configBytes := validCase.clusterYaml
-				providedConfig, err := config.ConfigFromBytesWithMocks([]byte(configBytes), plugins, helper.DummyEncryptService{}, helper.DummyCFInterrogator{})
+				providedConfig, err := config.ConfigFromBytesWithStubs([]byte(configBytes), plugins, helper.DummyEncryptService{}, helper.DummyCFInterrogator{})
 				if err != nil {
 					t.Errorf("failed to parse config %s: %v", configBytes, err)
 					t.FailNow()


### PR DESCRIPTION
Checks for the existence of the etcd stack and will bring the etcd servers up in parallel if the stack does not exist, i.e. it is a fresh cluster (or upgrade to nested stacks).  

Behavoir and benefits: -

* Performs lookup of cloudformation stacks before rendering stack templates - cusomises the resource dependencies based the on this result.
* New clusters start up quicker (servers start in parallel)
* Cluster updates still go through etcd one node at-a-time
* Removes the need to concoct a cfn-signal on the early nodes before etcd quorum and healthy cluster is achieved.


