### PR TITLE
fix: Attach kube-aws controller policy to pre-existing IAM role

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -231,7 +231,12 @@
       "Type" : "AWS::IAM::ManagedPolicy",
       "Properties" : {
         "Description" : "Policy for managing kube-aws k8s controllers",
-        "Path" : "/",
+				"Path" : "/",
+				{{ if and (.Controller.IAMConfig.Role.UseStrict) (.Controller.IAMConfig.Role.Name) }}
+				"Roles" : [
+           "{{.Controller.IAMConfig.Role.Name}}"
+				],
+				{{ end }}
         "PolicyDocument" :   {
           "Version":"2012-10-17",
           "Statement": [


### PR DESCRIPTION
## Fix for [custom kiam role feature](https://github.com/kubernetes-incubator/kube-aws/pull/1433)


### Why

When I worked on the custom kiam role PR I overlooked the fact that kube-aws autogenerates the controller policy:
* By default, kube-aws will create an `IAMManagedPolicy` for the controller, after it creates an `IAMControllerRole` and attaches the ManagedPolicy to it.
* If you use a pre-existing role (through the `useStrict` feature implemented in the custom kiam role PR), the `IAMManagedPolicy` gets generated, but it does not get attached to any role. It would be up to the developer to manually attach it in the console or through the aws cli. Moreoever, since the controller policy will always have a randomly generated name it complicates things.

In my personal opinion this is a bug. When using a pre-existing IAM role everything should work just as before.

### What

To fix this, I added an `if` condition in the stack-template. When creating the `ManagedPolicy`:
* If we are using a pre-existing role, and if that role name is in our cluster.yaml, then we attach the policy to our role, on creation.
* If we are using the kube-aws generated role, then the behaviour is the same as before.

---

I'm open to suggestions if there is anything else that should be added in or changed. I personally regard this as a bugfix, apologies for overlooking this detail in the first place when I implemented the custom role feature.