### PR TITLE
[Feature] Add more etcd options

### DIFF
--- a/core/etcd/config/templates/stack-template.json
+++ b/core/etcd/config/templates/stack-template.json
@@ -497,6 +497,12 @@
                   "ETCD_VERSION='",
                     "{{$.Etcd.Version}}",
                   "'\n"
+                  {{if $.Etcd.FormatOpts}}
+                  ,
+                  "ETCD_OPTS='",
+                    "{{$.Etcd.FormatOpts}}",
+                  "'\n"
+                  {{end}}
                 ]]}
               }
             }

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -770,6 +770,12 @@ worker:
 #        Description=Example Custom Service
 #        [Service]
 #        ExecStart=/bin/rkt run --set-env TAGS=Controller ...
+#  # extra etcd options 
+#  userSuppliedArgs:
+#    # for example, setting the --quota-backend-bytes and --auto-compaction-retention options
+#    quotaBackendBytes:
+#    autoCompactionRetention:
+
 
 ## Networking config
 

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -20,7 +20,7 @@ type Etcd struct {
 	DisasterRecovery   EtcdDisasterRecovery `yaml:"disasterRecovery,omitempty"`
 	VolumeMounts       []VolumeMount        `yaml:"volumeMounts,omitempty"`
 	EC2Instance        `yaml:",inline"`
-	UserSuppliedArgs   UserSuppliedArgs `yaml:"userSuppliedArgs,omitempty`
+	UserSuppliedArgs   UserSuppliedArgs `yaml:"userSuppliedArgs,omitempty"`
 	IAMConfig          IAMConfig        `yaml:"iam,omitempty"`
 	Nodes              []EtcdNode       `yaml:"nodes,omitempty"`
 	SecurityGroupIds   []string         `yaml:"securityGroupIds"`

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -3,7 +3,13 @@ package model
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
+)
+
+const (
+	MaxQuotaBackendBytes     int = 8 * 1024 * 1024 * 1024
+	DefaultQuotaBackendBytes int = 2 * 1024 * 1024 * 1024
 )
 
 type Etcd struct {
@@ -14,11 +20,12 @@ type Etcd struct {
 	DisasterRecovery   EtcdDisasterRecovery `yaml:"disasterRecovery,omitempty"`
 	VolumeMounts       []VolumeMount        `yaml:"volumeMounts,omitempty"`
 	EC2Instance        `yaml:",inline"`
-	IAMConfig          IAMConfig    `yaml:"iam,omitempty"`
-	Nodes              []EtcdNode   `yaml:"nodes,omitempty"`
-	SecurityGroupIds   []string     `yaml:"securityGroupIds"`
-	Snapshot           EtcdSnapshot `yaml:"snapshot,omitempty"`
-	Subnets            Subnets      `yaml:"subnets,omitempty"`
+	UserSuppliedArgs   UserSuppliedArgs `yaml:"userSuppliedArgs,omitempty`
+	IAMConfig          IAMConfig        `yaml:"iam,omitempty"`
+	Nodes              []EtcdNode       `yaml:"nodes,omitempty"`
+	SecurityGroupIds   []string         `yaml:"securityGroupIds"`
+	Snapshot           EtcdSnapshot     `yaml:"snapshot,omitempty"`
+	Subnets            Subnets          `yaml:"subnets,omitempty"`
 	StackExists        bool
 	UnknownKeys        `yaml:",inline"`
 }
@@ -27,6 +34,11 @@ type EtcdVersion string
 
 type EtcdDisasterRecovery struct {
 	Automated bool `yaml:"automated,omitempty"`
+}
+
+type UserSuppliedArgs struct {
+	QuotaBackendBytes       int `yaml:"quotaBackendBytes,omitempty"`
+	AutoCompactionRetention int `yaml:"autoCompactionRetention,omitempty"`
 }
 
 // Supported returns true when the disaster recovery feature provided by etcdadm can be enabled on the specified version of etcd
@@ -64,9 +76,13 @@ func NewDefaultEtcd() Etcd {
 			IOPS: 0,
 		},
 		StackExists: false,
+		UserSuppliedArgs: UserSuppliedArgs{
+			QuotaBackendBytes: DefaultQuotaBackendBytes,
+		},
 	}
 }
