### PR TITLE
fix(plugin): Fix unsupported type error while parsing helm chart values

### DIFF
--- a/model/plugin.go
+++ b/model/plugin.go
@@ -1,5 +1,10 @@
 package model
 
+import (
+	"fmt"
+	"reflect"
+)
+
 type PluginConfigs map[string]PluginConfig
 
 type PluginConfig struct {
@@ -8,3 +13,37 @@ type PluginConfig struct {
 }
 
 type Values map[string]interface{}
+
+func (v *Values) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	m := map[interface{}]interface{}{}
+	if err := unmarshal(&m); err != nil {
+		return err
+	}
+	r, err := ensureMapKeysAreStrings(m)
+	if err != nil {
+		return err
+	}
+	*v = r
+	return nil
+}
+
+func ensureMapKeysAreStrings(m map[interface{}]interface{}) (map[string]interface{}, error) {
+	r := map[string]interface{}{}
+	for k, v := range m {
+		typedKey, ok := k.(string)
+		if !ok {
+			return nil, fmt.Errorf("Unexpected type %s for key %s", reflect.TypeOf(k), k)
+		}
+		switch v.(type) {
+		case map[interface{}]interface{}:
+			nestedMapWithStringKeys, err := ensureMapKeysAreStrings(v.(map[interface{}]interface{}))
+			if err != nil {
+				return nil, err
+			}
+			r[typedKey] = nestedMapWithStringKeys
+		default:
+			r[typedKey] = v
+		}
+	}
+	return r, nil
+}

--- a/plugin/pluginmodel/config.go
+++ b/plugin/pluginmodel/config.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/kubernetes-incubator/kube-aws/model"
-	"reflect"
 )
 
 // A plugin consists of two parts: a set of metadata and a spec
@@ -277,38 +276,4 @@ type Kubelet struct {
 
 type FeatureGates map[string]string
 type NodeLabels map[string]string
-type Values map[string]interface{}
-
-func (v *Values) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	m := map[interface{}]interface{}{}
-	if err := unmarshal(&m); err != nil {
-		return err
-	}
-	r, err := ensureMapKeysAreStrings(m)
-	if err != nil {
-		return err
-	}
-	*v = r
-	return nil
-}
-
-func ensureMapKeysAreStrings(m map[interface{}]interface{}) (map[string]interface{}, error) {
-	r := map[string]interface{}{}
-	for k, v := range m {
-		typedKey, ok := k.(string)
-		if !ok {
-			return nil, fmt.Errorf("Unexpected type %s for key %s", reflect.TypeOf(k), k)
-		}
-		switch v.(type) {
-		case map[interface{}]interface{}:
-			nestedMapWithStringKeys, err := ensureMapKeysAreStrings(v.(map[interface{}]interface{}))
-			if err != nil {
-				return nil, err
-			}
-			r[typedKey] = nestedMapWithStringKeys
-		default:
-			r[typedKey] = v
-		}
-	}
-	return r, nil
-}
+type Values = model.Values

--- a/plugin/pluginmodel/config.go
+++ b/plugin/pluginmodel/config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kubernetes-incubator/kube-aws/model"
+	"reflect"
 )
 
 // A plugin consists of two parts: a set of metadata and a spec
@@ -277,3 +278,37 @@ type Kubelet struct {
 type FeatureGates map[string]string
 type NodeLabels map[string]string
 type Values map[string]interface{}
+
+func (v *Values) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	m := map[interface{}]interface{}{}
+	if err := unmarshal(&m); err != nil {
+		return err
+	}
+	r, err := ensureMapKeysAreStrings(m)
+	if err != nil {
+		return err
+	}
+	*v = r
+	return nil
+}
+
+func ensureMapKeysAreStrings(m map[interface{}]interface{}) (map[string]interface{}, error) {
+	r := map[string]interface{}{}
+	for k, v := range m {
+		typedKey, ok := k.(string)
+		if !ok {
+			return nil, fmt.Errorf("Unexpected type %s for key %s", reflect.TypeOf(k), k)
+		}
+		switch v.(type) {
+		case map[interface{}]interface{}:
+			nestedMapWithStringKeys, err := ensureMapKeysAreStrings(v.(map[interface{}]interface{}))
+			if err != nil {
+				return nil, err
+			}
+			r[typedKey] = nestedMapWithStringKeys
+		default:
+			r[typedKey] = v
+		}
+	}
+	return r, nil
+}


### PR DESCRIPTION
It seems like goyaml parses a nested hash into `map[interaface{}]interface{}` even when the actual yaml hash had string keys only.

More concretely,

```
mymap map[string]interface{} `yaml:"foo,omitempty"`
```

and

```yaml
foo:
  bar: 1
```

results in

```
map[string]interface{}{
  "foo": map[interface{}]interface{}{
    "bar": 1,
  }
}
```

Fix it by converting all the nested `map[interface{}]interface{}` objects to `map[string]interface{}` ones.

Fixes #1391