### PR TITLE
0.10.x migration preparation release

### DIFF
--- a/build
+++ b/build
@@ -3,10 +3,13 @@ set -euo pipefail
 
 COMMIT=$(git rev-parse HEAD)
 TAG=$(git describe --exact-match --abbrev=0 --tags "${COMMIT}" 2> /dev/null || true)
+BRANCH=$(git branch | grep \* | cut -d ' ' -f2 || true)
 OUTPUT_PATH=${OUTPUT_PATH:-"bin/kube-aws"}
+VERSION=""
 
 if [ -z "$TAG" ]; then
-	VERSION=$COMMIT
+        [[ -n "$BRANCH" ]] && VERSION="${BRANCH}/"
+	VERSION="${VERSION}${COMMIT:0:8}"
 else
 	VERSION=$TAG
 fi

--- a/cfnstack/ec2.go
+++ b/cfnstack/ec2.go
@@ -1,0 +1,9 @@
+package cfnstack
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type EC2Interrogator interface {
+	DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+}

--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -168,6 +168,9 @@ func NewCluster(cfg *config.Cluster, opts config.StackTemplateOptions, plugins [
 	c.StackConfig.Etcd.CustomSystemdUnits = append(c.StackConfig.Etcd.CustomSystemdUnits, extraEtcd.SystemdUnits...)
 	c.StackConfig.Etcd.CustomFiles = append(c.StackConfig.Etcd.CustomFiles, extraEtcd.Files...)
 	c.StackConfig.Etcd.IAMConfig.Policy.Statements = append(c.StackConfig.Etcd.IAMConfig.Policy.Statements, extraEtcd.IAMPolicyStatements...)
+	if !c.StackConfig.Kubernetes.Networking.SelfHosting.Enabled {
+		fmt.Printf("\nWARNING: You will not be able to upgrade your cluster to future kube-aws releases (0.11+) without changing your cluster network settings.\nPlease consider updating your cluster with Kubernetes.Networking.SelfHosting enabled to allow updates (the networking update does incure some minor cluster downtime/disruption as it rolls out so please do read the docs in the default cluster.yaml)\n\n")
+	}
 	if err = c.lookupMissingEtcdSubnetCIDRs(); err != nil {
 		return nil, fmt.Errorf("Failed to lookup subnets: %v", err)
 	}

--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -400,7 +400,7 @@ func (c *ClusterRef) lookupMissingEtcdSubnetCIDRs() error {
 			continue
 		}
 		if subnet.ID == "" {
-			return nil
+			continue
 		}
 		dsi := &ec2.DescribeSubnetsInput{
 			SubnetIds: []*string{

--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -400,7 +400,7 @@ func (c *ClusterRef) lookupMissingEtcdSubnetCIDRs() error {
 			continue
 		}
 		if subnet.ID == "" {
-			return fmt.Errorf("Subnet %s does not have an ID so can't lookup cidr", subnet.Name)
+			return nil
 		}
 		dsi := &ec2.DescribeSubnetsInput{
 			SubnetIds: []*string{

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/kubernetes-incubator/kube-aws/cfnresource"
+	"github.com/kubernetes-incubator/kube-aws/cfnstack"
 	"github.com/kubernetes-incubator/kube-aws/coreos/amiregistry"
 	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
 	"github.com/kubernetes-incubator/kube-aws/model"
@@ -549,20 +550,21 @@ type FlannelSettings struct {
 
 // Cluster is the container of all the configurable parameters of a kube-aws cluster, customizable via cluster.yaml
 type Cluster struct {
-	KubeClusterSettings    `yaml:",inline"`
-	DeploymentSettings     `yaml:",inline"`
-	DefaultWorkerSettings  `yaml:",inline"`
-	ControllerSettings     `yaml:",inline"`
-	EtcdSettings           `yaml:",inline"`
-	FlannelSettings        `yaml:",inline"`
-	AdminAPIEndpointName   string              `yaml:"adminAPIEndpointName,omitempty"`
-	ServiceCIDR            string              `yaml:"serviceCIDR,omitempty"`
-	RecordSetTTL           int                 `yaml:"recordSetTTL,omitempty"`
-	TLSCADurationDays      int                 `yaml:"tlsCADurationDays,omitempty"`
-	TLSCertDurationDays    int                 `yaml:"tlsCertDurationDays,omitempty"`
-	HostedZoneID           string              `yaml:"hostedZoneId,omitempty"`
-	PluginConfigs          model.PluginConfigs `yaml:"kubeAwsPlugins,omitempty"`
-	ProvidedEncryptService EncryptService
+	KubeClusterSettings     `yaml:",inline"`
+	DeploymentSettings      `yaml:",inline"`
+	DefaultWorkerSettings   `yaml:",inline"`
+	ControllerSettings      `yaml:",inline"`
+	EtcdSettings            `yaml:",inline"`
+	FlannelSettings         `yaml:",inline"`
+	AdminAPIEndpointName    string              `yaml:"adminAPIEndpointName,omitempty"`
+	ServiceCIDR             string              `yaml:"serviceCIDR,omitempty"`
+	RecordSetTTL            int                 `yaml:"recordSetTTL,omitempty"`
+	TLSCADurationDays       int                 `yaml:"tlsCADurationDays,omitempty"`
+	TLSCertDurationDays     int                 `yaml:"tlsCertDurationDays,omitempty"`
+	HostedZoneID            string              `yaml:"hostedZoneId,omitempty"`
+	PluginConfigs           model.PluginConfigs `yaml:"kubeAwsPlugins,omitempty"`
+	ProvidedEncryptService  EncryptService
+	ProvidedEC2Interrogator cfnstack.EC2Interrogator
 	// SSHAccessAllowedSourceCIDRs is network ranges of sources you'd like SSH accesses to be allowed from, in CIDR notation
 	SSHAccessAllowedSourceCIDRs model.CIDRRanges       `yaml:"sshAccessAllowedSourceCIDRs,omitempty"`
 	CustomSettings              map[string]interface{} `yaml:"customSettings,omitempty"`

--- a/core/controlplane/config/templates/cloud-config-etcd
+++ b/core/controlplane/config/templates/cloud-config-etcd
@@ -709,7 +709,7 @@ write_files:
 
       ETCD_INITIAL_CLUSTER_STATE=new
       ETCD_DATA_DIR=/var/lib/etcd2
-      ETCD_LISTEN_CLIENT_URLS=https://$private_ip:2379
+      ETCD_LISTEN_CLIENT_URLS=https://0.0.0.0:2379
       ETCD_ADVERTISE_CLIENT_URLS=https://$advertised_hostname:2379
       ETCD_LISTEN_PEER_URLS=https://$private_ip:2380
       ETCD_INITIAL_ADVERTISE_PEER_URLS=https://$advertised_hostname:2380" >> /var/run/coreos/etcd-environment

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1593,6 +1593,14 @@
             "ToPort": 22
           },
           {{end -}}
+          {{ range $_, $etcdSubnet := .Etcd.Subnets -}}
+          {
+            "CidrIp": "{{ $etcdSubnet.InstanceCIDR }}",
+            "FromPort": 2379,
+            "IpProtocol": "tcp",
+            "ToPort": 2379
+          },
+          {{ end -}}
           {
             "CidrIp": "0.0.0.0/0",
             "FromPort": 3,
@@ -1869,6 +1877,7 @@
     },
     {{end}}
     {{end}}
+    {{if not .Kubernetes.Networking.SelfHosting.Enabled }}
     {{range $index, $etcdInstance := $.EtcdNodes}}
     {{if $etcdInstance.EIPManaged}}
     "{{$etcdInstance.EIPLogicalName}}": {
@@ -1883,6 +1892,7 @@
       "Value": {{$etcdInstance.NetworkInterfacePrivateIPRef}},
       "Export": { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$etcdInstance.NetworkInterfacePrivateIPLogicalName}}" }}
     },
+    {{end}}
     {{end}}
     {{end}}
     {{ if not .Controller.IAMConfig.InstanceProfile.Arn }}

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -1,11 +1,11 @@
-{{define "Metadata"}}
+{{define "Metadata" -}}
 {
   "AWS::CloudFormation::Init" : {
     "configSets" : {
-      "etcd-client": [ "etcd-client-env" ]{{ if .AwsEnvironment.Enabled }},
-      "aws-environment": [ "aws-environment-env" ]{{end}}
+      {{ if not .Kubernetes.Networking.SelfHosting.Enabled }}"etcd-client": [ "etcd-client-env" ]{{if .AwsEnvironment.Enabled}},{{end}}{{end}}
+      {{ if .AwsEnvironment.Enabled }}"aws-environment": [ "aws-environment-env" ]{{end}}
     },
-    {{ if .AwsEnvironment.Enabled }}
+    {{ if .AwsEnvironment.Enabled -}}
     "aws-environment-env" : {
       "commands": {
          "write-environment": {
@@ -18,8 +18,9 @@
           }
         }
       }
-    },
-    {{end}}
+    }{{ if not .Kubernetes.Networking.SelfHosting.Enabled }},{{end}}
+    {{end -}}
+    {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
     "etcd-client-env": {
       "files" : {
         "/var/run/coreos/etcd-environment": {
@@ -35,6 +36,7 @@
         }
       }
     }
+    {{end}}
   }
 }
 {{end}}
@@ -107,8 +109,9 @@
           {{end}}
         ]
       }
-    },
+    }{{ if or (not .Kubernetes.Networking.SelfHosting.Enabled) .AwsEnvironment.Enabled }},
     "Metadata": {{template "Metadata" .}}
+    {{- end }}
   },
 {{end}}
 {{define "AutoScaling"}}
