### PR TITLE
Better identification of nodes

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -5664,8 +5664,13 @@ write_files:
               key: CriticalAddonsOnly
             hostNetwork: true
             dnsPolicy: ClusterFirstWithHostNet
-            nodeSelector:
-              kubernetes.io/role: node
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: node-role.kubernetes.io/master
+                      operator: DoesNotExist
             volumes:
               - name: ssl-certs
                 hostPath:

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1561,10 +1561,8 @@ write_files:
                 requiredDuringSchedulingIgnoredDuringExecution:
                   nodeSelectorTerms:
                   - matchExpressions:
-                    - key: kubernetes.io/role
-                      operator: In
-                      values:
-                        - node
+                    - key: node-role.kubernetes.io/master
+                      operator: DoesNotExist
             hostNetwork: true
             serviceAccountName: canal
             tolerations:

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -481,7 +481,7 @@ coreos:
         --container-runtime={{.ContainerRuntime}} \
         --rkt-path=/usr/bin/rkt \
         --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
-        --node-labels=kubernetes.io/role={{ toLabel .NodePoolName }}{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
+        --node-labels=node-role.kubernetes.io/node="",kubernetes.io/role={{ toLabel .NodePoolName }}{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-node=true \
         {{if .Taints}}--register-with-taints={{.Taints.String}}\
         {{end}}--allow-privileged=true \

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -481,7 +481,7 @@ coreos:
         --container-runtime={{.ContainerRuntime}} \
         --rkt-path=/usr/bin/rkt \
         --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
-        --node-labels=node-role.kubernetes.io/node="",kubernetes.io/role={{ toLabel .NodePoolName }}{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
+        --node-labels=kubernetes.io/role=node,node-role.kubernetes.io/node="",node-role.kubernetes.io/{{ toLabel .NodePoolName }}=""{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-node=true \
         {{if .Taints}}--register-with-taints={{.Taints.String}}\
         {{end}}--allow-privileged=true \

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -481,7 +481,7 @@ coreos:
         --container-runtime={{.ContainerRuntime}} \
         --rkt-path=/usr/bin/rkt \
         --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
-        --node-labels=kubernetes.io/role=node{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
+        --node-labels=kubernetes.io/role={{ toLabel .NodePoolName }}{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-node=true \
         {{if .Taints}}--register-with-taints={{.Taints.String}}\
         {{end}}--allow-privileged=true \


### PR DESCRIPTION
A small change to make it easier to quickly differentiate different nodepools of kube-aws clusters.   Presently we label all nodes with the role of 'node', which we can see when we call kubectl get nodes: -

```
NAME                                         STATUS    ROLES     AGE       VERSION
ip-10-29-12-160.us-west-2.compute.internal   Ready     node      2d        v1.10.4
ip-10-29-12-162.us-west-2.compute.internal   Ready     master    1d        v1.10.4
ip-10-29-16-25.us-west-2.compute.internal    Ready     node      15d       v1.10.4
ip-10-29-20-142.us-west-2.compute.internal   Ready     master    1d        v1.10.4
ip-10-29-21-214.us-west-2.compute.internal   Ready     node      15d       v1.10.4
ip-10-29-28-38.us-west-2.compute.internal    Ready     node      15d       v1.10.4
ip-10-29-31-77.us-west-2.compute.internal    Ready     master    1d        v1.10.4
```

This change will change the role to match the name of the nodepool to which the node belongs: -

```
NAME                                         STATUS    ROLES        AGE       VERSION
ip-10-29-10-108.us-west-2.compute.internal   Ready     nodepool-a   38m       v1.10.4
ip-10-29-15-109.us-west-2.compute.internal   Ready     master       49m       v1.10.4
ip-10-29-18-199.us-west-2.compute.internal   Ready     master       46m       v1.10.4
ip-10-29-18-221.us-west-2.compute.internal   Ready     nodepool-b   37m       v1.10.4
ip-10-29-26-132.us-west-2.compute.internal   Ready     master       43m       v1.10.4
ip-10-29-26-33.us-west-2.compute.internal    Ready     nodepool-c   38m       v1.10.4
```

This is a simple and convenient way of identifying to which of our nodepools that a kubernetes server belongs to.  The targetting of canal-node daemonset has been changed so instead of targetting all nodes that have role of 'node' it now targets all nodes which do not have the master label.