### PR TITLE
Add ability to configure flags for cluster-autoscaler-de.yaml [Small]

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -108,6 +108,7 @@ func NewDefaultCluster() *Cluster {
 		},
 		ClusterAutoscalerSupport: model.ClusterAutoscalerSupport{
 			Enabled: true,
+			Options: map[string]string{},
 		},
 		TLSBootstrap: TLSBootstrap{
 			Enabled: false,

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4526,6 +4526,9 @@ write_files:
                     - --skip-nodes-with-system-pods=false
                     - --expander=least-waste
                     - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,kubernetes.io/cluster/{{.ClusterName}}
+                    {{- range $flag, $value := .Addons.ClusterAutoscaler.Options }}
+                    - --{{ $flag }}={{ $value }}
+                    {{- end }}
                   env:
                     - name: AWS_REGION
                       value: {{.Region}}

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1351,6 +1351,13 @@ addons:
   # If you want to run CA on worker nodes, turn on `worker.nodePools[].clusterAutoscalerSupport.enabled` for the node pool.
   clusterAutoscaler:
     enabled: false
+    # Options below can be used to inject custom settings for the autoscaler.
+    # Sensible defaults are already configured in the controller-cloud-config but if you wish to override them simply
+    # add them here and they'll take precedence.
+    #options:
+    #  flag-name: value
+    #  v: 5 
+    #  expander: least-waste
 
   # When enabled, Kubernetes rescheduler is deployed to the cluster controller(s)
   # This feature is experimental currently so may not be production ready

--- a/model/addons.go
+++ b/model/addons.go
@@ -10,7 +10,8 @@ type Addons struct {
 }
 
 type ClusterAutoscalerSupport struct {
-	Enabled     bool `yaml:"enabled"`
+	Enabled     bool              `yaml:"enabled"`
+	Options     map[string]string `yaml:"options"`
 	UnknownKeys `yaml:",inline"`
 }
 

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -127,6 +127,7 @@ func TestMainClusterConfig(t *testing.T) {
 			},
 			ClusterAutoscalerSupport: model.ClusterAutoscalerSupport{
 				Enabled: true,
+				Options: map[string]string{},
 			},
 			TLSBootstrap: controlplane_config.TLSBootstrap{
 				Enabled: false,
@@ -432,6 +433,9 @@ addons:
     enabled: true
   clusterAutoscaler:
     enabled: true
+    options:
+      v: 5
+      test: present
   metricsServer:
     enabled: true
 worker:
@@ -448,6 +452,7 @@ worker:
 						},
 						ClusterAutoscaler: model.ClusterAutoscalerSupport{
 							Enabled: true,
+							Options: map[string]string{"v": "5", "test": "present"},
 						},
 						MetricsServer: model.MetricsServer{
 							Enabled: true,
@@ -1370,6 +1375,7 @@ worker:
 						},
 						ClusterAutoscalerSupport: model.ClusterAutoscalerSupport{
 							Enabled: true,
+							Options: map[string]string{},
 						},
 						TLSBootstrap: controlplane_config.TLSBootstrap{
 							Enabled: true,
@@ -1520,6 +1526,7 @@ worker:
 						},
 						ClusterAutoscalerSupport: model.ClusterAutoscalerSupport{
 							Enabled: true,
+							Options: map[string]string{},
 						},
 						TLSBootstrap: controlplane_config.TLSBootstrap{
 							Enabled: false,


### PR DESCRIPTION
### What
Exposing cluster autoscaler options via cluster.yaml

### Why
I'd like to be able to configure the cluster-autoscaler to make it more sensitive.
We have a lot of clusters of different shapes/sizes/responsibilities. One cluster in particular runs only 1 app (don’t ask :sadpanda:) which I believe makes it incompatible with the cluster-autoscaler default settings. We recently incurred the following outage:
- cluster-autoscaler scaled down the cluster to give just enough nodes to accommodate the 15 replicas of our app.
- team deployed new app version
- rolling update strategy of maxSurge=20% caused 3 new replica's to be added
- these 3 new replica's couldn't fit in the cluster
- cluster-autoscaler kicked in and started to provision new nodes, but new resources weren’t available in time and created a backlog in the scheduling of the new pods
- deploy eventually failed, i got pinged.

### How
I’ve added an _Options_ map to the Autoscaler struct which will be templated out in the cluster-autoscaler-deployment.yaml. This allows us (hotelscom) to specifically add the options we need but also give others the chance to override any they see fit.

#### Notes
I’ve chosen to retain the opinionated kube-aws direction by leaving the current default values hardcoded in the deployment.yaml, instead of setting them as defaults in the map.
I’ve tested that these values can still be overridden if duplicated in the ‘options’ map - it appears the libraries used by the autoscaler give precedence to whatever appears/is-resolved last.
