### PR TITLE
Feature/add custom kiam role

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -213,9 +213,9 @@
     "IAMInstanceProfileController": {
       "Properties": {
 		"Path": "/",
-		{{ if .Controller.IAMConfig.ManagedRole }}
+		{{ if and (.Controller.IAMConfig.Role.UseStrict) (.Controller.IAMConfig.Role.Name) }}
 		"Roles": [
-			"{{.Controller.IAMConfig.ManagedRole}}"
+			"{{.Controller.IAMConfig.Role.Name}}"
 		]
 		{{ else }}
         "Roles": [
@@ -450,7 +450,7 @@
           "Version": "2012-10-17"
         },
         "Path": "/",
-        {{if .Controller.IAMConfig.Role.Name }}
+        {{if and (.Controller.IAMConfig.Role.Name) (not .Controller.IAMConfig.Role.UseStrict) }}
         "RoleName":  {"Fn::Join": ["-", ["{{$.ClusterName}}", {"Ref": "AWS::Region"}, "{{.Controller.IAMConfig.Role.Name}}"]]},
         {{end}}
         "ManagedPolicyArns": [

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -37,7 +37,7 @@
           {{range $k, $v := $.Controller.InstanceTags -}}
           {
             "Key": "{{$k}}",
-            "PropagateAtLaunch": "true",
+            "PropagateAtLaunch": "true" ,
             "Value": "{{$v}}"
           },
           {{end -}}
@@ -212,12 +212,18 @@
     {{ if not .Controller.IAMConfig.InstanceProfile.Arn }}
     "IAMInstanceProfileController": {
       "Properties": {
-        "Path": "/",
+		"Path": "/",
+		{{ if .Controller.IAMConfig.ManagedRole }}
+		"Roles": [
+			"{{.Controller.IAMConfig.ManagedRole}}"
+		]
+		{{ else }}
         "Roles": [
-          {
-            "Ref": "IAMRoleController"
-          }
-        ]
+			{
+				"Ref": "IAMRoleController"
+			}
+		]
+		{{ end }}
       },
       "Type": "AWS::IAM::InstanceProfile"
     },

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -218,6 +218,11 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #      # the Statements included in the ManagedPolicy are the minimun ones required for the Controllers to run.
 #      name: "yourManagedRole"
 #
+#	   # If useStrict is enabled (i.e set to true), kube-aws will not create a new IAM role and will instead use an existing one.
+#	   # The existing role name must be set under iam.role.name and must exist on AWS before the cluster is rolled out.
+#	   # By default, useStrict is disabled (i.e set to false)
+#	   useStrict: true   
+#
 #      # If you set managedPolicies here it will be attached in addition to the created managedPolicy in kube-aws for the cluster.
 #      # CAUTION: if you attach a more restrictive policy in some resources (i.e ec2:* Deny) you can make kube-aws fail.
 #      managedPolicies:

--- a/model/iamconfig.go
+++ b/model/iamconfig.go
@@ -11,6 +11,7 @@ type IAMConfig struct {
 	InstanceProfile IAMInstanceProfile `yaml:"instanceProfile,omitempty"`
 	UnknownKeys     `yaml:",inline"`
 	Policy          IAMPolicy
+	ManagedRole     string `yaml:"managedRole,omitempty"`
 }
 
 type IAMRole struct {

--- a/model/iamconfig.go
+++ b/model/iamconfig.go
@@ -11,12 +11,12 @@ type IAMConfig struct {
 	InstanceProfile IAMInstanceProfile `yaml:"instanceProfile,omitempty"`
 	UnknownKeys     `yaml:",inline"`
 	Policy          IAMPolicy
-	ManagedRole     string `yaml:"managedRole,omitempty"`
 }
 
 type IAMRole struct {
 	ARN             `yaml:",inline"`
 	Name            string             `yaml:"name,omitempty"`
+	UseStrict       bool               `yaml:"useStrict,omitempty"`
 	ManagedPolicies []IAMManagedPolicy `yaml:"managedPolicies,omitempty"`
 }
 

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1714,18 +1714,38 @@ worker:
 			},
 		},
 		{
-			context: "WithControllerManagedRole",
+			context:    "WithControllerIAMDefaultUseStrict",
+			configYaml: minimalValidConfigYaml,
+			assertConfig: []ConfigTester{
+				func(c *config.Config, t *testing.T) {
+					expectedValue := false
+
+					if c.Controller.IAMConfig.Role.UseStrict != expectedValue {
+						t.Errorf("controller's iam.role.useStrict didn't match : expected=%v actual=%v", expectedValue, c.Controller.IAMConfig.Role.UseStrict)
+					}
+				},
+			},
+		},
+		{
+			context: "WithControllerIAMEnabledUseStrict",
 			configYaml: minimalValidConfigYaml + `
 controller:
   iam:
-    managedRole: us-west-2-cluster-existing-role
+   role:
+     name: myrole1
+     useStrict: true
 `,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
-					expectedIAMManagedRole := "us-west-2-cluster-existing-role"
+					expectedUseStrict := true
+					expectedRoleName := "myrole1"
 
-					if expectedIAMManagedRole != c.Controller.IAMConfig.ManagedRole {
-						t.Errorf("controller's iam.managedRole didn't match : expected=%v actual=%v", expectedIAMManagedRole, c.Controller.IAMConfig.ManagedRole)
+					if expectedRoleName != c.Controller.IAMConfig.Role.Name {
+						t.Errorf("controller's iam.role.name didn't match : expected=%v actual=%v", expectedRoleName, c.Controller.IAMConfig.Role.Name)
+					}
+
+					if expectedUseStrict != c.Controller.IAMConfig.Role.UseStrict {
+						t.Errorf("controller's iam.role.useStrict didn't matchg : expected=%v actual=%v", expectedUseStrict, c.Controller.IAMConfig.Role.UseStrict)
 					}
 				},
 			},

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1714,6 +1714,23 @@ worker:
 			},
 		},
 		{
+			context: "WithControllerManagedRole",
+			configYaml: minimalValidConfigYaml + `
+controller:
+  iam:
+    managedRole: us-west-2-cluster-existing-role
+`,
+			assertConfig: []ConfigTester{
+				func(c *config.Config, t *testing.T) {
+					expectedIAMManagedRole := "us-west-2-cluster-existing-role"
+
+					if expectedIAMManagedRole != c.Controller.IAMConfig.ManagedRole {
+						t.Errorf("controller's iam.managedRole didn't match : expected=%v actual=%v", expectedIAMManagedRole, c.Controller.IAMConfig.ManagedRole)
+					}
+				},
+			},
+		},
+		{
 			context: "WithWaitSignalDisabled",
 			configYaml: minimalValidConfigYaml + `
 waitSignal:


### PR DESCRIPTION
## What

This feature allows the user to specify if they want to use the `IAM.role.name` as strict (without appending the region and cluster-name to it) by providing a new flag under `IAM.role` in the `cluster.yaml` configuration file. E.g:
```yaml
controller:
  iam:
    role:
       name: myrole1
       useStrict: true
```

When the cluster is rolled-out with the above example, `kube-aws` will not create a new role (e.g `<clusterName> - <region> - myrole1 ` ) but will instead use `myrole1` that already exists on AWS as an `IAM Role`.

The `IAM role` needs to already be created and have a policy attached. What this feature does is simply assign the existing role (specified in the cluster.yaml file) to the `IAMControllerInstanceProfile` that is created upon cluster roll-outs, to replace the `IAMControllerRole` that is created along with the instance profile.

## Why

In order to create your own [Kiam](https://github.com/uswitch/kiam) roles you need to add a trust. The trust is part of the `Controller` and only gets created when the cluster is rolled-out. At Hotels.com, we would like to manage our `Kiam` specific roles and policies before we roll-out our cluster, and possibly re-use the same role for multiple cluster in the same AWS account. 

Currently, we cannot manage roles prior to rolling out our cluster because they cannot point to the Kiam specific trust, in order to point to it we would have to wait for it to be available and for the cluster to roll out. This keeps the role name predictable.

## How

In order to have an existing role attached to the ControllerInstanceProfile, we need to have that role's name. To keep the default behaviour, this feature uses the `IAM.Role.Name` field and introduces an extra field under `IAM.Role` called `UseStrict` (to use the strict form of the role name with nothing appended or prepended).

* By default, `UseStrict` is set to false. This keeps the default behaviour and the change will not affect existing clusters.

* If enabled, instead of creating a new role (`IAMControllerRole`) and then adding that to the `IAMInstanceProfileController`,  we simply pass the name of the existing role (taken from `IAM.Role.Name`) to the `IAMInstanceProfileController`. 

* If it is disabled, then we create a new controller role.

___Note:___ the same can be achieved by manually removing the role from the `IAMInstanceProfileController`, adding our existing role to the instance profile and then deleting the kiam server pods using the kube api, this however takes long and does not fix the initial issue of managing roles  before rolling out a cluster and minimising loss in the pods that use Kiam policies.
