### PR TITLE
Explicitly set default dnsmasq min-port [Tiny]

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3934,6 +3934,7 @@ write_files:
                 - -restartDnsmasq=true
                 - --
                 - -k
+                - --min-port=1024
                 - --cache-size=1000
                 - --server=/cluster.local/{{.DNSServiceIP}}
                 - --server=/in-addr.arpa/{{.DNSServiceIP}}


### PR DESCRIPTION
## What
Our perf team flagged up some repeated dns failures under load and tracked the issue down to the kube-dns dnsmasq configuration. This has since started hitting us hard in clusters running CI builds, causing lots of intermitted failures.

We believe the issues is resolved in [dnsmasq 2.79](https://github.com/PowerDNS/dnsmasq/blob/ebedcbaeb8c0e356077fba126f22a4049d52638b/src/dnsmasq.c#L225) so we've put in a [PR to kube-dns](https://github.com/kubernetes/dns/pull/262) to hopefully get a new kube-dns image built/released.

I plan on removing this explicit flag once the underlying dnsmasq is updated and the image is released.

## Why
I've chosen to PR this into kube-dns now as we view the failures pretty annoying and hard to debug, plus we don't have a hard timeline on a fresh kube-dns being cut.

That said, I would totally understand if you reject this PR on the basis that you'd prefer to wait for the fix to filter down through the next kube-dns release.

#kubeawsislove #kubeawsislife
