### PR TITLE
Break dependency on etcd from the nodepools

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1869,6 +1869,7 @@
     },
     {{end}}
     {{end}}
+    {{if not .Kubernetes.Networking.SelfHosting.Enabled }}
     {{range $index, $etcdInstance := $.EtcdNodes}}
     {{if $etcdInstance.EIPManaged}}
     "{{$etcdInstance.EIPLogicalName}}": {
@@ -1883,6 +1884,7 @@
       "Value": {{$etcdInstance.NetworkInterfacePrivateIPRef}},
       "Export": { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$etcdInstance.NetworkInterfacePrivateIPLogicalName}}" }}
     },
+    {{end}}
     {{end}}
     {{end}}
     {{ if not .Controller.IAMConfig.InstanceProfile.Arn }}

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -1,11 +1,11 @@
-{{define "Metadata"}}
+{{define "Metadata" -}}
 {
   "AWS::CloudFormation::Init" : {
     "configSets" : {
-      "etcd-client": [ "etcd-client-env" ]{{ if .AwsEnvironment.Enabled }},
-      "aws-environment": [ "aws-environment-env" ]{{end}}
+      {{ if not .Kubernetes.Networking.SelfHosting.Enabled }}"etcd-client": [ "etcd-client-env" ]{{if .AwsEnvironment.Enabled}},{{end}}{{end}}
+      {{ if .AwsEnvironment.Enabled }}"aws-environment": [ "aws-environment-env" ]{{end}}
     },
-    {{ if .AwsEnvironment.Enabled }}
+    {{ if .AwsEnvironment.Enabled -}}
     "aws-environment-env" : {
       "commands": {
          "write-environment": {
@@ -18,8 +18,9 @@
           }
         }
       }
-    },
-    {{end}}
+    }{{ if not .Kubernetes.Networking.SelfHosting.Enabled }},{{end}}
+    {{end -}}
+    {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
     "etcd-client-env": {
       "files" : {
         "/var/run/coreos/etcd-environment": {
@@ -35,6 +36,7 @@
         }
       }
     }
+    {{end}}
   }
 }
 {{end}}
@@ -107,8 +109,9 @@
           {{end}}
         ]
       }
-    },
+    }{{ if or (not .Kubernetes.Networking.SelfHosting.Enabled) .AwsEnvironment.Enabled }},
     "Metadata": {{template "Metadata" .}}
+    {{- end }}
   },
 {{end}}
 {{define "AutoScaling"}}
@@ -206,8 +209,9 @@
           "PauseTime": "PT2M"
           {{end}}
         }
-      },
+      }{{ if or (not .Kubernetes.Networking.SelfHosting.Enabled) .AwsEnvironment.Enabled }},
       "Metadata": {{template "Metadata" .}}
+      {{- end }}
     },
     {{if .NodeDrainer.Enabled }}
     "{{.LogicalName}}NodeDrainerLH" : {


### PR DESCRIPTION
This change is against the 0.10.x branch, not master, working towards an intended point release of 0.10.x with work to smooth the migration from etcds in the control-plane stack to their own stack in the 0.11.x release.

Remove etcd ENI/EIP outputs from the control plane stack and etcd-environment metadata section on the nodepools if Kubernetes.Networking.SelfHosting is Enabled.

This is not ready for a 0.10.x release - I expect a few more changes will be required.