### PR TITLE
Implement 'apply' command and deprecate 'up' and 'update'

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -75,7 +75,7 @@ func runCmdApply(_ *cobra.Command, _ []string) error {
 	}
 
 	successMsg :=
-		`Success! Your AWS resources are being applied:
+		`Success! Your AWS resources are being provisioned:
 %s
 `
 	logger.Infof(successMsg, info)

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/kubernetes-incubator/kube-aws/core/root"
+	"github.com/kubernetes-incubator/kube-aws/logger"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdApply = &cobra.Command{
+		Use:          "apply",
+		Short:        "Create or Update your cluster",
+		Long:         ``,
+		RunE:         runCmdApply,
+		SilenceUsage: true,
+	}
+
+	applyOpts = struct {
+		awsDebug, prettyPrint, skipWait, export bool
+		force                                   bool
+		targets                                 []string
+	}{}
+)
+
+func init() {
+	RootCmd.AddCommand(cmdApply)
+	cmdApply.Flags().BoolVar(&applyOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
+	cmdApply.Flags().BoolVar(&applyOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdApply.Flags().BoolVar(&applyOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
+	cmdApply.Flags().BoolVar(&applyOpts.skipWait, "skip-wait", false, "Don't wait the resources finish")
+	cmdApply.Flags().BoolVar(&applyOpts.force, "force", false, "Don't ask for confirmation")
+	cmdApply.Flags().StringSliceVar(&applyOpts.targets, "targets", root.AllOperationTargetsAsStringSlice(), "Update nothing but specified sub-stacks.  Specify `all` or any combination of `etcd`, `control-plane`, and node pool names. Defaults to `all`")
+}
+
+func runCmdApply(_ *cobra.Command, _ []string) error {
+	if !applyOpts.force && !applyConfirmation() {
+		logger.Info("Operation cancelled")
+		return nil
+	}
+
+	opts := root.NewOptions(applyOpts.prettyPrint, applyOpts.skipWait)
+
+	cluster, err := root.ClusterFromFile(configPath, opts, applyOpts.awsDebug)
+	if err != nil {
+		return fmt.Errorf("failed to read cluster config: %v", err)
+	}
+
+	targets := root.OperationTargetsFromStringSlice(applyOpts.targets)
+
+	if _, err := cluster.ValidateStack(targets); err != nil {
+		return err
+	}
+
+	if applyOpts.export {
+		if err := cluster.Export(); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	err = cluster.Apply(targets)
+	if err != nil {
+		return fmt.Errorf("error updating cluster: %v", err)
+	}
+
+	info, err := cluster.Info()
+	if err != nil {
+		return fmt.Errorf("failed fetching cluster info: %v", err)
+	}
+
+	successMsg :=
+		`Success! Your AWS resources are being applied:
+%s
+`
+	logger.Infof(successMsg, info)
+	return nil
+}
+
+func applyConfirmation() bool {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("This operation will create/update the cluster. Are you sure? [y,n]: ")
+	text, _ := reader.ReadString('\n')
+	text = strings.TrimSuffix(strings.ToLower(text), "\n")
+
+	return text == "y" || text == "yes"
+}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/kubernetes-incubator/kube-aws/core/root"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/spf13/cobra"
 )
@@ -13,19 +16,58 @@ var (
 		RunE:         runCmdUp,
 		SilenceUsage: true,
 	}
+
+	upOpts = struct {
+		awsDebug, export, prettyPrint, skipWait bool
+	}{}
 )
 
 func init() {
 	RootCmd.AddCommand(cmdUp)
-	cmdUp.Flags().BoolVar(&applyOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
-	cmdUp.Flags().BoolVar(&applyOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
-	cmdUp.Flags().BoolVar(&applyOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
-	cmdUp.Flags().BoolVar(&applyOpts.skipWait, "skip-wait", false, "Don't wait for the cluster components be ready")
+	cmdUp.Flags().BoolVar(&upOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
+	cmdUp.Flags().BoolVar(&upOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
+	cmdUp.Flags().BoolVar(&upOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdUp.Flags().BoolVar(&upOpts.skipWait, "skip-wait", false, "Don't wait for the cluster components be ready")
 }
 
-func runCmdUp(cobra *cobra.Command, command []string) error {
+func runCmdUp(_ *cobra.Command, _ []string) error {
 	logger.Warnf("WARNING! kube-aws 'up' command is deprecated and will be removed in future versions")
 	logger.Warnf("Please use 'apply' to create your cluster")
 
-	return runCmdApply(cobra, command)
+	opts := root.NewOptions(upOpts.prettyPrint, upOpts.skipWait)
+
+	cluster, err := root.ClusterFromFile(configPath, opts, upOpts.awsDebug)
+	if err != nil {
+		return fmt.Errorf("failed to initialize cluster driver: %v", err)
+	}
+
+	if _, err := cluster.ValidateStack(); err != nil {
+		return fmt.Errorf("error validating cluster: %v", err)
+	}
+
+	if upOpts.export {
+		if err := cluster.Export(); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	logger.Info("Creating AWS resources. Please wait. It may take a few minutes.")
+	if err := cluster.LegacyCreate(); err != nil {
+		return fmt.Errorf("error creating cluster: %v", err)
+	}
+
+	info, err := cluster.Info()
+	if err != nil {
+		return fmt.Errorf("failed fetching cluster info: %v", err)
+	}
+
+	successMsg :=
+		`Success! Your AWS resources have been created:
+%s
+The containers that power your cluster are now being downloaded.
+You should be able to access the Kubernetes API once the containers finish downloading.
+`
+	logger.Infof(successMsg, info)
+	return nil
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/kubernetes-incubator/kube-aws/core/root"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/spf13/cobra"
 )
@@ -11,61 +8,24 @@ import (
 var (
 	cmdUp = &cobra.Command{
 		Use:          "up",
-		Short:        "Create a new Kubernetes cluster",
+		Short:        "DEPRECATED: Create a new Kubernetes cluster",
 		Long:         ``,
 		RunE:         runCmdUp,
 		SilenceUsage: true,
 	}
-
-	upOpts = struct {
-		awsDebug, export, prettyPrint, skipWait bool
-	}{}
 )
 
 func init() {
 	RootCmd.AddCommand(cmdUp)
-	cmdUp.Flags().BoolVar(&upOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
-	cmdUp.Flags().BoolVar(&upOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
-	cmdUp.Flags().BoolVar(&upOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
-	cmdUp.Flags().BoolVar(&upOpts.skipWait, "skip-wait", false, "Don't wait for the cluster components be ready")
+	cmdUp.Flags().BoolVar(&applyOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
+	cmdUp.Flags().BoolVar(&applyOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
+	cmdUp.Flags().BoolVar(&applyOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdUp.Flags().BoolVar(&applyOpts.skipWait, "skip-wait", false, "Don't wait for the cluster components be ready")
 }
 
-func runCmdUp(_ *cobra.Command, _ []string) error {
-	opts := root.NewOptions(upOpts.prettyPrint, upOpts.skipWait)
+func runCmdUp(cobra *cobra.Command, command []string) error {
+	logger.Warnf("WARNING! kube-aws 'up' command is deprecated and will be removed in future versions")
+	logger.Warnf("Please use 'apply' to create your cluster")
 
-	cluster, err := root.ClusterFromFile(configPath, opts, upOpts.awsDebug)
-	if err != nil {
-		return fmt.Errorf("failed to initialize cluster driver: %v", err)
-	}
-
-	if _, err := cluster.ValidateStack(); err != nil {
-		return fmt.Errorf("error validating cluster: %v", err)
-	}
-
-	if upOpts.export {
-		if err := cluster.Export(); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	logger.Info("Creating AWS resources. Please wait. It may take a few minutes.")
-	if err := cluster.Create(); err != nil {
-		return fmt.Errorf("error creating cluster: %v", err)
-	}
-
-	info, err := cluster.Info()
-	if err != nil {
-		return fmt.Errorf("failed fetching cluster info: %v", err)
-	}
-
-	successMsg :=
-		`Success! Your AWS resources have been created:
-%s
-The containers that power your cluster are now being downloaded.
-
-You should be able to access the Kubernetes API once the containers finish downloading.
-`
-	logger.Infof(successMsg, info)
-	return nil
+	return runCmdApply(cobra, command)
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,86 +1,33 @@
 package cmd
 
 import (
-	"fmt"
-
-	"bufio"
 	"github.com/kubernetes-incubator/kube-aws/core/root"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 var (
 	cmdUpdate = &cobra.Command{
 		Use:          "update",
-		Short:        "Update an existing Kubernetes cluster",
+		Short:        "DEPRECATED: Update an existing Kubernetes cluster",
 		Long:         ``,
 		RunE:         runCmdUpdate,
 		SilenceUsage: true,
 	}
-
-	updateOpts = struct {
-		awsDebug, prettyPrint, skipWait bool
-		force                           bool
-		targets                         []string
-	}{}
 )
 
 func init() {
 	RootCmd.AddCommand(cmdUpdate)
-	cmdUpdate.Flags().BoolVar(&updateOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
-	cmdUpdate.Flags().BoolVar(&updateOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
-	cmdUpdate.Flags().BoolVar(&updateOpts.skipWait, "skip-wait", false, "Don't wait the resources finish")
-	cmdUpdate.Flags().BoolVar(&updateOpts.force, "force", false, "Don't ask for confirmation")
-	cmdUpdate.Flags().StringSliceVar(&updateOpts.targets, "targets", root.AllOperationTargetsAsStringSlice(), "Update nothing but specified sub-stacks.  Specify `all` or any combination of `etcd`, `control-plane`, and node pool names. Defaults to `all`")
+	cmdUpdate.Flags().BoolVar(&applyOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdUpdate.Flags().BoolVar(&applyOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
+	cmdUpdate.Flags().BoolVar(&applyOpts.skipWait, "skip-wait", false, "Don't wait the resources finish")
+	cmdUpdate.Flags().BoolVar(&applyOpts.force, "force", false, "Don't ask for confirmation")
+	cmdUpdate.Flags().StringSliceVar(&applyOpts.targets, "targets", root.AllOperationTargetsAsStringSlice(), "Update nothing but specified sub-stacks.  Specify `all` or any combination of `etcd`, `control-plane`, and node pool names. Defaults to `all`")
 }
 
-func runCmdUpdate(_ *cobra.Command, _ []string) error {
-	if !updateOpts.force && !updateConfirmation() {
-		logger.Info("Operation cancelled")
-		return nil
-	}
+func runCmdUpdate(cobra *cobra.Command, command []string) error {
+	logger.Warnf("WARNING! kube-aws 'update' command is deprecated and will be removed in future versions")
+	logger.Warnf("Please use 'apply' to update your cluster")
 
-	opts := root.NewOptions(updateOpts.prettyPrint, updateOpts.skipWait)
-
-	cluster, err := root.ClusterFromFile(configPath, opts, updateOpts.awsDebug)
-	if err != nil {
-		return fmt.Errorf("failed to read cluster config: %v", err)
-	}
-
-	targets := root.OperationTargetsFromStringSlice(updateOpts.targets)
-
-	if _, err := cluster.ValidateStack(targets); err != nil {
-		return err
-	}
-
-	report, err := cluster.Update(targets)
-	if err != nil {
-		return fmt.Errorf("error updating cluster: %v", err)
-	}
-	if report != "" {
-		logger.Infof("Update stack: %s\n", report)
-	}
-
-	info, err := cluster.Info()
-	if err != nil {
-		return fmt.Errorf("failed fetching cluster info: %v", err)
-	}
-
-	successMsg :=
-		`Success! Your AWS resources are being updated:
-%s
-`
-	logger.Infof(successMsg, info)
-	return nil
-}
-
-func updateConfirmation() bool {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Print("This operation will update the cluster. Are you sure? [y,n]: ")
-	text, _ := reader.ReadString('\n')
-	text = strings.TrimSuffix(strings.ToLower(text), "\n")
-
-	return text == "y" || text == "yes"
+	return runCmdApply(cobra, command)
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,6 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+
+	"bufio"
+	"os"
+	"strings"
+
 	"github.com/kubernetes-incubator/kube-aws/core/root"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/spf13/cobra"
@@ -14,20 +20,71 @@ var (
 		RunE:         runCmdUpdate,
 		SilenceUsage: true,
 	}
+
+	updateOpts = struct {
+		awsDebug, prettyPrint, skipWait bool
+		force                           bool
+		targets                         []string
+	}{}
 )
 
 func init() {
 	RootCmd.AddCommand(cmdUpdate)
-	cmdUpdate.Flags().BoolVar(&applyOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
-	cmdUpdate.Flags().BoolVar(&applyOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
-	cmdUpdate.Flags().BoolVar(&applyOpts.skipWait, "skip-wait", false, "Don't wait the resources finish")
-	cmdUpdate.Flags().BoolVar(&applyOpts.force, "force", false, "Don't ask for confirmation")
-	cmdUpdate.Flags().StringSliceVar(&applyOpts.targets, "targets", root.AllOperationTargetsAsStringSlice(), "Update nothing but specified sub-stacks.  Specify `all` or any combination of `etcd`, `control-plane`, and node pool names. Defaults to `all`")
+	cmdUpdate.Flags().BoolVar(&updateOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdUpdate.Flags().BoolVar(&updateOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
+	cmdUpdate.Flags().BoolVar(&updateOpts.skipWait, "skip-wait", false, "Don't wait the resources finish")
+	cmdUpdate.Flags().BoolVar(&updateOpts.force, "force", false, "Don't ask for confirmation")
+	cmdUpdate.Flags().StringSliceVar(&updateOpts.targets, "targets", root.AllOperationTargetsAsStringSlice(), "Update nothing but specified sub-stacks.  Specify `all` or any combination of `etcd`, `control-plane`, and node pool names. Defaults to `all`")
 }
 
-func runCmdUpdate(cobra *cobra.Command, command []string) error {
+func runCmdUpdate(_ *cobra.Command, _ []string) error {
 	logger.Warnf("WARNING! kube-aws 'update' command is deprecated and will be removed in future versions")
 	logger.Warnf("Please use 'apply' to update your cluster")
 
-	return runCmdApply(cobra, command)
+	if !updateOpts.force && !updateConfirmation() {
+		logger.Info("Operation cancelled")
+		return nil
+	}
+
+	opts := root.NewOptions(updateOpts.prettyPrint, updateOpts.skipWait)
+
+	cluster, err := root.ClusterFromFile(configPath, opts, updateOpts.awsDebug)
+	if err != nil {
+		return fmt.Errorf("failed to read cluster config: %v", err)
+	}
+
+	targets := root.OperationTargetsFromStringSlice(updateOpts.targets)
+
+	if _, err := cluster.ValidateStack(targets); err != nil {
+		return err
+	}
+
+	report, err := cluster.LegacyUpdate(targets)
+	if err != nil {
+		return fmt.Errorf("error updating cluster: %v", err)
+	}
+	if report != "" {
+		logger.Infof("Update stack: %s\n", report)
+	}
+
+	info, err := cluster.Info()
+	if err != nil {
+		return fmt.Errorf("failed fetching cluster info: %v", err)
+	}
+
+	successMsg :=
+		`Success! Your AWS resources are being updated:
+%s
+`
+	logger.Infof(successMsg, info)
+	return nil
+}
+
+func updateConfirmation() bool {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("This operation will update the cluster. Are you sure? [y,n]: ")
+	text, _ := reader.ReadString('\n')
+	text = strings.TrimSuffix(strings.ToLower(text), "\n")
+
+	return text == "y" || text == "yes"
 }

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -471,8 +471,8 @@ func (c clusterImpl) Apply(targets OperationTargets) error {
 
 	exists, err := cfnstack.StackExists(cfSvc, c.controlPlane.ClusterName)
 	if err != nil {
-		logger.Errorf("please check your AWS Credentials/Permissions")
-		return fmt.Errorf("can't lookup AWS CloudFormation stacks")
+		logger.Errorf("please check your AWS credentials/permissions")
+		return fmt.Errorf("can't lookup AWS CloudFormation stacks: %s", err)
 	}
 
 	if exists {
@@ -492,8 +492,8 @@ func (c clusterImpl) update(cfSvc *cloudformation.CloudFormation, targets Operat
 
 	exists, err := cfnstack.NestedStackExists(cfSvc, c.controlPlane.ClusterName, naming.FromStackToCfnResource(c.etcd.Etcd.LogicalName()))
 	if err != nil {
-		logger.Errorf("please check your AWS Credentials/Permissions")
-		return "", fmt.Errorf("can't lookup AWS CloudFormation stacks")
+		logger.Errorf("please check your AWS credentials/permissions")
+		return "", fmt.Errorf("can't lookup AWS CloudFormation stacks: %s", err)
 	}
 	// fail fast if it looks like we are trying to update a legacy cluster.
 	if !exists {

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -109,9 +109,11 @@ func (c clusterImpl) EstimateCost() ([]string, error) {
 type Cluster interface {
 	Apply(OperationTargets) error
 	Assets() (cfnstack.Assets, error)
+	LegacyCreate() error
 	Export() error
 	EstimateCost() ([]string, error)
 	Info() (*Info, error)
+	LegacyUpdate(OperationTargets) (string, error)
 	ValidateStack(...OperationTargets) (string, error)
 	ValidateTemplates() error
 	ControlPlane() *controlplane.Cluster
@@ -250,6 +252,12 @@ func (c clusterImpl) operationTargetsFromUserInput(opts []OperationTargets) Oper
 		targets = c.allOperationTargets()
 	}
 	return targets
+}
+
+// remove with legacy up command
+func (c clusterImpl) LegacyCreate() error {
+	cfSvc := cloudformation.New(c.session)
+	return c.create(cfSvc)
 }
 
 func (c clusterImpl) create(cfSvc *cloudformation.CloudFormation) error {
@@ -486,6 +494,12 @@ func (c clusterImpl) Apply(targets OperationTargets) error {
 		return nil
 	}
 	return c.create(cfSvc)
+}
+
+// remove with legacy up command
+func (c clusterImpl) LegacyUpdate(targets OperationTargets) (string, error) {
+	cfSvc := cloudformation.New(c.session)
+	return c.update(cfSvc, targets)
 }
 
 func (c clusterImpl) update(cfSvc *cloudformation.CloudFormation, targets OperationTargets) (string, error) {


### PR DESCRIPTION
Make integration with CI/CD automation tools simpler by having a single 'apply' command that handles the correct cloud formation create or update depending on whether the cluster stacks exists or not.

This change adds an apply command and puts a deprecation message on 'up' and 'update' which then proceed to do an 'apply'.  This is to allow a period of backwards compatibility for people that have existing automations around 'up' and 'update' so they can have a notice period to change over to apply.