### PR TITLE
0.10.x Add kubernetes manifests from customfiles

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -979,7 +979,7 @@ write_files:
       {{ end }}
 
       # Allow installing kubernetes manifests via customFiles in the controller config - installs all manifests in mfdir/custom directory.
-      if ! [[ $(echo ${mfdir}/custom/*.yaml) == ${mfdir}'/custom/*.yaml' ]]; then
+      if ls ${mfdir}/custom/*.yaml &> /dev/null; then
         applyall ${mfdir}/custom/*.yaml
       fi
 

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -950,38 +950,39 @@ write_files:
       applyall "${mfdir}/kube-rescheduler-de.yaml"
       {{- end }}
 
-      mfdir=/srv/kubernetes/rbac
-
       # Cluster roles and bindings
-      applyall "${mfdir}/cluster-roles/node-extensions.yaml"
-
-      applyall "${mfdir}/cluster-role-bindings"/{kube-admin,system-worker,node,node-proxier,node-extensions,heapster}".yaml"
+      applyall "${rbac}/cluster-roles/node-extensions.yaml"
+      applyall "${rbac}/cluster-role-bindings"/{kube-admin,system-worker,node,node-proxier,node-extensions,heapster}".yaml"
 
       {{ if .KubernetesDashboard.AdminPrivileges }}
-      applyall "${mfdir}/cluster-role-bindings/kubernetes-dashboard-admin.yaml"
+        applyall "${rbac}/cluster-role-bindings/kubernetes-dashboard-admin.yaml"
       {{- end }}
 
       # Roles and bindings
-      applyall "${mfdir}/roles"/{pod-nanny,kubernetes-dashboard}".yaml"
+      applyall "${rbac}/roles"/{pod-nanny{{ if .KubernetesDashboard.Enabled }},kubernetes-dashboard{{ end }}}".yaml"
 
-      applyall "${mfdir}/role-bindings"/{heapster-nanny,kubernetes-dashboard}".yaml"
+      applyall "${rbac}/role-bindings"/{heapster-nanny{{ if .KubernetesDashboard.Enabled }},kubernetes-dashboard{{ end }}}".yaml"
 
       {{ if .Experimental.TLSBootstrap.Enabled }}
-      applyall "${mfdir}/cluster-roles"/{node-bootstrapper,kubelet-certificate-bootstrap}".yaml"
+      applyall "${rbac}/cluster-roles"/{node-bootstrapper,kubelet-certificate-bootstrap}".yaml"
 
-      applyall "${mfdir}/cluster-role-bindings"/{node-bootstrapper,kubelet-certificate-bootstrap}".yaml"
+      applyall "${rbac}/cluster-role-bindings"/{node-bootstrapper,kubelet-certificate-bootstrap}".yaml"
       {{ end }}
 
       {{if .Experimental.Kube2IamSupport.Enabled }}
-        mfdir=/srv/kubernetes/manifests
         applyall "${mfdir}/kube2iam-rbac.yaml"
         applyall "${mfdir}/kube2iam-ds.yaml";
       {{ end }}
 
       {{ if .Experimental.GpuSupport.Enabled }}
-        mfdir=/srv/kubernetes/manifests
         applyall "${mfdir}/nvidia-driver-installer.yaml"
       {{ end }}
+
+      # Install any manifest files that we find in mfdir/extra directory so that we can add
+      # kubernetes manifests using customFiles.
+      if ! [[ $(echo ${mfdir}/custom/*.yaml) == ${mfdir}'/custom/*.yaml' ]]; then
+        applyall ${mfdir}/custom/*.yaml
+      fi
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -959,9 +959,9 @@ write_files:
       {{- end }}
 
       # Roles and bindings
-      applyall "${rbac}/roles"/{pod-nanny{{ if .KubernetesDashboard.Enabled }},kubernetes-dashboard{{ end }}}".yaml"
+      applyall "${rbac}/roles"/{pod-nanny,kubernetes-dashboard}".yaml"
 
-      applyall "${rbac}/role-bindings"/{heapster-nanny{{ if .KubernetesDashboard.Enabled }},kubernetes-dashboard{{ end }}}".yaml"
+      applyall "${rbac}/role-bindings"/{heapster-nanny,kubernetes-dashboard}".yaml"
 
       {{ if .Experimental.TLSBootstrap.Enabled }}
       applyall "${rbac}/cluster-roles"/{node-bootstrapper,kubelet-certificate-bootstrap}".yaml"

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -978,8 +978,7 @@ write_files:
         applyall "${mfdir}/nvidia-driver-installer.yaml"
       {{ end }}
 
-      # Install any manifest files that we find in mfdir/extra directory so that we can add
-      # kubernetes manifests using customFiles.
+      # Allow installing kubernetes manifests via customFiles in the controller config - installs all manifests in mfdir/custom directory.
       if ! [[ $(echo ${mfdir}/custom/*.yaml) == ${mfdir}'/custom/*.yaml' ]]; then
         applyall ${mfdir}/custom/*.yaml
       fi

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -229,6 +229,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     kube-aws.coreos.com/role: controller
 #
 #  # User defined files that will be added to the Controller cluster cloud-init configuration in the "write_files:" section.
+#  # Writing a kubernetes manifest to path /srv/kubernetes/manifests/custom/*.yaml will be automatically
+#  # installed when the controllers start up.
+# 
 #  customFiles:
 #    - path: "/etc/rkt/auth.d/docker.json"
 #      permissions: 0600


### PR DESCRIPTION
Please can we include this change in the 0.10.x release?  It would help us greatly if we can include these two customFile changes so that we can move some of our code out of our fork of kube-aws and closer to using the upstream version instead.

This change patches 'install-kube-system' so that it will kubectl apply any manifest files written to /srv/kubernetes/manifests/custom/*.yaml