@@ -206,8 +209,9 @@
           "PauseTime": "PT2M"
           {{end}}
         }
-      },
+      }{{ if or (not .Kubernetes.Networking.SelfHosting.Enabled) .AwsEnvironment.Enabled }},
       "Metadata": {{template "Metadata" .}}
+      {{- end }}
     },
     {{if .NodeDrainer.Enabled }}
     "{{.LogicalName}}NodeDrainerLH" : {

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/kubernetes-incubator/kube-aws/cfnstack"
 	controlplane "github.com/kubernetes-incubator/kube-aws/core/controlplane/config"
 	nodepool "github.com/kubernetes-incubator/kube-aws/core/nodepool/config"
 	"github.com/kubernetes-incubator/kube-aws/model"
@@ -172,12 +173,13 @@ func failFastWhenUnknownKeysFound(vs []unknownKeyValidation) error {
 	return nil
 }
 
-func ConfigFromBytesWithEncryptService(data []byte, plugins []*pluginmodel.Plugin, encryptService controlplane.EncryptService) (*Config, error) {
+func ConfigFromBytesWithStubs(data []byte, plugins []*pluginmodel.Plugin, encryptService controlplane.EncryptService, ec2 cfnstack.EC2Interrogator) (*Config, error) {
 	c, err := ConfigFromBytes(data, plugins)
 	if err != nil {
 		return nil, err
 	}
 	c.ProvidedEncryptService = encryptService
+	c.ProvidedEC2Interrogator = ec2
 
 	// Uses the same encrypt service for node pools for consistency
 	for _, p := range c.NodePools {

--- a/model/derived/etcd_node.go
+++ b/model/derived/etcd_node.go
@@ -2,6 +2,7 @@ package derived
 
 import (
 	"fmt"
+
 	"github.com/kubernetes-incubator/kube-aws/model"
 )
 

--- a/test/helper/cfn.go
+++ b/test/helper/cfn.go
@@ -2,13 +2,23 @@ package helper
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 type DummyCloudformationService struct {
 	ExpectedTags []*cloudformation.Tag
 	StackEvents  []*cloudformation.StackEvent
 	StackStatus  string
+}
+
+type DummyEC2Interrogator struct {
+	DescribeSubnetsOutput *ec2.DescribeSubnetsOutput
+}
+
+func (ec DummyEC2Interrogator) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	return ec.DescribeSubnetsOutput, nil
 }
 
 func (cfSvc *DummyCloudformationService) CreateStack(req *cloudformation.CreateStackInput) (*cloudformation.CreateStackOutput, error) {

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3418,7 +3418,7 @@ worker:
 			configBytes := validCase.configYaml
 			// TODO Allow including plugins in test data?
 			plugins := []*pluginmodel.Plugin{}
-			providedConfig, err := config.ConfigFromBytesWithEncryptService([]byte(configBytes), plugins, helper.DummyEncryptService{})
+			providedConfig, err := config.ConfigFromBytesWithStubs([]byte(configBytes), plugins, helper.DummyEncryptService{}, helper.DummyEC2Interrogator{})
 			if err != nil {
 				t.Errorf("failed to parse config %s: %v", configBytes, err)
 				t.FailNow()

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -471,7 +471,7 @@ spec:
 				}
 
 				configBytes := validCase.clusterYaml
-				providedConfig, err := config.ConfigFromBytesWithEncryptService([]byte(configBytes), plugins, helper.DummyEncryptService{})
+				providedConfig, err := config.ConfigFromBytesWithStubs([]byte(configBytes), plugins, helper.DummyEncryptService{}, helper.DummyEC2Interrogator{})
 				if err != nil {
 					t.Errorf("failed to parse config %s: %v", configBytes, err)
 					t.FailNow()


### PR DESCRIPTION
This update to the 0.10.x branch needs to be run in order to allow an in place upgrade from kube-aws 0.10.x to the new 0.11.x release with separate 'network' and 'etcd' stacks.

The following changes have been made:
* When Kubernetes.Networking.SelfHosting is enabled the references to outputs from the control plane stack for etcd ip addresses are removed (they are not needed)
* A Warning is printed when you perform an upgrade without SelfHosting enabled that you won't be able to update to future releases.
* I lookup the CIDRs for the subnets containing the etcd servers and relax the incoming rule to allow connections to the etcds on port 2379 from any servers in the same subnets.  This is needed because the etcds in the new stack need to be able to connect across to the existing etcds.  Once migrated, the new migrated etcd have the same tight rules as before.
* I allow etcds to listen on all of their interfaces - which is needed so I can find them and connect to them directly without faffing around trying to work out if they have an attached ENI or not.  Again, this behaviour is only adopted for the migration and new migrated etcds will have more restrictive networking.

These changes combined break the cloudformation dependencies that prevent migration with the 0.11.x release and give access to the existing etcds so that we can migrate their contents.  A PR for the 11.x base will add the features it requires to manage the upgrade.