### PR TITLE
Add branch to build version when not a tagged release

### DIFF
--- a/build
+++ b/build
@@ -3,10 +3,13 @@ set -euo pipefail
 
 COMMIT=$(git rev-parse HEAD)
 TAG=$(git describe --exact-match --abbrev=0 --tags "${COMMIT}" 2> /dev/null || true)
+BRANCH=$(git branch | grep \* | cut -d ' ' -f2 || true)
 OUTPUT_PATH=${OUTPUT_PATH:-"bin/kube-aws"}
+VERSION=""
 
 if [ -z "$TAG" ]; then
-	VERSION=$COMMIT
+        [[ -n "$BRANCH" ]] && VERSION="${BRANCH}/"
+	VERSION="${VERSION}${COMMIT:0:8}"
 else
 	VERSION=$TAG
 fi


### PR DESCRIPTION
When doing development/testing of kube-aws the inclusion of the branch in the kube-aws version will be a great help in quickly identifying the binary you are working with.  Now that we display the kube-aws version in the motd this also helps us confirm the geneology of an existing running cluster.

Tag releases unchange - this is only added for untagged developement builds.