### PR TITLE
feat: Node pools backed by Spotinst Elastigroup

### DIFF
--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -29,6 +29,11 @@ exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE
   "#!/bin/bash -xe",
   "# s3-part-fingerprint: {{ (execTemplate "s3" .) | fingerprint }}",
   {"Fn::Sub": "echo '{{.StackNameEnvVarName}}=${AWS::StackName}' >>{{.StackNameEnvFileName}}"},
+  {{if .Elastigroup.Enabled}}
+  {"Fn::Sub": [
+    "echo \"WAIT_HANDLE='${WaitHandle}'\" >>{{.StackNameEnvFileName}}", {"WaitHandle": {"Ref": "{{.LogicalName}}WaitHandle"}}
+  ]},
+  {{end}}
   {{ (execTemplate "instance-script" .) | toJSON }}
 ]]}}
 {{ end }}
@@ -932,6 +937,8 @@ write_files:
     permissions: 0700
     content: |
       #!/bin/bash -e
+      
+      instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
 
       rkt run \
         --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
@@ -939,14 +946,23 @@ write_files:
         --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false \
         --mount volume=awsenv,target=/var/run/coreos \
         --uuid-file-save=/var/run/coreos/cfn-signal.uuid \
-        --set-env={{.StackNameEnvVarName}}=${{.StackNameEnvVarName}} \
+        --set-env={{.StackNameEnvVarName}}=${{.StackNameEnvVarName}} \{{if .Elastigroup.Enabled}}
+        --set-env=WAIT_HANDLE=$WAIT_HANDLE \{{end}}
+        --set-env=SPOTINST_TOKEN={{$.Elastigroup.AccessToken}} \
         --net=host \
         --trust-keys-from-https \
         {{.AWSCliImage.Options}}{{.AWSCliImage.RktRepo}} --exec=/bin/bash -- \
-          -ec \
+          -ec \{{if .Elastigroup.Enabled}}
           '
-            cfn-signal -e 0 --region {{.Region}} --resource {{.LogicalName}} --stack "${{.StackNameEnvVarName}}"
+          cfn-signal -e 0 $WAIT_HANDLE{{if .LoadBalancer.Enabled}}
+          instance_signal=$(echo '\''{"instanceId" : "'${instance_id}'", "signal" : "INSTANCE_READY"}'\'')
+          echo $instance_signal > instance_signal
+          token=$SPOTINST_TOKEN
+          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${token}" -d @instance_signal https://api.spotinst.io/aws/ec2/instance/signal
+          {{end}}'{{else}}
           '
+          cfn-signal -e 0 --region {{.Region}} --resource {{.LogicalName}} --stack "${{.StackNameEnvVarName}}"
+          '{{end}}
 
       rkt rm --uuid-file=/var/run/coreos/cfn-signal.uuid || :
 

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -18,7 +18,8 @@
           }
         }
       }
-    }{{ if not .Kubernetes.Networking.SelfHosting.Enabled }},{{end}}
+    }
+    {{ if not .Kubernetes.Networking.SelfHosting.Enabled }},{{end}}
     {{end -}}
     {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
     "etcd-client-env": {
@@ -39,6 +40,201 @@
     {{end}}
   }
 }
