### PR TITLE
Resolve CFN dependency issue when updating to v0.10.x

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1877,7 +1877,6 @@
     },
     {{end}}
     {{end}}
-    {{if not .Kubernetes.Networking.SelfHosting.Enabled }}
     {{range $index, $etcdInstance := $.EtcdNodes}}
     {{if $etcdInstance.EIPManaged}}
     "{{$etcdInstance.EIPLogicalName}}": {
@@ -1892,7 +1891,6 @@
       "Value": {{$etcdInstance.NetworkInterfacePrivateIPRef}},
       "Export": { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$etcdInstance.NetworkInterfacePrivateIPLogicalName}}" }}
     },
-    {{end}}
     {{end}}
     {{end}}
     {{ if not .Controller.IAMConfig.InstanceProfile.Arn }}


### PR DESCRIPTION
Upgrading can cause cfn error and rollback: 

```
+00:00:14    UPDATE_FAILED                   Controlplane              "Embedded stack arn:aws:cloudformation:us-west-2:034324643013:stack/ko-Controlplane-U7SB0W9VL40E/8bd91500-6e32-11e8-871f-50a68af39629 was not successfully updated. Currently in UPDATE_ROLLBACK_IN_PROGRESS with reason: Export ko-Controlplane-U7SB0W9VL40E-Etcd0PrivateIP cannot be deleted as it is in use by ko-Nodepoola-ACYQ1L68QT9X, ko-Nodepoolb-25KUVVCIZCN1 and ko-Nodepoolc-9GE9825UJZHU"
```

This is because the v0.10.1 release tries to remove some outputs from the controlplane stack before the nodepools have remove their use of it.

This resolves issue https://github.com/kubernetes-incubator/kube-aws/issues/1411

Apologies, I think this might have to be a quick 0.10.2 release or retag 0.10.1 to this commit! :(