### PR TITLE
0.11.x Extend CustomFiles to be able to render go templates

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -674,7 +674,7 @@ write_files:
   - path: {{$w.Path}}
     permissions: {{$w.PermissionsString}}
     encoding: gzip+base64
-    content: {{$w.GzippedBase64Content}}
+    content: {{$w.RenderGzippedBase64Content .}}
   {{- end }}
 {{- end }}
   - path: /etc/modules-load.d/ip_vs.conf

--- a/core/etcd/config/templates/cloud-config-etcd
+++ b/core/etcd/config/templates/cloud-config-etcd
@@ -471,7 +471,7 @@ write_files:
   - path: {{$w.Path}}
     permissions: {{$w.PermissionsString}}
     encoding: gzip+base64
-    content: {{$w.GzippedBase64Content}}
+    content: {{$w.RenderGzippedBase64Content .}}
   {{- end }}
 {{- end }}
 {{if and (.AmazonSsmAgent.Enabled) (ne .AmazonSsmAgent.DownloadUrl "")}}

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -789,7 +789,7 @@ write_files:
   - path: {{$w.Path}}
     permissions: {{$w.PermissionsString}}
     encoding: gzip+base64
-    content: {{$w.GzippedBase64Content}}
+    content: {{$w.RenderGzippedBase64Content .}}
   {{- end }}
 {{- end }}
   - path: /etc/modules-load.d/ip_vs.conf

--- a/model/custom_file.go
+++ b/model/custom_file.go
@@ -2,14 +2,18 @@ package model
 
 import (
 	"fmt"
+	"strings"
+	"text/template"
 
 	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
+	"github.com/kubernetes-incubator/kube-aws/logger"
 )
 
 type CustomFile struct {
 	Path        string `yaml:"path"`
 	Permissions uint   `yaml:"permissions"`
-	Content     string `yaml:"content"`
+	Content     string `yaml:"content,omitempty"`
+	Template    string `yaml:"template,omitempty"`
 	UnknownKeys `yaml:",inline"`
 }
 
@@ -24,4 +28,43 @@ func (c CustomFile) GzippedBase64Content() string {
 		return ""
 	}
 	return out
+}
+
+func (c CustomFile) RenderContent(ctx interface{}) (string, error) {
+	var err error
+	if c.customFileHasTemplate() {
+		c.Content, err = c.renderTemplate(ctx)
+		if err != nil {
+			return "", err
+		}
+	}
+	return c.Content, nil
+}
+
+func (c CustomFile) RenderGzippedBase64Content(ctx interface{}) (string, error) {
+	content, err := c.RenderContent(ctx)
+	if err != nil {
+		return "", err
+	}
+	return gzipcompressor.CompressString(content)
+}
+
+func (c CustomFile) customFileHasTemplate() bool {
+	return c.Template != ""
+}
+
+func (c CustomFile) renderTemplate(ctx interface{}) (string, error) {
+	var buf strings.Builder
+
+	tmpl, err := template.New("").Parse(c.Template)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse CustomFile template %s: %v", c.Path, err)
+	}
+	err = tmpl.Execute(&buf, ctx)
+	if err != nil {
+		return "", fmt.Errorf("error rendering CustomFile template %s: %v", c.Path, err)
+	}
+
+	logger.Debugf("successfully rendered CustomFile template %s", c.Path)
+	return buf.String(), nil
 }

--- a/model/custom_file_test.go
+++ b/model/custom_file_test.go
@@ -1,0 +1,101 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/go-yaml/yaml"
+	"github.com/stretchr/testify/assert"
+)
+
+type TestContextFruit struct {
+	ChoiceOfFruit string
+}
+
+type TestContextAnimal struct {
+	IsADog      bool
+	Name        string
+	YearOfBirth string
+}
+
+var (
+	// simple plain file case
+	customFileContent = `path: /tmp/testfile
+permissions: 0777
+content: hello world
+`
+
+	// customfile contains a template
+	customFileTemplate = `path: /tmp/testfile
+permissions: 0777
+template: I love {{ .ChoiceOfFruit }}
+`
+)
+
+func TestCustomFileRendersContent(t *testing.T) {
+	cfile := CustomFile{}
+	err := yaml.Unmarshal([]byte(customFileContent), &cfile)
+	assert.NoError(t, err)
+	output, err := cfile.RenderContent(TestContextFruit{})
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world", output)
+}
+
+func TestCustomFileRenderWithEncoding(t *testing.T) {
+	helloWorldEncoded := `H4sIAAAAAAAA/8pIzcnJVyjPL8pJAQQAAP//hRFKDQsAAAA=`
+
+	cfile := CustomFile{}
+	err := yaml.Unmarshal([]byte(customFileContent), &cfile)
+	assert.NoError(t, err)
+	output, err := cfile.RenderGzippedBase64Content(TestContextFruit{})
+	assert.NoError(t, err)
+	assert.Equal(t, helloWorldEncoded, output)
+}
+
+func TestCustomFileRenderTemplate(t *testing.T) {
+	cfile := CustomFile{}
+	err := yaml.Unmarshal([]byte(customFileTemplate), &cfile)
+	assert.NoError(t, err)
+	output, err := cfile.RenderContent(TestContextFruit{ChoiceOfFruit: "apples"})
+	assert.NoError(t, err)
+	assert.Equal(t, "I love apples", output)
+}
+
+func TestCustomFileRenderTemplateWithEncoding(t *testing.T) {
+	iLoveApplesEncoded := `H4sIAAAAAAAA//JUyMkvS1VILCjISS0GBAAA//+rYX5CDQAAAA==`
+
+	cfile := CustomFile{}
+	err := yaml.Unmarshal([]byte(customFileTemplate), &cfile)
+	assert.NoError(t, err)
+	output, err := cfile.RenderGzippedBase64Content(TestContextFruit{ChoiceOfFruit: "apples"})
+	assert.NoError(t, err)
+	assert.Equal(t, iLoveApplesEncoded, output)
+}
+
+func TestCustomBadTemplate(t *testing.T) {
+	badTemplate := `path: /tmp/testfile
+permissions: 0777
+template: I love {{ if .ChoiceOfFruit }}`
+
+	cfile := CustomFile{}
+	err := yaml.Unmarshal([]byte(badTemplate), &cfile)
+	assert.NoError(t, err)
+	output, err := cfile.RenderContent(TestContextAnimal{})
+	assert.Error(t, err)
+	assert.Equal(t, "", output)
+}
+
+func TestDualCustomFileContent(t *testing.T) {
+	// customFile contains both content AND template
+	cf := `path: /tmp/testfile
+permissions: 0777
+content: I love bananas
+template: I love {{ .ChoiceOfFruit }}
+`
+
+	cfile := CustomFile{}
+	err := yaml.Unmarshal([]byte(cf), &cfile)
+	assert.NoError(t, err)
+	output, err := cfile.RenderContent(TestContextFruit{ChoiceOfFruit: "apples"})
+	assert.NoError(t, err)
+	assert.Equal(t, "I love apples", output)
+}


### PR DESCRIPTION
We want to remove our customisations to kube-aws from our forked branch and would like to move some of those customisations from the kube-aws code into our cluster.yaml files.  Some of these customisations need to lookup cluster configuration information and so need to be templates rather than simple strings.

This change extends to the CustomFile type to add a template field and adds a new Render function that will automatically render the template if it is present or render our the simple content as before (plus some tests of these operations).