### PR TITLE
0.11.x Add kubernetes manifests from customfiles

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1120,7 +1120,7 @@ write_files:
       {{ end }}
 
       # Allow installing kubernetes manifests via customFiles in the controller config - installs all manifests in mfdir/custom directory.
-      if ! [[ $(echo ${mfdir}/custom/*.yaml) == ${mfdir}'/custom/*.yaml' ]]; then
+      if ls ${mfdir}/custom/*.yaml &> /dev/null; then
         applyall ${mfdir}/custom/*.yaml
       fi
 

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1119,8 +1119,7 @@ write_files:
         applyall "${mfdir}/nvidia-driver-installer.yaml"
       {{ end }}
 
-      # Install any manifest files that we find in mfdir/extra directory so that we can add
-      # kubernetes manifests using customFiles.
+      # Allow installing kubernetes manifests via customFiles in the controller config - installs all manifests in mfdir/custom directory.
       if ! [[ $(echo ${mfdir}/custom/*.yaml) == ${mfdir}'/custom/*.yaml' ]]; then
         applyall ${mfdir}/custom/*.yaml
       fi

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1089,40 +1089,41 @@ write_files:
         "${mfdir}/kube-dns-svc.yaml" \
         {{ if .KubernetesDashboard.Enabled }}"${mfdir}/kubernetes-dashboard-svc.yaml"{{ end }}
 
-      mfdir=/srv/kubernetes/rbac
-
       # Cluster roles and bindings
-      applyall "${mfdir}/cluster-roles/node-extensions.yaml"
-
-      applyall "${mfdir}/cluster-role-bindings"/{kube-admin,system-worker,node,node-proxier,node-extensions,heapster}".yaml"
+      applyall "${rbac}/cluster-roles/node-extensions.yaml"
+      applyall "${rbac}/cluster-role-bindings"/{kube-admin,system-worker,node,node-proxier,node-extensions,heapster}".yaml"
 
       {{ if .KubernetesDashboard.Enabled }}
       {{ if .KubernetesDashboard.AdminPrivileges }}
-      applyall "${mfdir}/cluster-role-bindings/kubernetes-dashboard-admin.yaml"
+        applyall "${rbac}/cluster-role-bindings/kubernetes-dashboard-admin.yaml"
       {{- end }}
       {{- end }}
 
       # Roles and bindings
-      applyall "${mfdir}/roles"/{pod-nanny{{ if .KubernetesDashboard.Enabled }},kubernetes-dashboard{{ end }}}".yaml"
+      applyall "${rbac}/roles"/{pod-nanny{{ if .KubernetesDashboard.Enabled }},kubernetes-dashboard{{ end }}}".yaml"
 
-      applyall "${mfdir}/role-bindings"/{heapster-nanny{{ if .KubernetesDashboard.Enabled }},kubernetes-dashboard{{ end }}}".yaml"
+      applyall "${rbac}/role-bindings"/{heapster-nanny{{ if .KubernetesDashboard.Enabled }},kubernetes-dashboard{{ end }}}".yaml"
 
       {{ if .Experimental.TLSBootstrap.Enabled }}
-      applyall "${mfdir}/cluster-roles"/{node-bootstrapper,kubelet-certificate-bootstrap}".yaml"
+      applyall "${rbac}/cluster-roles"/{node-bootstrapper,kubelet-certificate-bootstrap}".yaml"
 
-      applyall "${mfdir}/cluster-role-bindings"/{node-bootstrapper,kubelet-certificate-bootstrap}".yaml"
+      applyall "${rbac}/cluster-role-bindings"/{node-bootstrapper,kubelet-certificate-bootstrap}".yaml"
       {{ end }}
 
       {{if .Experimental.Kube2IamSupport.Enabled }}
-        mfdir=/srv/kubernetes/manifests
         applyall "${mfdir}/kube2iam-rbac.yaml"
         applyall "${mfdir}/kube2iam-ds.yaml"
       {{ end }}
 
       {{ if .Experimental.GpuSupport.Enabled }}
-        mfdir=/srv/kubernetes/manifests
         applyall "${mfdir}/nvidia-driver-installer.yaml"
       {{ end }}
+
+      # Install any manifest files that we find in mfdir/extra directory so that we can add
+      # kubernetes manifests using customFiles.
+      if ! [[ $(echo ${mfdir}/custom/*.yaml) == ${mfdir}'/custom/*.yaml' ]]; then
+        applyall ${mfdir}/custom/*.yaml
+      fi
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -241,6 +241,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     kube-aws.coreos.com/role: controller
 #
 #  # User defined files that will be added to the Controller cluster cloud-init configuration in the "write_files:" section.
+#  # Writing a kubernetes manifest to path /srv/kubernetes/manifests/custom/*.yaml will be automatically
+#  # installed when the controllers start up.
+# 
 #  customFiles:
 #    - path: "/etc/rkt/auth.d/docker.json"
 #      permissions: 0600


### PR DESCRIPTION
We would like to be able to install kubernetes objects through kube-aws using our customFile directives on the controller, giving us a way of extending kube-aws without maintaining our own fork of it.

This PR adds the functionality into install-kube-system to pick up any manifests that have been written to /srv/kubernetes/manifests/custom/*.yaml.  This is intended for only advanced users as failing to install these manifests will cause the update to fail and roll back.

Also fixed an issue with the code where a variable 'mfdir' was redeclared mid-way through the script confusing maintainers as to its correct value.
