### PR TITLE
cluster.yaml: removed whitespace in waitSignal configuration

### DIFF
--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1244,7 +1244,7 @@ kubernetes:
 # It is enabled by default.
 #waitSignal:
 #  enabled: true
-#   maxBatchSize: 1
+#  maxBatchSize: 1
 
 # Autosaves all Kubernetes resources (in .json format) to a bucket 's3:.../<your-cluster-name>/backup/*'.
 # The autosave process executes on start-up and repeats every 24 hours.


### PR DESCRIPTION
the line configuring the maxBatchSize in the waitSignal config contained one
whitespace too much which made the kube-aws validation step fail if the config
was used