### PR TITLE
feat: Ability to toggle node pool rolling strategy between Sequential and Parallel

### DIFF
--- a/core/nodepool/cluster/cluster_test.go
+++ b/core/nodepool/cluster/cluster_test.go
@@ -106,8 +106,7 @@ func TestValidateKeyPair(t *testing.T) {
 s3URI: s3://mybucket/mydir
 apiEndpoints:
 - name: public
-  sequentialRoll:
-    enabled: false
+  nodePoolRollingStrategy: parallel
   dnsName: test-cluster.example.com
   loadBalancer:
     hostedZone:

--- a/core/nodepool/cluster/cluster_test.go
+++ b/core/nodepool/cluster/cluster_test.go
@@ -106,6 +106,8 @@ func TestValidateKeyPair(t *testing.T) {
 s3URI: s3://mybucket/mydir
 apiEndpoints:
 - name: public
+  sequentialRoll:
+    enabled: false
   dnsName: test-cluster.example.com
   loadBalancer:
     hostedZone:

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -120,11 +120,11 @@ func ConfigFromBytes(data []byte, plugins []*pluginmodel.Plugin) (*Config, error
 			}
 		}
 
-		if np.NodePoolRollingStrategy != "parallel" && np.NodePoolRollingStrategy != "sequential" {
-			if c.Worker.NodePoolRollingStrategy != "" && (c.Worker.NodePoolRollingStrategy == "sequential" || c.Worker.NodePoolRollingStrategy == "parallel") {
+		if np.NodePoolRollingStrategy != "Parallel" && np.NodePoolRollingStrategy != "Sequential" {
+			if c.Worker.NodePoolRollingStrategy != "" && (c.Worker.NodePoolRollingStrategy == "Sequential" || c.Worker.NodePoolRollingStrategy == "Parallel") {
 				np.NodePoolRollingStrategy = c.Worker.NodePoolRollingStrategy
 			} else {
-				np.NodePoolRollingStrategy = "parallel"
+				np.NodePoolRollingStrategy = "Parallel"
 			}
 		}
 

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -34,10 +34,10 @@ type UnmarshalledConfig struct {
 }
 
 type Worker struct {
-	APIEndpointName      string                     `yaml:"apiEndpointName,omitempty"`
-	NodePools            []*nodepool.ProvidedConfig `yaml:"nodePools,omitempty"`
-	model.UnknownKeys    `yaml:",inline"`
-	GlobalSequentialRoll model.SequentialRoll `yaml:"globalSequentialRoll,omitempty"`
+	APIEndpointName         string                     `yaml:"apiEndpointName,omitempty"`
+	NodePools               []*nodepool.ProvidedConfig `yaml:"nodePools,omitempty"`
+	model.UnknownKeys       `yaml:",inline"`
+	NodePoolRollingStrategy string `yaml:"nodePoolRollingStrategy,omitempty"`
 }
 
 type Config struct {
@@ -120,9 +120,11 @@ func ConfigFromBytes(data []byte, plugins []*pluginmodel.Plugin) (*Config, error
 			}
 		}
 
-		if np.SequentialRoll.Enabled == false {
-			if c.Worker.GlobalSequentialRoll.Enabled == true {
-				np.SequentialRoll.Enabled = true
+		if np.NodePoolRollingStrategy != "parallel" && np.NodePoolRollingStrategy != "sequential" {
+			if c.Worker.NodePoolRollingStrategy != "" && (c.Worker.NodePoolRollingStrategy == "sequential" || c.Worker.NodePoolRollingStrategy == "parallel") {
+				np.NodePoolRollingStrategy = c.Worker.NodePoolRollingStrategy
+			} else {
+				np.NodePoolRollingStrategy = "parallel"
 			}
 		}
 

--- a/core/root/config/config.go
+++ b/core/root/config/config.go
@@ -34,9 +34,10 @@ type UnmarshalledConfig struct {
 }
 
 type Worker struct {
-	APIEndpointName   string                     `yaml:"apiEndpointName,omitempty"`
-	NodePools         []*nodepool.ProvidedConfig `yaml:"nodePools,omitempty"`
-	model.UnknownKeys `yaml:",inline"`
+	APIEndpointName      string                     `yaml:"apiEndpointName,omitempty"`
+	NodePools            []*nodepool.ProvidedConfig `yaml:"nodePools,omitempty"`
+	model.UnknownKeys    `yaml:",inline"`
+	GlobalSequentialRoll model.SequentialRoll `yaml:"globalSequentialRoll,omitempty"`
 }
 
 type Config struct {
@@ -108,7 +109,6 @@ func ConfigFromBytes(data []byte, plugins []*pluginmodel.Plugin) (*Config, error
 		if err := np.Taints.Validate(); err != nil {
 			return nil, fmt.Errorf("invalid taints for node pool at index %d: %v", i, err)
 		}
-
 		if np.APIEndpointName == "" {
 			if c.Worker.APIEndpointName == "" {
 				if len(cpConfig.APIEndpoints) > 1 {
@@ -117,6 +117,12 @@ func ConfigFromBytes(data []byte, plugins []*pluginmodel.Plugin) (*Config, error
 				np.APIEndpointName = cpConfig.APIEndpoints.GetDefault().Name
 			} else {
 				np.APIEndpointName = c.Worker.APIEndpointName
+			}
+		}
+
+		if np.SequentialRoll.Enabled == false {
+			if c.Worker.GlobalSequentialRoll.Enabled == true {
+				np.SequentialRoll.Enabled = true
 			}
 		}
 

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -269,12 +269,13 @@ worker:
 #  # Required if there are 2 or more API endpoints defined in `apiEndpoints`
 #  # Can be overriden per node pool by specifying `worker.nodePools[].apiEndpointName`
 #  apiEndpointName: versionedPublic
-#  # Used to globally toggle nodePool sequential rollout strategy
-#  # Default behaviour (false / disabled) will not overwrite anything
-#  # If enabled (set to true) it will overwrite all "sequentialRoll" false values at a nodePool level (see below)
-#  # For finer grain control, enable it at a lower (nodePool) level if only targeting specific nodePools.
-#  GlobalSequentialRoll:
-#    enabled: true
+#  # Used to globally specify nodePool rolling strategy across availability zones: 'sequential' or 'parallel'
+#  # Default behaviour ('parallel') will roll out nodes concurrently across availability zones
+#  # If set to 'sequential', the nodePools will roll out sequentially, in order of declaration, across availability zones
+#  # If set at a Worker level, it will only take effect if it is not set at a nodePool level
+#  # For finer grain control, declare it on a nodePool-by-nodePool basis
+#  nodePoolRollingStrategy: sequential
+
   nodePools:
     - # Name of this node pool. Must be unique among all the node pools in this cluster
       name: nodepool1
@@ -283,15 +284,13 @@ worker:
 #      # If omitted, public subnets are created by kube-aws and used for worker nodes
 #      subnets:
 #      - name: ManagedPublicSubnet1
-#      # Used to toggle how the worker nodepools will roll out.
-#      # Default behaviour (false / disabled) will create / upgrade each nodepool in parallel
-#      # If enabled, the worker nodepools will roll out one after the other
-#      # in sequence of how they are defined in the nodePool section
-#      # NOTICE: if there are multiple nodePool groups that are to be rolled sequentially and concurrently
-#      # the nodePools that have sequential roll out need to be declared before those with concurrent roll out
-#      # otherwise the first declared sequential nodePool will be dependent on the last declared concurrent nodePool
-#      sequentialRoll:
-#        enabled: false
+#      # Used to specify the strategy in which nodePools will roll out across availability zones: in sequence or parallel
+#      # By default (if not set at nodePool/worker level) the nodePools will roll out in parallel across all availability zones
+#      # If set to 'sequential', the nodePools will roll out one-by-one in order of declaration across all availability zones
+#      # NOTICE: if there are multiple nodePool groups that will use both rolling strategies ('sequential'/'parallel')
+#      # the nodePools rolling out in sequence should be declared before those that roll out in parallel
+#      # otherwise, the first declared nodePool to roll out in sequence will depend on the last concurrent nodePool
+#      nodePoolRollingStrategy: parallel
 #      # Existing "glue" security groups attached to worker nodes which are typically used to allow
 #      # access from worker nodes to services running on an existing infrastructure
 #      securityGroupIds:

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -268,8 +268,13 @@ worker:
 #  # The name of the API endpoint defined in the top level `apiEndpoints` that the worker node pools will use to access the k8s API
 #  # Required if there are 2 or more API endpoints defined in `apiEndpoints`
 #  # Can be overriden per node pool by specifying `worker.nodePools[].apiEndpointName`
-#  apiEndpointName: versionedPublic
-#
+#  apiEndpointName: versionedPublic\
+#  # Used to globally toggle nodePool sequential rollout strategy
+#  # Default behaviour (false / disabled) will not overwrite anything
+#  # If enabled (set to true) it will overwrite all "sequentialRoll" false values at a nodePool level (see below)
+#  # For finer grain control, enable it at a lower (nodePool) level if only targeting specific nodePools.
+#  GlobalSequentialRoll:
+#    enabled: true
   nodePools:
     - # Name of this node pool. Must be unique among all the node pools in this cluster
       name: nodepool1
@@ -278,7 +283,15 @@ worker:
 #      # If omitted, public subnets are created by kube-aws and used for worker nodes
 #      subnets:
 #      - name: ManagedPublicSubnet1
-#
+#      # Used to toggle how the worker nodepools will roll out.
+#      # Default behaviour (false / disabled) will create / upgrade each nodepool in parallel
+#      # If enabled, the worker nodepools will roll out one after the other
+#      # in sequence of how they are defined in the nodePool section
+#      # NOTICE: if there are multiple nodePool groups that are to be rolled sequentially and concurrently
+#      # the nodePools that have sequential roll out need to be declared before those with concurrent roll out
+#      # otherwise the first declared sequential nodePool will be dependent on the last declared concurrent nodePool
+#      sequentialRoll:
+#        enabled: false
 #      # Existing "glue" security groups attached to worker nodes which are typically used to allow
 #      # access from worker nodes to services running on an existing infrastructure
 #      securityGroupIds:

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -269,12 +269,12 @@ worker:
 #  # Required if there are 2 or more API endpoints defined in `apiEndpoints`
 #  # Can be overriden per node pool by specifying `worker.nodePools[].apiEndpointName`
 #  apiEndpointName: versionedPublic
-#  # Used to globally specify nodePool rolling strategy across availability zones: 'sequential' or 'parallel'
+#  # Used to globally specify nodePool rolling strategy across availability zones: 'Sequential' or 'Parallel'
 #  # Default behaviour ('parallel') will roll out nodes concurrently across availability zones
-#  # If set to 'sequential', the nodePools will roll out sequentially, in order of declaration, across availability zones
+#  # If set to 'Sequential', the nodePools will roll out sequentially, in order of declaration, across availability zones
 #  # If set at a Worker level, it will only take effect if it is not set at a nodePool level
 #  # For finer grain control, declare it on a nodePool-by-nodePool basis
-#  nodePoolRollingStrategy: sequential
+#  nodePoolRollingStrategy: Sequential
 
   nodePools:
     - # Name of this node pool. Must be unique among all the node pools in this cluster
@@ -286,11 +286,11 @@ worker:
 #      - name: ManagedPublicSubnet1
 #      # Used to specify the strategy in which nodePools will roll out across availability zones: in sequence or parallel
 #      # By default (if not set at nodePool/worker level) the nodePools will roll out in parallel across all availability zones
-#      # If set to 'sequential', the nodePools will roll out one-by-one in order of declaration across all availability zones
-#      # NOTICE: if there are multiple nodePool groups that will use both rolling strategies ('sequential'/'parallel')
+#      # If set to 'Sequential', the nodePools will roll out one-by-one in order of declaration across all availability zones
+#      # NOTICE: if there are multiple nodePool groups that will use both rolling strategies ('Sequential'/'Parallel')
 #      # the nodePools rolling out in sequence should be declared before those that roll out in parallel
 #      # otherwise, the first declared nodePool to roll out in sequence will depend on the last concurrent nodePool
-#      nodePoolRollingStrategy: parallel
+#      nodePoolRollingStrategy: Parallel
 #      # Existing "glue" security groups attached to worker nodes which are typically used to allow
 #      # access from worker nodes to services running on an existing infrastructure
 #      securityGroupIds:

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -269,9 +269,10 @@ worker:
 #  # Required if there are 2 or more API endpoints defined in `apiEndpoints`
 #  # Can be overriden per node pool by specifying `worker.nodePools[].apiEndpointName`
 #  apiEndpointName: versionedPublic
-#  # Used to globally specify nodePool rolling strategy across availability zones: 'Sequential' or 'Parallel'
-#  # Default behaviour ('parallel') will roll out nodes concurrently across availability zones
-#  # If set to 'Sequential', the nodePools will roll out sequentially, in order of declaration, across availability zones
+#
+#  # Used to globally specify the strategy in which nodePools will roll out: in sequence or parallel
+#  # Default behaviour ('parallel') will roll out nodePools concurrently
+#  # If set to 'Sequential', the nodePools will roll out sequentially, in order of declaration
 #  # If set at a Worker level, it will only take effect if it is not set at a nodePool level
 #  # For finer grain control, declare it on a nodePool-by-nodePool basis
 #  nodePoolRollingStrategy: Sequential
@@ -284,13 +285,14 @@ worker:
 #      # If omitted, public subnets are created by kube-aws and used for worker nodes
 #      subnets:
 #      - name: ManagedPublicSubnet1
-#      # Used to specify the strategy in which nodePools will roll out across availability zones: in sequence or parallel
-#      # By default (if not set at nodePool/worker level) the nodePools will roll out in parallel across all availability zones
-#      # If set to 'Sequential', the nodePools will roll out one-by-one in order of declaration across all availability zones
+#      # Used to specify the strategy in which the nodePool will roll out: in sequence or parallel
+#      # By default (if not set at nodePool/worker level) the nodePool will roll out in parallel
+#      # If set to 'Sequential', the nodePools will roll out one-by-one in order of declaration
 #      # NOTICE: if there are multiple nodePool groups that will use both rolling strategies ('Sequential'/'Parallel')
 #      # the nodePools rolling out in sequence should be declared before those that roll out in parallel
 #      # otherwise, the first declared nodePool to roll out in sequence will depend on the last concurrent nodePool
 #      nodePoolRollingStrategy: Parallel
+#
 #      # Existing "glue" security groups attached to worker nodes which are typically used to allow
 #      # access from worker nodes to services running on an existing infrastructure
 #      securityGroupIds:

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -268,7 +268,7 @@ worker:
 #  # The name of the API endpoint defined in the top level `apiEndpoints` that the worker node pools will use to access the k8s API
 #  # Required if there are 2 or more API endpoints defined in `apiEndpoints`
 #  # Can be overriden per node pool by specifying `worker.nodePools[].apiEndpointName`
-#  apiEndpointName: versionedPublic\
+#  apiEndpointName: versionedPublic
 #  # Used to globally toggle nodePool sequential rollout strategy
 #  # Default behaviour (false / disabled) will not overwrite anything
 #  # If enabled (set to true) it will overwrite all "sequentialRoll" false values at a nodePool level (see below)

--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -99,7 +99,7 @@
       },
       "DependsOn": [
         "{{$.ControlPlane.Name}}"
-        {{ if $p.SequentialRoll -}}
+        {{ if eq $p.NodePoolRollingStrategy "sequential" -}}
           {{ if $i -}}
           ,"{{ (index $.NodePools (sub $i 1)).Name}}"
           {{ end -}}

--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -99,7 +99,7 @@
       },
       "DependsOn": [
         "{{$.ControlPlane.Name}}"
-        {{ if eq $p.NodePoolRollingStrategy "sequential" -}}
+        {{ if eq $p.NodePoolRollingStrategy "Sequential" -}}
           {{ if $i -}}
           ,"{{ (index $.NodePools (sub $i 1)).Name}}"
           {{ end -}}

--- a/core/root/config/templates/stack-template.json
+++ b/core/root/config/templates/stack-template.json
@@ -73,7 +73,7 @@
         "TemplateURL" : "{{$.Etcd.TemplateURL}}"
       }
     }
-    {{range $_, $p := .NodePools}},
+    {{range $i, $p := .NodePools}},
     "{{$p.Name}}": {
       "Type" : "AWS::CloudFormation::Stack",
       "Properties" : {
@@ -99,6 +99,11 @@
       },
       "DependsOn": [
         "{{$.ControlPlane.Name}}"
+        {{ if $p.SequentialRoll -}}
+          {{ if $i -}}
+          ,"{{ (index $.NodePools (sub $i 1)).Name}}"
+          {{ end -}}
+        {{ end -}}
       ]
     }{{end}}
     {{range $n, $r := .ExtraCfnResources}}

--- a/core/root/template_params.go
+++ b/core/root/template_params.go
@@ -168,13 +168,11 @@ func (p nodePool) NeedToExportIAMroles() bool {
 	return p.nodePool.IAMConfig.InstanceProfile.Arn == ""
 }
 
-func (p nodePool) SequentialRoll() bool {
-	return p.nodePool.SequentialRoll.Enabled
+// returns NodePoolRolling strategy string to be used in stack-template
+func (p nodePool) NodePoolRollingStrategy() string {
+	return p.nodePool.NodePoolConfig.NodePoolRollingStrategy
 }
 
-func (p nodePool) SequentialWorkerRoll() bool {
-	return true
-}
 func (c TemplateParams) ControlPlane() controlPlane {
 	return controlPlane{
 		controlPlane: c.cluster.controlPlane,

--- a/core/root/template_params.go
+++ b/core/root/template_params.go
@@ -168,6 +168,13 @@ func (p nodePool) NeedToExportIAMroles() bool {
 	return p.nodePool.IAMConfig.InstanceProfile.Arn == ""
 }
 
+func (p nodePool) SequentialRoll() bool {
+	return p.nodePool.SequentialRoll.Enabled
+}
+
+func (p nodePool) SequentialWorkerRoll() bool {
+	return true
+}
 func (c TemplateParams) ControlPlane() controlPlane {
 	return controlPlane{
 		controlPlane: c.cluster.controlPlane,
@@ -186,8 +193,8 @@ func (c TemplateParams) Network() networkStack {
 	}
 }
 
-func (c TemplateParams) NodePools() []NestedStack {
-	nps := []NestedStack{}
+func (c TemplateParams) NodePools() []nodePool {
+	nps := []nodePool{}
 	for _, np := range c.cluster.nodePools {
 		nps = append(nps, nodePool{
 			nodePool: np,

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -17,22 +17,16 @@ type NodePoolConfig struct {
 	CustomSettings            map[string]interface{} `yaml:"customSettings,omitempty"`
 	VolumeMounts              []VolumeMount          `yaml:"volumeMounts,omitempty"`
 	Raid0Mounts               []Raid0Mount           `yaml:"raid0Mounts,omitempty"`
-	UnknownKeys               `yaml:",inline"`
 	NodeSettings              `yaml:",inline"`
 	NodeStatusUpdateFrequency string              `yaml:"nodeStatusUpdateFrequency"`
 	CustomFiles               []CustomFile        `yaml:"customFiles,omitempty"`
 	CustomSystemdUnits        []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
 	Gpu                       Gpu                 `yaml:"gpu"`
-	SequentialRoll            SequentialRoll      `yaml:"sequentialRoll,omitempty"`
+	NodePoolRollingStrategy   string              `yaml:"nodePoolRollingStrategy,omitempty"`
+	UnknownKeys               `yaml:",inline"`
 }
 
 type ClusterAutoscaler struct {
-	Enabled     bool `yaml:"enabled,omitempty"`
-	UnknownKeys `yaml:",inline"`
-}
-
-// SequentialRoll will allow the nodepools to roll one at a time in the order they are defined in the nodePool body
-type SequentialRoll struct {
 	Enabled     bool `yaml:"enabled,omitempty"`
 	UnknownKeys `yaml:",inline"`
 }

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+
 	"github.com/kubernetes-incubator/kube-aws/logger"
 )
 
@@ -22,9 +23,16 @@ type NodePoolConfig struct {
 	CustomFiles               []CustomFile        `yaml:"customFiles,omitempty"`
 	CustomSystemdUnits        []CustomSystemdUnit `yaml:"customSystemdUnits,omitempty"`
 	Gpu                       Gpu                 `yaml:"gpu"`
+	SequentialRoll            SequentialRoll      `yaml:"sequentialRoll,omitempty"`
 }
 
 type ClusterAutoscaler struct {
+	Enabled     bool `yaml:"enabled,omitempty"`
+	UnknownKeys `yaml:",inline"`
+}
+
+// SequentialRoll will allow the nodepools to roll one at a time in the order they are defined in the nodePool body
+type SequentialRoll struct {
 	Enabled     bool `yaml:"enabled,omitempty"`
 	UnknownKeys `yaml:",inline"`
 }


### PR DESCRIPTION
### What

Ability to toggle in your `cluster.yaml`  file at a `nodePool:` or `worker:` level whether nodePools are going to be rolled out / rolled in sequentially or concurrently

### Why

After doing a fair share of rolls, it was noticed that at times, platforms are more resilient to a full `Availability Zone` going down rather than having 1 `nodePool` going down in each respective `Availability Zone`. Since sometimes it is needed to roll out nodePools in sequential order, it would be easier to have it as a toggleable option in your `cluster.yaml`.

This should allow for easier switching between rolling out workers sequentially or concurrently.

### How

* In the root stack-template, I made it so that when we loop through our currently declared `nodePools` we store their index. In the `DependsOn` field, I have added control flow to check if the current `nodePool`  has `sequentialRoll` enabled, and if it does, the previous nodePool is added as a dependency.

* To toggle `sequentialRoll` globally, I have added the sequentialRoll field in the `Worker` struct. When the config is read from a file, if the sequentialRoll field is enabled at a `Worker` level, then it overwrites all values of sequentialRoll false at a nodePool level, setting them to true. This ensures that if declared at a global level, then all of the nodePools are going to be rolled out sequentially. If that is not the desired behaviour, simply set the targeted nodePools to roll out sequentially on an individual basis.

*  The TemplateParams `NodePools` function now returns a slice of `nodePool` instead of a slice of `NestedStack` interfaces, this was done in order to be able to use the sequentialRoll flags in the stack-template.

#### Notes

* I tested this in cluster with 2 sets of nodePools (3 nodePools per set), one concurrent and one sequential, across 3 different AZs and it worked perfectly. There is a caveat, however, if there are nodePools being rolled out sequentially and concurrently, the nodePools declared sequentially will have to be declared before the concurrent ones, otherwise the first declared sequential nodePool will dependend on the last declared concurrent nodePool. 

* If nodePools are to be rolled sequentially, they will roll out in order of declaration in your `cluster.yaml` (unsure if I specified that anywhere) e.g if you have A, B, C declared in that order, thats the order they will also roll out in.