-func (i Etcd) LogicalName() string {
+
+func (e Etcd) LogicalName() string {
 	return "Etcd"
 }
 
@@ -151,11 +167,37 @@ func (e Etcd) SystemdUnitName() string {
 	return "etcd2.service"
 }
 
+func ValidateQuotaBackendBytes(bytes int) error {
+	if bytes > MaxQuotaBackendBytes {
+		return fmt.Errorf("quotaBackendBytes: %v is higher than the maximum allowed value 8,589,934,592", bytes)
+	}
+	return nil
+}
+
 func (e Etcd) Validate() error {
 	if err := ValidateVolumeMounts(e.VolumeMounts); err != nil {
 		return err
 	}
+
+	if err := ValidateQuotaBackendBytes(e.UserSuppliedArgs.QuotaBackendBytes); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (e Etcd) FormatOpts() string {
+	opts := []string{}
+	if e.UserSuppliedArgs.QuotaBackendBytes != 0 {
+		quotaFlag := []string{"--quota-backend-bytes", strconv.Itoa(e.UserSuppliedArgs.QuotaBackendBytes)}
+		opts = append(opts, strings.Join(quotaFlag, "="))
+	}
+
+	if e.UserSuppliedArgs.AutoCompactionRetention != 0 {
+		compactFlag := []string{"--auto-compaction-retention", strconv.Itoa(e.UserSuppliedArgs.AutoCompactionRetention)}
+		opts = append(opts, strings.Join(compactFlag, "="))
+	}
+	return strings.Join(opts, " ")
 }
 
 // Version returns the version of etcd (e.g. `3.2.1`) to be used for this etcd cluster

--- a/model/etcd_test.go
+++ b/model/etcd_test.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestEtcd(t *testing.T) {
+	etcdTest := Etcd{
+		EC2Instance: EC2Instance{
+			Count:        1,
+			InstanceType: "t2.medium",
+			RootVolume: RootVolume{
+				Size: 30,
+				Type: "gp2",
+				IOPS: 0,
+			},
+			Tenancy: "default",
+		},
+		DataVolume: DataVolume{
+			Size: 30,
+			Type: "gp2",
+			IOPS: 0,
+		},
+		StackExists: false,
+		UserSuppliedArgs: UserSuppliedArgs{
+			QuotaBackendBytes:       100000000,
+			AutoCompactionRetention: 1,
+		},
+	}
+
+	if etcdTest.LogicalName() != "Etcd" {
+		t.Errorf("logical name incorrect, expected: Etcd, got: %s", etcdTest.LogicalName())
+	}
+
+	if etcdTest.NameTagKey() != "kube-aws:etcd:name" {
+		t.Errorf("name tag key incorrect, expected: kube-aws:etcd:name, got: %s", etcdTest.NameTagKey())
+	}
+
+	if etcdTest.Version() != "3.2.13" {
+		t.Errorf("etcd version incorrect, epxected: 3.2.13, got: %s", etcdTest.Version())
+	}
+
+	if !etcdTest.NodeShouldHaveEIP() {
+		t.Error("expected: true, got: false")
+	}
+
+	if etcdTest.SystemdUnitName() != "etcd-member.service" {
+		t.Errorf("etcd systemd unit name incorrect, expected: etcd-member.service, got %s", etcdTest.SystemdUnitName())
+	}
+
+	if etcdTest.SecurityGroupRefs()[0] != `{"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackName}-EtcdSecurityGroup"}}` {
+		t.Errorf("etcd security group refs incorrect, expected: `{'Fn::ImportValue' : {'Fn::Sub' : '${NetworkStackName}-EtcdSecurityGroup'}}`, got: %s", etcdTest.SecurityGroupRefs()[0])
+	}
+
+	if err := etcdTest.Validate(); err != nil {
+		t.Error(err)
+	}
+
+	if etcdTest.FormatOpts() != "--quota-backend-bytes=100000000 --auto-compaction-retention=1" {
+		t.Errorf("etcd optional args incorrect, expected `--quota-backend-bytes=100000000 --auto-compaction-retention=1`, got: `%s`", etcdTest.FormatOpts())
+	}
+}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -68,6 +68,9 @@ func TestMainClusterConfig(t *testing.T) {
 				Subnets: model.Subnets{
 					subnet1,
 				},
+				UserSuppliedArgs: model.UserSuppliedArgs{
+					QuotaBackendBytes: model.DefaultQuotaBackendBytes,
+				},
 			},
 		}
 		actual := c.EtcdSettings

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -74,7 +74,6 @@ func TestMainClusterConfig(t *testing.T) {
 			},
 		}
 		actual := c.EtcdSettings
