### PR TITLE
Differentiate the node drainer containers

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2677,7 +2677,7 @@ write_files:
                   - mountPath: /workdir
                     name: workdir
               containers:
-                - name: main
+                - name: kube-node-drainer-asg-status-updater
                   image: {{.AWSCliImage.RepoWithTag}}
                   env:
                   - name: NODE_NAME
@@ -2769,7 +2769,7 @@ write_files:
                   - mountPath: /workdir
                     name: workdir
               containers:
-                - name: main
+                - name: kube-node-drainer
                   image: {{.AWSCliImage.RepoWithTag}}
                   env:
                   - name: NODE_NAME


### PR DESCRIPTION
At least in our setup, most containers are named after the application and these just show as `main` in the Datadog monitoring.