### PR TITLE
Improve customFile templating

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -685,7 +685,7 @@ write_files:
   - path: {{$w.Path}}
     permissions: {{$w.PermissionsString}}
     encoding: gzip+base64
-    content: {{$w.RenderGzippedBase64Content .}}
+    content: {{$w.RenderGzippedBase64Content $}}
   {{- end }}
 {{- end }}
   - path: /etc/modules-load.d/ip_vs.conf

--- a/core/etcd/config/templates/cloud-config-etcd
+++ b/core/etcd/config/templates/cloud-config-etcd
@@ -534,7 +534,7 @@ write_files:
   - path: {{$w.Path}}
     permissions: {{$w.PermissionsString}}
     encoding: gzip+base64
-    content: {{$w.RenderGzippedBase64Content .}}
+    content: {{$w.RenderGzippedBase64Content $}}
   {{- end }}
 {{- end }}
 {{if and (.AmazonSsmAgent.Enabled) (ne .AmazonSsmAgent.DownloadUrl "")}}

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -800,7 +800,7 @@ write_files:
   - path: {{$w.Path}}
     permissions: {{$w.PermissionsString}}
     encoding: gzip+base64
-    content: {{$w.RenderGzippedBase64Content .}}
+    content: {{$w.RenderGzippedBase64Content $}}
   {{- end }}
 {{- end }}
   - path: /etc/modules-load.d/ip_vs.conf

--- a/model/custom_file.go
+++ b/model/custom_file.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/kubernetes-incubator/kube-aws/filereader/texttemplate"
 	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 )
@@ -56,7 +57,7 @@ func (c CustomFile) customFileHasTemplate() bool {
 func (c CustomFile) renderTemplate(ctx interface{}) (string, error) {
 	var buf strings.Builder
 
-	tmpl, err := template.New("").Parse(c.Template)
+	tmpl, err := texttemplate.Parse("template", c.Template, template.FuncMap{})
 	if err != nil {
 		return "", fmt.Errorf("failed to parse CustomFile template %s: %v", c.Path, err)
 	}


### PR DESCRIPTION
Fix - pass whole context not just the current context
Use kube-aws texttemplate pkg so that all kube-aws funcmaps can be used, e.g. default, fingerprint etc.