-		fmt.Printf("actual is %v", actual)
 		if !reflect.DeepEqual(expected, actual) {
 			t.Errorf(
 				"EtcdSettings didn't match: expected=%v actual=%v",

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -74,6 +74,7 @@ func TestMainClusterConfig(t *testing.T) {
 			},
 		}
 		actual := c.EtcdSettings
+		fmt.Printf("actual is %v", actual)
 		if !reflect.DeepEqual(expected, actual) {
 			t.Errorf(
 				"EtcdSettings didn't match: expected=%v actual=%v",
@@ -802,6 +803,9 @@ etcd:
 							Subnets: model.Subnets{
 								subnet1,
 							},
+							UserSuppliedArgs: model.UserSuppliedArgs{
+								QuotaBackendBytes: model.DefaultQuotaBackendBytes,
+							},
 						},
 					}
 					actual := c.EtcdSettings
@@ -859,6 +863,9 @@ etcd:
 							Subnets: model.Subnets{
 								subnet1,
 							},
+							UserSuppliedArgs: model.UserSuppliedArgs{
+								QuotaBackendBytes: model.DefaultQuotaBackendBytes,
+							},
 						},
 					}
 					actual := c.EtcdSettings
@@ -914,8 +921,12 @@ etcd:
 								Type:      "gp2",
 								IOPS:      0,
 								Ephemeral: false,
-							}, Subnets: model.Subnets{
+							},
+							Subnets: model.Subnets{
 								subnet1,
+							},
+							UserSuppliedArgs: model.UserSuppliedArgs{
+								QuotaBackendBytes: model.DefaultQuotaBackendBytes,
 							},
 						},
 					}
@@ -991,6 +1002,9 @@ etcd:
 							Subnets: model.Subnets{
 								subnet1,
 							},
+							UserSuppliedArgs: model.UserSuppliedArgs{
+								QuotaBackendBytes: model.DefaultQuotaBackendBytes,
+							},
 						},
 					}
 					actual := c.EtcdSettings
@@ -1064,6 +1078,9 @@ etcd:
 							},
 							Subnets: model.Subnets{
 								subnet1,
+							},
+							UserSuppliedArgs: model.UserSuppliedArgs{
+								QuotaBackendBytes: model.DefaultQuotaBackendBytes,
 							},
 						},
 					}
@@ -1142,6 +1159,9 @@ etcd:
 							Subnets: model.Subnets{
 								subnet1,
 							},
+							UserSuppliedArgs: model.UserSuppliedArgs{
+								QuotaBackendBytes: model.DefaultQuotaBackendBytes,
+							},
 						},
 					}
 					actual := c.EtcdSettings
@@ -1218,6 +1238,9 @@ etcd:
 							},
 							Subnets: model.Subnets{
 								subnet1,
+							},
+							UserSuppliedArgs: model.UserSuppliedArgs{
+								QuotaBackendBytes: model.DefaultQuotaBackendBytes,
 							},
 						},
 					}
@@ -3100,6 +3123,9 @@ subnets:
 								Ephemeral: false,
 							},
 							Subnets: subnets,
+						},
+						UserSuppliedArgs: model.UserSuppliedArgs{
+							QuotaBackendBytes: model.DefaultQuotaBackendBytes,
 						},
 					}
 					actual := c.EtcdSettings

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -3123,9 +3123,9 @@ subnets:
 								Ephemeral: false,
 							},
 							Subnets: subnets,
-						},
-						UserSuppliedArgs: model.UserSuppliedArgs{
-							QuotaBackendBytes: model.DefaultQuotaBackendBytes,
+							UserSuppliedArgs: model.UserSuppliedArgs{
+								QuotaBackendBytes: model.DefaultQuotaBackendBytes,
+							},
 						},
 					}
 					actual := c.EtcdSettings


### PR DESCRIPTION
This Pull request is to address the option of passing arguments to `/usr/local/bin/etcd` such as setting `--quota-backend-bytes` accordingly to the size of the etcd nodes. 

Apologize for my rusty Golang and I am pretty sure there are more places I need to change. Really appreciate your feedback. 