### PR TITLE
Remove invalid aws tag symbols from branch names

### DIFF
--- a/build
+++ b/build
@@ -3,7 +3,7 @@ set -euo pipefail
 
 COMMIT=$(git rev-parse HEAD)
 TAG=$(git describe --exact-match --abbrev=0 --tags "${COMMIT}" 2> /dev/null || true)
-BRANCH=$(git branch | grep \* | cut -d ' ' -f2 || true)
+BRANCH=$(git branch | grep \* | cut -d ' ' -f2 | sed -e 's/[^a-zA-Z0-9+=._:/-]*//g' || true)
 OUTPUT_PATH=${OUTPUT_PATH:-"bin/kube-aws"}
 VERSION=""
 


### PR DESCRIPTION
I had an cluster roll failed with the cloudformation failure...

```
+00:08:02	UPDATE_FAILED           		APIEndpointDefaultELB 	"One or more tags are not valid"
+00:08:03	UPDATE_FAILED           		IAMRoleController     	"Resource creation cancelled"
+00:08:03	UPDATE_ROLLBACK_IN_PROGRESS		davem-lab-secure-Controlplane-1RO8IL4N198PU	"The following resource(s) failed to update: [APIEndpointDefaultELB, IAMRoleController]. "
+00:08:10	UPDATE_FAILED           		Controlplane          	"Embedded stack arn:aws:cloudformation:us-west-2:034324643013:stack/davem-lab-secure-Controlplane-1RO8IL4N198PU/77ca9b10-8a7a-11e8-a97b-50d5ca789e4a was not successfully updated. Currently in UPDATE_ROLLBACK_IN_PROGRESS with reason: The following resource(s) failed to update: [APIEndpointDefaultELB, IAMRoleController]. "
+00:08:11	UPDATE_ROLLBACK_IN_PROGRESS		davem-lab-secure      	"The following resource(s) failed to update: [Controlplane]. "
Error: error updating cluster: unexpected stack status: UPDATE_ROLLBACK_IN_PROGRESS
```

The issue is because I built kube-aws from a detached head branch and so aws was trying to set the tag `kube-aws:version` = `(HEAD`. '(' is not a valid symbol for ELB tags which is causing the update to fail and the roll back.

This change to the build script strips any illegal characters from the branch name when constructing the kube-aws version identifier and so as in my example, the resultant version became 
 `HEAD/dc1946f7+dirty` which is a valid aws tag and now the roll succeeds.