+{{end}}
+{{define "Elastigroup"}}
+    "{{.LogicalName}}": {
+      "Type": "Custom::elastigroup",
+      "Properties": {
+        "ServiceToken": "arn:aws:lambda:{{.Region}}:178579023202:function:spotinst-cloudformation",
+        "accessToken": "{{$.Elastigroup.AccessToken}}",
+        "accountId": "{{$.Elastigroup.AccountId}}",
+        "updatePolicy": {
+          "shouldRoll": {
+            "Ref": "shouldRoll"
+          },
+          "rollConfig": {
+            "batchSizePercentage": 50,
+            "gracePeriod": 600
+          },
+          "shouldUpdateTargetCapacity": {
+            "Ref": "shouldUpdateTargetCapacity"
+          }
+        },
+        "group": {
+          "name": "{{.LogicalName}}",
+          "description": "Elastigroup for kube-aws Worker Nodes",
+          "strategy": {
+            "risk": "{{$.Elastigroup.Risk}}",
+            "onDemandCount": "{{$.Elastigroup.OnDemandCount}}",
+            "availabilityVsCost": "{{$.Elastigroup.AvalilabilityVsCost}}",
+            "drainingTimeout": "{{$.Elastigroup.DrainingTimeout}}",
+            "fallbackToOd": "{{$.Elastigroup.FallbackToOd}}",
+            "lifetimePeriod": "days",
+            "revertToSpot": {
+              "performAt": "{{$.Elastigroup.RevertToSpot}}"
+            }
+            {{if .LoadBalancer.Enabled}}
+            , 
+            "signals": [
+              {
+                "name": "INSTANCE_READY",
+                "timeout": "{{$.Elastigroup.SignalsTimeout}}"
+              }
+            ]
+            {{end}}
+          },
+          "capacity": {
+            "target": "{{$.Elastigroup.TargetSize}}",
+            "minimum": "{{$.Elastigroup.MinSize}}",
+            "maximum": "{{$.Elastigroup.MaxSize}}",
+            "unit": "instance"
+          },
+          "compute": {
+            "instanceTypes": {
+              "ondemand": "{{.InstanceType}}",
+              "spot": [
+                {{range $index, $var := $.Elastigroup.SpotInstanceTypes}}
+                  {{if gt $index 0}},{{end}} 
+                  "{{$var}}"
+                {{end}}               
+              ]
+            },
+            "availabilityZones": [
+              {
+                {{range $index, $subnet := .Subnets}}
+                "name": "{{$subnet.AvailabilityZone}}",
+                "subnetIds": [
+                  {{if gt $index 0}},{{end}}
+                  {{$subnet.Ref}}
+                  {{end}}
+                ]
+              }
+            ],
+            "product": "Linux/UNIX",
+            "launchSpecification": {
+              {{if .LoadBalancer.Enabled}}
+              "loadBalancersConfig": {
+                "loadBalancers": [
+                  {{if .TargetGroup.Enabled}}
+                  {{range $index, $elb := .LoadBalancer.Names}}
+                  {{if $index}},{{end}}
+                  {
+                    "name": "{{$elb}}",
+                    "type": "{{$.Elastigroup.ElbType}}",
+                    "arn": "{{(index $.TargetGroup.Arns $index)}}"
+                  }
+                  {{end}}
+                  {{else}}
+                  {{range $index, $elb := .LoadBalancer.Names}}
+                  {{if $index}},{{end}}
+                  {
+                    "name": "{{$elb}}",
+                    "type": "{{$.Elastigroup.ElbType}}"
+                  }
+                  {{end}}
+                  {{end}}
+                ] 
+              },
+              {{end}}
+              "securityGroupIds": [
+                {{range $sgIndex, $sgRef := $.SecurityGroupRefs}}
+                {{if gt $sgIndex 0}},{{end}}
+                {{$sgRef}}
+                {{end}}
+              ],
+              "monitoring": false,
+              "ebsOptimized": false,
+              "imageId": "{{.AMI}}",
+              {{if .KeyName}}"keyPair": "{{.KeyName}}",{{end}}
+              "userData": {{ $.UserDataWorker.Parts.instance.Template }},
+              "blockDeviceMappings": [
+                {
+                  "deviceName": "/dev/xvda",
+                  "ebs": {
+                    "deleteOnTermination": true,
+                    "volumeSize": "{{.RootVolume.Size}}",
+                    "volumeType": "{{.RootVolume.Type}}"
+                  }
+                }{{range $volumeMountSpecIndex, $volumeMountSpec := .VolumeMounts}},
+                {
+                  "deviceName": "{{$volumeMountSpec.Device}}",
+                  "ebs": {
+                    "deleteOnTermination": true,
+                    "volumeSize": "{{$volumeMountSpec.Size}}",
+                    "volumeType": "{{$volumeMountSpec.Type}}"
+                  }
+                }{{- end -}}{{range $raid0MountSpecIndex, $raid0MountSpec := $.Raid0Mounts}}{{range $DeviceIndex, $Device := $raid0MountSpec.Devices}},
+                {  
+                  "DeviceName": "{{$Device}}",
+                  "Ebs": {
+                    "VolumeSize": "{{$raid0MountSpec.Size}}",
+                    {{if gt $raid0MountSpec.Iops 0}}
+                    "Iops": "{{$raid0MountSpec.Iops}}",
+                    {{end}}
+                    "VolumeType": "{{$raid0MountSpec.Type}}"
+                  }
+                }{{end}}
+                {{- end -}}
+              ],
+              "tags": [
+                {{range $k, $v := .InstanceTags -}}
+                {
+                  "tagKey": "{{$k}}",
+                  "tagValue": "{{$v}}"
+                },
+                {{end -}}      
+                {
+                  "tagKey": "kubernetes.io/cluster/{{ .ClusterName }}",
+                  "tagValue": "owned"
+                },
+                {
+                  "tagKey": "kube-aws:node-pool:name",   
+                  "tagValue": "{{.NodePoolName}}"
+                },
+                {
+                  "tagKey": "Name",
+                  "tagValue": "{{.ClusterName}}-{{.StackName}}-kube-aws-worker"
+                }
+              ],
+              "iamRole": {
+                {{if .IAMConfig.InstanceProfile.Arn }}
+                "arn": "{{.IAMConfig.InstanceProfile.Arn}}",
+                {{else}}
+                "arn": { 
+                  "Fn::GetAtt": [
+                    "IAMInstanceProfileWorker", 
+                    "Arn"
+                  ] 
+                }
+                {{end}}
+              },
+              "healthCheckType": "EC2",
+              "healthCheckGracePeriod": 600,
+              "healthCheckUnhealthyDurationBeforeReplacement": 60,
+              "tenancy": "default"
+            }
+          },
+          "scheduling": {},
+          "thirdPartiesIntegration": {}
+        }
+      }{{ if or (not .Kubernetes.Networking.SelfHosting.Enabled) .AwsEnvironment.Enabled }},
+      "Metadata": {{template "Metadata" .}}
+      {{- end }}
+    },
+    "{{.LogicalName}}WaitCondition": {
+      "Type": "AWS::CloudFormation::WaitCondition",
+      "DependsOn": "{{.LogicalName}}",
+      "Properties": {
+        "Handle": {
+          "Ref": "{{.LogicalName}}WaitHandle"
+        },
+        "Timeout": "900",
+        "Count": "{{$.Elastigroup.TargetSize}}"
+      }
+    },
+    "{{.LogicalName}}WaitHandle": {
+      "Type": "AWS::CloudFormation::WaitConditionHandle"
+    },
 {{end}}
 {{define "SpotFleet"}}
   "{{.LogicalName}}": {
@@ -505,10 +701,10 @@
           "Version": "2012-10-17"
         },
         "Path": "/",
