### PR TITLE
Add updateStrategy RollingUpdate for kiam agent

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -5731,6 +5731,8 @@ write_files:
         namespace: kube-system
         name: kiam-agent
       spec:
+        updateStrategy:
+          type: RollingUpdate
         template:
           metadata:
             annotations:


### PR DESCRIPTION
Kiam-server ```updateStrategy``` is set to [```RollingUpdate```,](https://github.com/kubernetes-incubator/kube-aws/blob/master/core/controlplane/config/templates/cloud-config-controller#L5596-L5598) and it seems no problem to set ```RollingUpdate``` to kiam-agent ```updateStrategy```, so I add it.