### PR TITLE
Update reserved storage flag name

### DIFF
--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -1121,16 +1121,16 @@ func TestKubeletReserved(t *testing.T) {
 		{
 			conf: `
 kubelet:
-  kubeReserved: "cpu=100m,memory=100Mi,storage=1Gi"
-  systemReserved: "cpu=200m,memory=200Mi,storage=2Gi"
+  kubeReserved: "cpu=100m,memory=100Mi,ephemeral-storage=1Gi"
+  systemReserved: "cpu=200m,memory=200Mi,ephemeral-storage=2Gi"
 `,
-			kubeReserved:   "cpu=100m,memory=100Mi,storage=1Gi",
-			systemReserved: "cpu=200m,memory=200Mi,storage=2Gi",
+			kubeReserved:   "cpu=100m,memory=100Mi,ephemeral-storage=1Gi",
+			systemReserved: "cpu=200m,memory=200Mi,ephemeral-storage=2Gi",
 		},
 		{
 			conf: `
-kubeReserved: "cpu=100m,memory=100Mi,storage=1Gi"
-systemReserved: "cpu=200m,memory=200Mi,storage=2Gi"
+kubeReserved: "cpu=100m,memory=100Mi,ephemeral-storage=1Gi"
+systemReserved: "cpu=200m,memory=200Mi,ephemeral-storage=2Gi"
 `,
 			kubeReserved:   "",
 			systemReserved: "",

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1507,9 +1507,9 @@ kubelet:
   # How resources are reserved: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
   # How to size these limits: https://kubernetes.io/blog/2016/11/visualize-kubelet-performance-with-node-dashboard/
   # kubeReserved is used to reserve capacity for kubernetes system daemons
-  #kubeReserved: "cpu=100m,memory=100Mi,storage=1Gi"
+  #kubeReserved: "cpu=100m,memory=100Mi,ephemeral-storage=1Gi"
   # systemReserved is used to reserve capacity for OS system daemons
-  #systemReserved: "cpu=100m,memory=100Mi,storage=1Gi"
+  #systemReserved: "cpu=100m,memory=100Mi,ephemeral-storage=1Gi"
 
 # AWS Tags for cloudformation stack resources
 #stackTags:


### PR DESCRIPTION
It seems `storage` is no longer a valid value since k8s 1.8.

Fixes `failed to run Kubelet: cannot reserve "storage" resource`

Ref https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/ and https://github.com/kubernetes/kops/issues/3576 and https://github.com/kubernetes/website/pull/9532.