-        {{if .IAMConfig.Role.Name }}
+        {{if .IAMConfig.Role.Name }} 
         "RoleName":  {"Fn::Join": ["-", ["{{$.ClusterName}}", {"Ref": "AWS::Region"}, "{{.IAMConfig.Role.Name}}"]]},
         {{end}}
-        "ManagedPolicyArns": [
+        "ManagedPolicyArns": [ 
           {{range $policyIndex, $policyArn := .IAMConfig.Role.ManagedPolicies }}
             "{{$policyArn.Arn}}",
           {{end}}
@@ -537,9 +733,28 @@
       "Description": "CloudWatch LogGroup to send journald logs to"
     }
     {{ end }}
+    {{if .Elastigroup.Enabled}}
+    ,
+    "shouldRoll": {
+      "Type": "String",
+      "Default": "false",
+      "Description": "Should roll when updating"
+    },
+    "shouldUpdateTargetCapacity": {
+      "Type": "String",
+      "Default": "true",
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Description": "Should update target capacity on group update"
+    }
+    {{end}}
   },
   "Resources": {
-    {{if .SpotFleet.Enabled}}
+    {{if .Elastigroup.Enabled}}
+    {{template "Elastigroup" .}}
+    {{else if .SpotFleet.Enabled}}
     {{template "SpotFleet" .}}
     {{else}}
     {{template "AutoScaling" .}}

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -412,11 +412,64 @@ worker:
 #        # Max number of nodes concurrently updated
 #        maxBatchSize: 1
 #
+#
+#      #
+#      #      # Spotinst Elastigroup config for worker nodes
+#      #
+#      elastiGroup:
+#        # Spotinst API Access Token
+#        accessToken: "YOUR_ACCESSTOKEN_KEY"
+#
+#        # Spotinst Account ID
+#        accountId: "YOUR_ACCOUNT_ID"
+#
+#        # In the case of a ‘scale down’ policy action, this is the minimum number of running instances/vCPU weight in the group. 
+#        minSize: 1
+#
+#        #  - In the case of a ‘scale up’ policy action, this is the maximum number of running instances/vCPU weight in the group.
+#        maxSize: 3
+#
+#        # Number of running instances/vCPU weight in your Elastigroup
+#        targetSize: 1
+#
+#        #  What % of instances of your target instance count should be launched as spot instances. 
+#        risk: 100
+#
+#        # Out of your target instance count, how many instances should be launched as On-Demand/Reserved
+#        onDemandCount: 0
+#
+#        # Choose the orientation the Spotinst’s algorithm will lean towards. 
+#        # See https://api.spotinst.com/integration-docs/elastigroup/concepts/general-concepts/cluster-orientation/ for available options.
+#        availabilityVsCost: "balanced"
+#
+#        # (Seconds) The time you would like to allocate for existing sessions to drain before spot termination or scaling.
+#        drainingTimeout: 120
+#
+#        # In the case of no available spot instances, this will enable the fallback to On-Demand instances. 
+#        fallbackToOd: true
+#
+#        # In the event of a fallback to On-Demand instances, select the time period to revert back to Spot. 
+#        # Supported Arguments ia  "always" (default), "timeWindow", "never". 
+#        # For timeWindow or never to be valid the group must have availabilityOriented OR persistence defined.
+#        revertToSpot: "always"
+#        
+#        # The timeout in seconds to hold the instance until a signal is sent.
+#        signalsTimeout: 900
+#        
+#        # Elastic Load Balancer Type 
+#        # Select ELB Type "CLASSIC" or "TARGET_GROUP".
+#        elbType: "CLASSIC"
+#
+#        # SpotInstance's Instance Type.
+#        # You can specify multiple instance type in array
+#        spotInstanceTypes: [t2.medium] 
+#        
 #      # Auto Scaling Group definition for workers. If only `workerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
 #      autoScalingGroup:
 #        minSize: 1
 #        maxSize: 3
 #        rollingUpdateMinInstancesInService: 2
+#
 #
 #      #
 #      # Spot fleet config for worker nodes

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -9,6 +9,7 @@ type NodePoolConfig struct {
 	Autoscaling               Autoscaling      `yaml:"autoscaling,omitempty"`
 	AutoScalingGroup          AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
 	SpotFleet                 SpotFleet        `yaml:"spotFleet,omitempty"`
+	Elastigroup               Elastigroup      `yaml:"elastiGroup"`
 	EC2Instance               `yaml:",inline"`
 	IAMConfig                 IAMConfig              `yaml:"iam,omitempty"`
 	SpotPrice                 string                 `yaml:"spotPrice,omitempty"`

--- a/model/spot_inst.go
+++ b/model/spot_inst.go
@@ -1,0 +1,23 @@
+package model
+
+type Elastigroup struct {
+	AccessToken         string        `yaml:"accessToken,omitempty"`
+	AccountId           string        `yaml:"accountId,omitempty"`
+	MinSize             int           `yaml:"minSize,omitempty"`
+	MaxSize             int           `yaml:"maxSize,omitempty"`
+	TargetSize          int           `yaml:"targetSize,omitempty"`
+	Risk                int           `yaml:"risk,omitempty"`
+	OnDemandCount       int           `yaml:"onDemandCount,omitempty"`
+	AvalilabilityVsCost string        `yaml:"availabilityVsCost,omitempty"`
+	DrainingTimeout     int           `yaml:"drainingTimeout,omitempty"`
+	FallbackToOd        bool          `yaml:"fallbackToOd,omitempty"`
+	LifetimePeriod      string        `yaml:"lifetimePeriod,omitempty"`
+	RevertToSpot        string        `yaml:"revertToSpot,omitempty"`
+	SignalsTimeout      int           `yaml:"signalsTimeout,omitempty"`
+	ElbType             string        `yaml:"elbType,omitempty"`
+	SpotInstanceTypes   []interface{} `yaml:"spotInstanceTypes,omitempty"`
+}
+
+func (f Elastigroup) Enabled() bool {
+	return f.TargetSize > 0
+}


### PR DESCRIPTION
I've introduced feature which does integration with Spotinst's Elastigroup.
You can use Spotinst's Elastigroup for worker-nodes.