### PR TITLE
Fix dep ensure empty package issue

### DIFF
--- a/core/network/config/config.go
+++ b/core/network/config/config.go
@@ -1,3 +1,3 @@
 package config
 
-const DepFindsCode = true
+// The templates.go file is generated at build time but dep requires that each package contains some go source in order to import it.

--- a/core/network/config/config.go
+++ b/core/network/config/config.go
@@ -1,0 +1,3 @@
+package config
+
+const DepFindsCode = true


### PR DESCRIPTION
When embedding kube-aws in another go tool we want to be able to pull it in using dep ensure.  dep refuses to pull in empty packages and so does not like the network/config package which is empty until a build is performed and the templates.go file generated.

Committing this stub file satisfies dep and allows it to successfully pull in kube-aws.