### PR TITLE
0.12 release: remove legacy networking (less is more)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,23 +2,30 @@
 
 
 [[projects]]
+  digest = "1:a047a7359c2d49094ffa32d3737a2f0035978e46396f4e592d78c3c479e635e6"
   name = "github.com/Masterminds/semver"
   packages = ["."]
+  pruneopts = ""
   revision = "59c29afe1a994eacb71c833025ca7acf874bb1da"
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:a05b9ec52300c1709ca61cf248dee6d9d52dfd6a1b24b2dadda4d8b93ff8aa89"
   name = "github.com/Masterminds/sprig"
   packages = ["."]
+  pruneopts = ""
   revision = "9526be0327b26ad31aa70296a7b10704883976d5"
   version = "2.12.0"
 
 [[projects]]
+  digest = "1:4cd16cfeb5c924029357ea73eeb68ec6292006d159e5a2d44ce55a0f0eabd23a"
   name = "github.com/aokoli/goutils"
   packages = ["."]
+  pruneopts = ""
   revision = "e57d01ace047c1a43e6a49ecf3ecc50ed2be81d1"
 
 [[projects]]
+  digest = "1:7c16652299686ea6c477751db35d74bf41ccdc0940ca3fac86679fe837e469cc"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -54,131 +61,195 @@
     "service/kms",
     "service/route53",
     "service/s3",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = ""
   revision = "e0cdae7a65ba3a5e66a0af747a7b3967ddac099c"
   version = "v1.8.30"
 
 [[projects]]
+  digest = "1:d67d2cf6384e448151f03df3d603d88cf15ef2a1e0eb78ba464c8b15a2d0e6b1"
   name = "github.com/coreos/coreos-cloudinit"
   packages = [
     "config",
-    "config/validate"
+    "config/validate",
   ]
+  pruneopts = ""
   revision = "5be99bf577f2768193c7fb587ef5a8806c1503cf"
   version = "v1.13.0"
 
 [[projects]]
   branch = "v1"
+  digest = "1:bdd8568424f1993eeeb66741808ad093a9bf0b257e87f629dbb53ebb37b07400"
   name = "github.com/coreos/yaml"
   packages = ["."]
+  pruneopts = ""
   revision = "6b16a5714269b2f70720a45406b1babd947a17ef"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:4f058e70dd54497119d11e7d937f27935aa72cbddc4c2e33941bb16e7dd2bae3"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = ""
   revision = "afbc45e87f3ba324c532d12c71918ef52e0fb194"
 
 [[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "github.com/go-yaml/yaml"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
+  digest = "1:8604036476f9d33b2d573e45b91ba2df875ca81640dd8c10f03bbaf789f7f686"
   name = "github.com/huandu/xstrings"
   packages = ["."]
+  pruneopts = ""
   revision = "3959339b333561bf62a38b424fd41517c2c90f40"
 
 [[projects]]
+  digest = "1:976b05b7862b650ce4a7a2fb67f470df2643428a9d730102bdb83e2a64e8feaf"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = ""
   revision = "3e95a51e0639b4cf372f2ccf74c86749d747fbdc"
   version = "0.2.2"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:c4239c01bae2646fbc5d0120deb86b8cabc40d01bde261b9cea497fb6f8542ad"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = ""
   revision = "bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:6b55df4b0517a459af9d3879c99330af4367adcf45f3d0d37ded80a6272ae057"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:74c32990510c9f188556aa17600313e867d1d06f5a9db244056a95d144ec34ce"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = ""
   revision = "a1f051bc3eba734da4772d60e2d677f47cf93ef4"
   version = "v0.0.2"
 
 [[projects]]
+  digest = "1:261bc565833ef4f02121450d74eb88d5ae4bd74bfe5d0e862cddb8550ec35000"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:a30066593578732a356dc7e5d7f78d69184ca65aeeff5939241a3ab10559bb06"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = ""
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:9ac7b403085a29c194a586b2a02b8b00a944e252272e76342d5435e3e1aa8f9b"
   name = "github.com/tidwall/gjson"
   packages = ["."]
+  pruneopts = ""
   revision = "01f00f129617a6fe98941fb920d6c760241b54d2"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:4db4f92bb9cb04cfc4fccb36aba2598b02a988008c4cc0692b241214ad8ac96e"
   name = "github.com/tidwall/match"
   packages = ["."]
+  pruneopts = ""
   revision = "1731857f09b1f38450e2c12409748407822dc6be"
 
 [[projects]]
+  digest = "1:ed6a1c415a0bd35c9c18eec74bfd460a57ba21fb3bc0da629afc275096edffa4"
   name = "github.com/tidwall/sjson"
   packages = ["."]
+  pruneopts = ""
   revision = "6a22caf2fd45d5e2119bfc3717e984f15a7eb7ee"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:406b5c5fa32d27d0a323a0816762af02cbe0692ebf6516822bf75f43438e03e1"
   name = "golang.org/x/crypto"
   packages = [
     "pbkdf2",
     "scrypt",
-    "ssh/terminal"
+    "ssh/terminal",
   ]
+  pruneopts = ""
   revision = "7e9105388ebff089b3f99f0ef676ea55a6da3a7e"
 
 [[projects]]
   branch = "master"
+  digest = "1:ba4898d0f47bb5a26d7e1842bc1b29799441fbcc76aed65ba45d5b6918e35130"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "bb9c189858d91f42db229b04d45a4c3d23a7662a"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3d26a915875916434709ce73a6b7ce10f45abb9f4a2dd9a812b6a6b8898402fc"
+  input-imports = [
+    "github.com/Masterminds/semver",
+    "github.com/Masterminds/sprig",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/awserr",
+    "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/cloudformation",
+    "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
+    "github.com/aws/aws-sdk-go/service/ec2",
+    "github.com/aws/aws-sdk-go/service/elb",
+    "github.com/aws/aws-sdk-go/service/elbv2",
+    "github.com/aws/aws-sdk-go/service/kms",
+    "github.com/aws/aws-sdk-go/service/route53",
+    "github.com/aws/aws-sdk-go/service/s3",
+    "github.com/coreos/coreos-cloudinit/config/validate",
+    "github.com/go-yaml/yaml",
+    "github.com/spf13/cobra",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "github.com/tidwall/sjson",
+    "golang.org/x/crypto/ssh/terminal",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -219,7 +219,6 @@ func NewDefaultCluster() *Cluster {
 				},
 				Networking: Networking{
 					SelfHosting: SelfHosting{
-						Enabled:         true,
 						Type:            "canal",
 						Typha:           false,
 						CalicoNodeImage: model.Image{Repo: "quay.io/calico/node", Tag: kubeNetworkingSelfHostingDefaultCalicoNodeImageTag, RktPullDocker: false},
@@ -233,10 +232,6 @@ func NewDefaultCluster() *Cluster {
 			CloudFormationStreaming:            true,
 			HyperkubeImage:                     model.Image{Repo: "k8s.gcr.io/hyperkube-amd64", Tag: k8sVer, RktPullDocker: true},
 			AWSCliImage:                        model.Image{Repo: "quay.io/coreos/awscli", Tag: "master", RktPullDocker: false},
-			CalicoNodeImage:                    model.Image{Repo: "quay.io/calico/node", Tag: "v2.6.5", RktPullDocker: false},
-			CalicoCniImage:                     model.Image{Repo: "quay.io/calico/cni", Tag: "v1.11.2", RktPullDocker: false},
-			CalicoKubeControllersImage:         model.Image{Repo: "quay.io/calico/kube-controllers", Tag: "v1.0.2", RktPullDocker: false},
-			CalicoCtlImage:                     model.Image{Repo: "quay.io/calico/ctl", Tag: "v1.6.3", RktPullDocker: false},
 			ClusterAutoscalerImage:             model.Image{Repo: "k8s.gcr.io/cluster-autoscaler", Tag: "v1.1.0", RktPullDocker: false},
 			ClusterProportionalAutoscalerImage: model.Image{Repo: "k8s.gcr.io/cluster-proportional-autoscaler-amd64", Tag: "1.1.2", RktPullDocker: false},
 			CoreDnsImage:                       model.Image{Repo: "coredns/coredns", Tag: "1.1.3", RktPullDocker: false},
@@ -253,7 +248,6 @@ func NewDefaultCluster() *Cluster {
 			AddonResizerImage:                  model.Image{Repo: "k8s.gcr.io/addon-resizer", Tag: "1.8.1", RktPullDocker: false},
 			KubernetesDashboardImage:           model.Image{Repo: "k8s.gcr.io/kubernetes-dashboard-amd64", Tag: "v1.8.3", RktPullDocker: false},
 			PauseImage:                         model.Image{Repo: "k8s.gcr.io/pause-amd64", Tag: "3.1", RktPullDocker: false},
-			FlannelImage:                       model.Image{Repo: "quay.io/coreos/flannel", Tag: "v0.9.1", RktPullDocker: false},
 			JournaldCloudWatchLogsImage:        model.Image{Repo: "jollinshead/journald-cloudwatch-logs", Tag: "0.1", RktPullDocker: true},
 		},
 		KubeClusterSettings: KubeClusterSettings{
@@ -468,7 +462,6 @@ type KubeClusterSettings struct {
 	ExternalDNSName string `yaml:"externalDNSName,omitempty"`
 	// Required by kubelet to locate the cluster-internal dns hosted on controller nodes in the base cluster
 	DNSServiceIP string `yaml:"dnsServiceIP,omitempty"`
-	UseCalico    bool   `yaml:"useCalico,omitempty"`
 	PodCIDR      string `yaml:"podCIDR,omitempty"`
 	ServiceCIDR  string `yaml:"serviceCIDR,omitempty"`
 }
@@ -531,10 +524,6 @@ type DeploymentSettings struct {
 	// Images repository
 	HyperkubeImage                     model.Image `yaml:"hyperkubeImage,omitempty"`
 	AWSCliImage                        model.Image `yaml:"awsCliImage,omitempty"`
-	CalicoNodeImage                    model.Image `yaml:"calicoNodeImage,omitempty"`
-	CalicoCniImage                     model.Image `yaml:"calicoCniImage,omitempty"`
-	CalicoCtlImage                     model.Image `yaml:"calicoCtlImage,omitempty"`
-	CalicoKubeControllersImage         model.Image `yaml:"calicoKubeControllersImage,omitempty"`
 	ClusterAutoscalerImage             model.Image `yaml:"clusterAutoscalerImage,omitempty"`
 	ClusterProportionalAutoscalerImage model.Image `yaml:"clusterProportionalAutoscalerImage,omitempty"`
 	CoreDnsImage                       model.Image `yaml:"coreDnsImage,omitempty"`
@@ -551,7 +540,6 @@ type DeploymentSettings struct {
 	AddonResizerImage                  model.Image `yaml:"addonResizerImage,omitempty"`
 	KubernetesDashboardImage           model.Image `yaml:"kubernetesDashboardImage,omitempty"`
 	PauseImage                         model.Image `yaml:"pauseImage,omitempty"`
-	FlannelImage                       model.Image `yaml:"flannelImage,omitempty"`
 	JournaldCloudWatchLogsImage        model.Image `yaml:"journaldCloudWatchLogsImage,omitempty"`
 	Kubernetes                         Kubernetes  `yaml:"kubernetes,omitempty"`
 	HostOS                             HostOS      `yaml:"hostOS,omitempty"`
@@ -803,7 +791,6 @@ type Networking struct {
 }
 
 type SelfHosting struct {
-	Enabled         bool        `yaml:"enabled"`
 	Type            string      `yaml:"type"`
 	Typha           bool        `yaml:"typha"`
 	CalicoNodeImage model.Image `yaml:"calicoNodeImage"`
@@ -1317,13 +1304,11 @@ func (c Cluster) validate() error {
 		}
 	}
 
-	if c.Kubernetes.Networking.SelfHosting.Enabled {
-		if (c.Kubernetes.Networking.SelfHosting.Type != "canal") && (c.Kubernetes.Networking.SelfHosting.Type != "flannel") {
-			return fmt.Errorf("networkingdaemonsets - style must be either 'canal' or 'flannel'")
-		}
-		if c.Kubernetes.Networking.SelfHosting.Typha && c.Kubernetes.Networking.SelfHosting.Type != "canal" {
-			return fmt.Errorf("networkingdaemonsets - you can only enable typha when deploying type 'canal'")
-		}
+	if (c.Kubernetes.Networking.SelfHosting.Type != "canal") && (c.Kubernetes.Networking.SelfHosting.Type != "flannel") {
+		return fmt.Errorf("networkingdaemonsets - style must be either 'canal' or 'flannel'")
+	}
+	if c.Kubernetes.Networking.SelfHosting.Typha && c.Kubernetes.Networking.SelfHosting.Type != "canal" {
+		return fmt.Errorf("networkingdaemonsets - you can only enable typha when deploying type 'canal'")
 	}
 
 	return nil

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1304,7 +1304,7 @@ func (c Cluster) validate() error {
 		}
 	}
 
-	if (c.Kubernetes.Networking.SelfHosting.Type != "canal") && (c.Kubernetes.Networking.SelfHosting.Type != "flannel") {
+	if c.Kubernetes.Networking.SelfHosting.Type != "canal" && c.Kubernetes.Networking.SelfHosting.Type != "flannel" {
 		return fmt.Errorf("networkingdaemonsets - style must be either 'canal' or 'flannel'")
 	}
 	if c.Kubernetes.Networking.SelfHosting.Typha && c.Kubernetes.Networking.SelfHosting.Type != "canal" {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -36,13 +36,6 @@ exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE
 coreos:
   update:
     reboot-strategy: "off"
-  {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-  flannel:
-    interface: $private_ipv4
-    etcd_cafile: /etc/kubernetes/ssl/etcd-trusted-ca.pem
-    etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
-    etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
-  {{- end }}
   units:
 {{if .DisableContainerLinuxAutomaticUpdates}}
     - name: disable-automatic-update.service
@@ -267,17 +260,6 @@ coreos:
             [Service]
             Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
 
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        - name: 40-flannel.conf
-          content: |
-            [Unit]
-            Wants=flanneld.service
-            [Service]
-            EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
-            ExecStartPre=/usr/bin/systemctl is-active flanneld.service
-        {{- end}}
-
-    {{ if .Kubernetes.Networking.SelfHosting.Enabled -}}
     - name: flanneld.service
       enable: false
     {{ if .AssetsEncryptionEnabled -}}
@@ -293,56 +275,6 @@ coreos:
         RemainAfterExit=true
         ExecStart=/opt/bin/decrypt-assets
     {{- end }}
-    {{- else -}}
-    - name: flanneld.service
-      drop-ins:
-        - name: 10-etcd.conf
-          content: |
-            [Unit]
-            Wants=cfn-etcd-environment.service
-            After=cfn-etcd-environment.service
-
-            [Service]
-            EnvironmentFile=-/etc/etcd-environment
-            Environment="ETCD_SSL_DIR=/etc/kubernetes/ssl"
-            EnvironmentFile=-/run/flannel/etcd-endpoints.opts
-            ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
-            ExecStartPre=/bin/sh -ec "echo FLANNELD_ETCD_ENDPOINTS=${ETCD_ENDPOINTS} >/run/flannel/etcd-endpoints.opts"
-            {{- if .AssetsEncryptionEnabled }}
-            ExecStartPre=/opt/bin/decrypt-assets
-            {{- end}}
-            ExecStartPre=/usr/bin/etcdctl \
-            --ca-file=/etc/kubernetes/ssl/etcd-trusted-ca.pem \
-            --cert-file=/etc/kubernetes/ssl/etcd-client.pem \
-            --key-file=/etc/kubernetes/ssl/etcd-client-key.pem \
-            --endpoints="${ETCD_ENDPOINTS}" \
-            set /coreos.com/network/config '{"Network" : "{{.PodCIDR}}", "Backend" : {"Type" : "vxlan"}}'
-            TimeoutStartSec=120
-
-{{if .FlannelImage.RktPullDocker}}
-        - name: 20-flannel-custom-image.conf
-          content: |
-            [Unit]
-            PartOf=flanneld.service
-            Before=docker.service
-
-            [Service]
-            Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
-            Environment="RKT_RUN_ARGS={{.FlannelImage.Options}}"
-
-    - name: flannel-docker-opts.service
-      drop-ins:
-        - name: 10-flannel-docker-options.conf
-          content: |
-            [Unit]
-            PartOf=flanneld.service
-            Before=docker.service
-
-            [Service]
-            Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
-            Environment="RKT_RUN_ARGS={{.FlannelImage.Options}} --uuid-file-save=/var/lib/coreos/flannel-wrapper2.uuid"
-{{end}}
-    {{- end }}
 
     - name: kubelet.service
       command: start
@@ -351,9 +283,6 @@ coreos:
         [Unit]
         Wants=cfn-etcd-environment.service
         After=cfn-etcd-environment.service
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        Wants=flanneld.service
-        {{ end -}}
         Wants=rpc-statd.service
         Wants=decrypt-assets.service
         After=decrypt-assets.service
@@ -367,11 +296,6 @@ coreos:
         Environment="RKT_RUN_ARGS={{.HyperkubeImage.Options}}\
         --volume dns,kind=host,source=/etc/resolv.conf \
         --mount volume=dns,target=/etc/resolv.conf \
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd-trusted-ca.pem \
-        --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
-        --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
-        {{ end -}}
         {{ if eq .ContainerRuntime "rkt" -}}
         --volume rkt,kind=host,source=/opt/bin/host-rkt \
         --mount volume=rkt,target=/usr/bin/rkt \
@@ -382,12 +306,10 @@ coreos:
         {{ end -}}
         --volume var-lib-cni,kind=host,source=/var/lib/cni \
         --mount volume=var-lib-cni,target=/var/lib/cni \
-        {{ if .Kubernetes.Networking.SelfHosting.Enabled -}}
         --volume var-run-calico,kind=host,source=/var/run/calico \
         --mount volume=var-run-calico,target=/var/run/calico \
         --volume var-lib-calico,kind=host,source=/var/lib/calico \
         --mount volume=var-lib-calico,target=/var/lib/calico \
-        {{ end -}}
         --volume var-log,kind=host,source=/var/log \
         --mount volume=var-log,target=/var/log \
         --volume cni-bin,kind=host,source=/opt/cni/bin \
@@ -395,33 +317,14 @@ coreos:
         --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
         --mount volume=etc-kubernetes,target=/etc/kubernetes"
         ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        ExecStartPre=/usr/bin/etcdctl \
-          --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
-          --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
-          --cert-file /etc/kubernetes/ssl/etcd-client.pem \
-          --endpoints "${ETCD_ENDPOINTS}" \
-          cluster-health
-        ExecStartPre=/usr/bin/systemctl is-active flanneld.service
-        {{ end -}}
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
-        {{ if .Kubernetes.Networking.SelfHosting.Enabled -}}
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
-        {{ end -}}
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /srv/kubernetes/manifests  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        {{ if .UseCalico -}}
-        ExecStartPre=/bin/sh -ec "find /etc/kubernetes/cni/net.d/ -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
-        ExecStartPre=/usr/bin/docker run --rm -e SLEEP=false -e KUBERNETES_SERVICE_HOST= -e KUBERNETES_SERVICE_PORT= -v /opt/cni/bin:/host/opt/cni/bin {{ .CalicoCniImage.RepoWithTag }} /install-cni.sh
-        {{ else -}}
-        ExecStartPre=/usr/bin/docker run --rm -v /opt/cni/bin:/host/opt/cni/bin {{.HyperkubeImage.RepoWithTag}} /bin/sh -ec 'cp -rp /opt/cni/bin/* /host/opt/cni/bin'
-        {{ end -}}
-        {{ end -}}
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --kubeconfig=/etc/kubernetes/kubeconfig/controller.yaml \
         {{if checkVersion "<1.10" .K8sVer -}}
@@ -562,9 +465,6 @@ coreos:
         # FIXME: Remove dependency on the apiserver insecure port
         ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl -s -m 20 -f  http://127.0.0.1:8080/healthz > /dev/null &&  /usr/bin/curl -s -m 20 -f  http://127.0.0.1:10252/healthz > /dev/null && /usr/bin/curl -s -m 20 -f  http://127.0.0.1:10251/healthz > /dev/null &&  /usr/bin/curl --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null && /usr/bin/curl -s -m 20 -f http://127.0.0.1:10256/healthz > /dev/null; then break ; fi;  done"
 
-        {{ if (and (not .Kubernetes.Networking.SelfHosting.Enabled) .UseCalico) -}}
-        ExecStartPre=/usr/bin/bash -c "until /usr/bin/docker run --net=host --pid=host --rm {{ .CalicoCtlImage.RepoWithTag }} node status > /dev/null; do sleep 3; done && echo Calico running"
-        {{- end }}
         {{if .Experimental.AuditLog.Enabled -}}
         ExecStartPre=/opt/bin/check-worker-communication
         {{end -}}
@@ -1007,11 +907,6 @@ write_files:
       fi
       rbac=/srv/kubernetes/rbac
 
-      {{- if .Kubernetes.Networking.SelfHosting.Enabled }}
-      # When using NetworkingDeamonSets ensure that all nodes
-      # have a podCIDR attribute
-      /opt/bin/add-node-cidrs
-      ensuredelete "${mfdir}/calico.yaml"
       applyall "${rbac}/network-daemonsets.yaml"
       {{- if eq .Kubernetes.Networking.SelfHosting.Type "canal" }}
       ensuredelete "${mfdir}/flannel.yaml"
@@ -1019,14 +914,6 @@ write_files:
       {{- else }}
       ensuredelete "${mfdir}/canal.yaml"
       applyall "${mfdir}/flannel.yaml"
-      {{- end }}
-      {{- else }}
-      ensuredelete "${mfdir}/flannel.yaml"
-      ensuredelete "${mfdir}/canal.yaml"
-      {{- if .UseCalico }}
-      /bin/bash /opt/bin/populate-tls-calico-etcd
-      applyall "${mfdir}/calico.yaml"
-      {{- end }}
       {{- end }}
 
       {{ if .Addons.MetricsServer.Enabled -}}
@@ -2219,255 +2106,6 @@ write_files:
                 configMap:
                   name: flannel-cfg
 
-  - path: /srv/kubernetes/manifests/calico.yaml
-    content: |
-      kind: ConfigMap
-      apiVersion: v1
-      metadata:
-        name: calico-config
-        namespace: kube-system
-      data:
-        etcd_endpoints: "#ETCD_ENDPOINTS#"
-        cni_network_config: |-
-          {
-              "name": "calico",
-              "type": "flannel",
-              "delegate": {
-                  "type": "calico",
-                  "etcd_endpoints": "__ETCD_ENDPOINTS__",
-                  "etcd_key_file": "__ETCD_KEY_FILE__",
-                  "etcd_cert_file": "__ETCD_CERT_FILE__",
-                  "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
-                  "log_level": "info",
-                  "policy": {
-                      "type": "k8s",
-                      "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-                      "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-                  },
-                  "kubernetes": {
-                      "kubeconfig": "__KUBECONFIG_FILEPATH__"
-                  }
-              }
-          }
-
-        etcd_ca: "/calico-secrets/etcd-ca"
-        etcd_cert: "/calico-secrets/etcd-cert"
-        etcd_key: "/calico-secrets/etcd-key"
-
-      ---
-
-      apiVersion: v1
-      kind: Secret
-      type: Opaque
-      metadata:
-        name: calico-etcd-secrets
-        namespace: kube-system
-      data:
-        etcd-key: "$ETCDKEY"
-        etcd-cert: "$ETCDCERT"
-        etcd-ca: "$ETCDCA"
-
-      ---
-
-      kind: DaemonSet
-      apiVersion: extensions/v1beta1
-      metadata:
-        name: calico-node
-        namespace: kube-system
-        labels:
-          k8s-app: calico-node
-      spec:
-        selector:
-          matchLabels:
-            k8s-app: calico-node
-        updateStrategy:
-          type: RollingUpdate
-        template:
-          metadata:
-            labels:
-              k8s-app: calico-node
-            annotations:
-              scheduler.alpha.kubernetes.io/critical-pod: ''
-          spec:
-            {{if .Experimental.Admission.Priority.Enabled -}}
-            priorityClassName: system-node-critical
-            {{ end -}}
-            tolerations:
-            - operator: Exists
-              effect: NoSchedule
-            - operator: Exists
-              effect: NoExecute
-            - operator: Exists
-              key: CriticalAddonsOnly
-            hostNetwork: true
-            # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
-            # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
-            terminationGracePeriodSeconds: 0
-            initContainers:
-              - name: remove-cni-networks
-                image: {{.HyperkubeImage.RepoWithTag}}
-                command:
-                - /bin/rm
-                - -rf
-                - /etc/kubernetes/cni/net.d/10-calico.conflist
-                - /etc/kubernetes/cni/net.d/10-flannel.conflist
-                volumeMounts:
-                - mountPath: /etc/kubernetes/cni/net.d
-                  name: cni-net-dir
-            containers:
-              - name: calico-node
-                image: {{ .CalicoNodeImage.RepoWithTag }}
-                env:
-                  - name: ETCD_ENDPOINTS
-                    valueFrom:
-                      configMapKeyRef:
-                        name: calico-config
-                        key: etcd_endpoints
-                  - name: CALICO_NETWORKING_BACKEND
-                    value: "none"
-                  - name: CLUSTER_TYPE
-                    value: "kubeaws,canal"
-                  - name: CALICO_DISABLE_FILE_LOGGING
-                    value: "true"
-                  - name: NO_DEFAULT_POOLS
-                    value: "true"
-                  - name: ETCD_CA_CERT_FILE
-                    valueFrom:
-                      configMapKeyRef:
-                        name: calico-config
-                        key: etcd_ca
-                  - name: ETCD_KEY_FILE
-                    valueFrom:
-                      configMapKeyRef:
-                        name: calico-config
-                        key: etcd_key
-                  - name: ETCD_CERT_FILE
-                    valueFrom:
-                      configMapKeyRef:
-                        name: calico-config
-                        key: etcd_cert
-                securityContext:
-                  privileged: true
-                volumeMounts:
-                  - mountPath: /lib/modules
-                    name: lib-modules
-                    readOnly: true
-                  - mountPath: /var/run/calico
-                    name: var-run-calico
-                    readOnly: false
-                  - mountPath: /var/lib/calico
-                    name: var-lib-calico
-                    readOnly: false
-                  - mountPath: /calico-secrets
-                    name: etcd-certs
-                  - mountPath: /etc/resolv.conf
-                    name: dns
-                    readOnly: true
-            volumes:
-              - name: lib-modules
-                hostPath:
-                  path: /lib/modules
-              - name: var-run-calico
-                hostPath:
-                  path: /var/run/calico
-              - name: var-lib-calico
-                hostPath:
-                  path: /var/lib/calico
-              - name: cni-bin-dir
-                hostPath:
-                  path: /opt/cni/bin
-              - name: cni-net-dir
-                hostPath:
-                  path: /etc/kubernetes/cni/net.d
-              - name: etcd-certs
-                secret:
-                  secretName: calico-etcd-secrets
-              - name: dns
-                hostPath:
-                  path: /etc/resolv.conf
-
-      ---
-
-      apiVersion: extensions/v1beta1
-      kind: Deployment
-      metadata:
-        name: calico-kube-controllers
-        namespace: kube-system
-        labels:
-          k8s-app: calico-policy
-        annotations:
-          scheduler.alpha.kubernetes.io/critical-pod: ''
-
-      spec:
-        replicas: 1
-        template:
-          metadata:
-            name: calico-kube-controllers
-            namespace: kube-system
-            labels:
-              k8s-app: calico-policy
-          spec:
-            {{if .Experimental.Admission.Priority.Enabled -}}
-            priorityClassName: system-node-critical
-            {{ end -}}
-            tolerations:
-            - key: "node.alpha.kubernetes.io/role"
-              operator: "Equal"
-              value: "master"
-              effect: "NoSchedule"
-            - key: "CriticalAddonsOnly"
-              operator: "Exists"
-            hostNetwork: true
-            containers:
-              - name: calico-kube-controllers
-                image: {{ .CalicoKubeControllersImage.RepoWithTag }}
-                env:
-                  - name: ETCD_ENDPOINTS
-                    valueFrom:
-                      configMapKeyRef:
-                        name: calico-config
-                        key: etcd_endpoints
-                  - name: ETCD_CA_CERT_FILE
-                    valueFrom:
-                      configMapKeyRef:
-                        name: calico-config
-                        key: etcd_ca
-                  - name: ETCD_KEY_FILE
-                    valueFrom:
-                      configMapKeyRef:
-                        name: calico-config
-                        key: etcd_key
-                  - name: ETCD_CERT_FILE
-                    valueFrom:
-                      configMapKeyRef:
-                        name: calico-config
-                        key: etcd_cert
-                  - name: K8S_API
-                    value: "https://kubernetes.default:443"
-                  - name: CONFIGURE_ETC_HOSTS
-                    value: "true"
-                volumeMounts:
-                  - mountPath: /calico-secrets
-                    name: etcd-certs
-            volumes:
-              - name: etcd-certs
-                secret:
-                  secretName: calico-etcd-secrets
-
-  - path: /opt/bin/populate-tls-calico-etcd
-    owner: root:root
-    permissions: 0700
-    content: |
-      #!/bin/bash -e
-
-      etcd_ca=$(cat /etc/kubernetes/ssl/etcd-trusted-ca.pem | base64 | tr -d '\n')
-      etcd_key=$(cat /etc/kubernetes/ssl/etcd-client-key.pem | base64 | tr -d '\n')
-      etcd_cert=$(cat /etc/kubernetes/ssl/etcd-client.pem | base64 | tr -d '\n')
-
-      sed -i -e "s#\$ETCDCA#$etcd_ca#g" /srv/kubernetes/manifests/calico.yaml
-      sed -i -e "s#\$ETCDCERT#$etcd_cert#g" /srv/kubernetes/manifests/calico.yaml
-      sed -i -e "s#\$ETCDKEY#$etcd_key#g" /srv/kubernetes/manifests/calico.yaml
-
 {{ if .KubeResourcesAutosave.Enabled }}
   - path: /srv/kubernetes/manifests/kube-resources-autosave-de.yaml
     content: |
@@ -3576,12 +3214,10 @@ write_files:
           {{ if .Experimental.DisableSecurityGroupIngress }}
           - --cloud-config=/etc/kubernetes/additional-configs/cloud.config
           {{ end }}
-          {{ if .Kubernetes.Networking.SelfHosting.Enabled -}}
           - --allocate-node-cidrs=true
           - --cluster-cidr={{.PodCIDR}}
           - --configure-cloud-routes=false {{/* no need to auto configure cloud routes when using flannel or canal */}}
           - --service-cluster-ip-range={{.ServiceCIDR}} {{/* removes the service CIDR range from the cluster CIDR if it intersects */}}
-          {{- end }}
           {{ if not .Addons.MetricsServer.Enabled -}}
           - --horizontal-pod-autoscaler-use-rest-clients=false
           {{end}}
@@ -4976,197 +4612,6 @@ write_files:
           name: kubelet-context
         current-context: kubelet-context
 
-{{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-{{ if not .UseCalico }}
-  - path: /etc/kubernetes/cni/net.d/10-flannel.conf
-    content: |
-        {
-            "name": "podnet",
-            "type": "flannel",
-            "delegate": {
-                "isDefaultGateway": true
-            }
-        }
-
-{{ else }}
-
-  # FIXME: Remove dependency on the apiserver insecure port
-  - path: /etc/kubernetes/cni/net.d/10-calico.conf
-    content: |
-      {
-        "name": "calico",
-        "type": "flannel",
-        "delegate": {
-          "type": "calico",
-          "etcd_endpoints": "#ETCD_ENDPOINTS#",
-          "etcd_key_file": "/etc/kubernetes/ssl/etcd-client-key.pem",
-          "etcd_cert_file": "/etc/kubernetes/ssl/etcd-client.pem",
-          "etcd_ca_cert_file": "/etc/kubernetes/ssl/etcd-trusted-ca.pem",
-          "log_level": "info",
-          "policy": {
-            "type": "k8s",
-            "k8s_api_root": "http://127.0.0.1:8080/api/v1/"
-          }
-        }
-      }
-
-{{ end }}
-{{- end }}
-
-{{- if .Kubernetes.Networking.SelfHosting.Enabled }}
-  - path: /opt/bin/add-node-cidrs
-    permissions: 0755
-    content: |
-      #!/bin/bash
-      set -u
-
-      # NDS Migration helper script - patch missing podcidrs
-      # Legacy nodes do not have a podcidr allocated (it is just received through docker) so when
-      # migrating to the flannel deamonset we need to make sure that all nodes have the podcidr set
-      # that they are actually using.  This can be found by looking at existing pods on the node or
-      # we will run our own pod in order to work out the cidr (always assumed to be a /24).
-
-      pod_cidr="{{.PodCIDR}}"
-      cidr_match="^${pod_cidr%%\.*}.*" # Match just the first IP tuple
-      temporary_podlist="/tmp/podlist"
-      retries=5
-
-      kubectl() {
-        docker run --rm -i --net=host -v /etc/kubernetes:/etc/kubernetes:ro -v /etc/resolv.conf:/etc/resolv.conf:ro {{.HyperkubeImage.RepoWithTag}} /kubectl "$@"
-      }
-
-      log() {
-        >&2 echo "$@"
-      }
-
-      generate_running_pod_list() {
-          kubectl get pods -o wide --all-namespaces | awk '($4 == "Running"){print}' >$temporary_podlist
-      }
-
-      match_running_pods() {
-        local node=$1
-        log "Trying to match a running pod on node ${node}..."
-        cat $temporary_podlist | awk "(\$7 ~ \"${cidr_match}\" && \$8 == \"$node\"){print \$7}" | head -1
-      }
-
-      run_pod() {
-        local node=$1
-        local ipaddress
-
-        log "Running a pod on node ${node} to determine pod ip address..."
-        local selector="{ \"apiVersion\": \"v1\", \"spec\": { \"nodeSelector\": { \"kubernetes.io/hostname\": \"${node}\" }, \"tolerations\": [ { \"effect\": \"NoSchedule\", \"operator\": \"Exists\" }, { \"effect\": \"NoExecute\", \"operator\": \"Exists\" } ] } }"
-        ipaddress=$(kubectl -n kube-system run find-pod-ip-${node%%.*} --pod-running-timeout=1m -i -t --image={{.HyperkubeImage.RepoWithTag}} --restart=Never --overrides="${selector}" -- /bin/sh -c "cat /proc/net/fib_trie | awk '/32 host/ {print f} {f=\$2}' | grep -v 127.0.0.1 | uniq") || return 1
-        kubectl -n kube-system delete pod find-pod-ip-${node%%.*} 2>&1 >/dev/null
-
-        if [[ -n "${ipaddress}" ]]; then
-          echo "${ipaddress}"
-          return 0
-        else
-          log "Running pod did not return an ip address"
-          return 1
-        fi
-      }
-
-      find_node_cidr() {
-        local node=$1
-        local found
-
-        log "Finding cidrs on node ${node}"
-        if ! node_ready "${node}"; then
-          log "Aborting lookup of cidr, node is not ready."
-          return 1
-        fi
-
-        found=$(match_running_pods "${node}")
-        if [[ -n "${found}" ]]; then
-          log "Found a running pod with ip ${found}"
-        else
-          log "No suitable pods running on node, starting our own..."
-          if ! found=$(run_pod "${node}"); then
-            log "Running pod failed."
-            return 1
-          fi
-        fi
-
-        if [[ -n "$found" ]]; then
-          echo "${found%\.*}.0/24"
-          return 0
-        else
-          log "Found ip address was empty!"
-          return 1
-        fi
-      }
-
-      patch_node() {
-        local node=$1
-        local podcidr=$2
-        local tries=0
-
-        while [ "$tries" -lt "$retries" ]; do
-          kubectl patch node "${node}" -p "{\"spec\":{\"podCIDR\":\"${podcidr}\"}}" && return 0
-          log "Patch failed, wait 20s and retry"
-          sleep 20
-          tries=$((tries += 1))
-        done
-      }
-
-      list_ready_nodes() {
-        kubectl get nodes | awk '($2 == "Ready" && $3 != "master"){print $1}' || log "Failed to list running pods" && exit 1
-      }
-
-      read_node() {
-        local node=$1
-        local tries=0
-
-        while [ "$tries" -lt "$retries" ]; do
-          kubectl get node $node -o jsonpath='{.spec.podCIDR}' && return 0
-          log "Failed to read node ${node}, sleep and try again"
-          sleep 20
-          tries=$((tries += 1))
-        done
-        return 1
-      }
-
-      node_ready() {
-        local node=$1
-        local tries=0
-        local ready
-
-        while [ "$tries" -lt "$retries" ]; do
-          ready=$(kubectl get nodes | awk "(\$1 == \"${node}\" && \$2 == \"Ready\"){print}") && break
-          log "Failed to list nodes, sleep and try again"
-          sleep 20
-          tries=$((tries += 1))
-        done
-        [[ -n "$ready" ]]
-      }
-
-      # MAIN
-
-      log "Finding and setting all missing podCIDRs..."
-      generate_running_pod_list
-      nodes=$(list_ready_nodes)
-      for node in $nodes
-      do
-        if ! pod_cidr=$(read_node ${node}); then
-          log "Failed to read node ${node}, skipping."
-          continue
-        fi
-        if [[ -n "${pod_cidr}" ]]; then
-            log "Node ${node} already has podcidr: ${pod_cidr}"
-        else
-          log "Node ${node} does not have a pod_cidr!"
-          if cidr=$(find_node_cidr "${node}"); then
-            log "Patching node ${node} with CIDR ${cidr}"
-            patch_node "${node}" "${cidr}"
-          else
-            log "Could not find the pod_cidr for node ${node}, skipping"
-          fi
-        fi
-      done
-
-{{- end }}
-
 # AdvancedAuditing is enabled by default since K8S v1.8.
 # With AdvancedAuditing, you have to provide a audit policy file.
 # Otherwise no audit logs are recorded at all.
@@ -5368,7 +4813,7 @@ write_files:
                   - "--auto-discover-default-role"
                   - "--iptables=true"
                   - "--host-ip=$(HOST_IP)"
-           {{- if (or (and (not .Kubernetes.Networking.SelfHosting.Enabled) .UseCalico) (and .Kubernetes.Networking.SelfHosting.Enabled (eq .Kubernetes.Networking.SelfHosting.Type "canal"))) }}
+           {{- if eq .Kubernetes.Networking.SelfHosting.Type "canal" }}
                   - "--host-interface=cali+"
            {{- else }}
                   - "--host-interface=cni0"
@@ -5786,7 +5231,7 @@ write_files:
                   - /agent
                 args:
                   - --iptables
-           {{- if (or (and (not .Kubernetes.Networking.SelfHosting.Enabled) .UseCalico) (and .Kubernetes.Networking.SelfHosting.Enabled (eq .Kubernetes.Networking.SelfHosting.Type "canal"))) }}
+           {{- if eq .Kubernetes.Networking.SelfHosting.Type "canal" }}
                   - --host-interface=cali+
            {{- else}}
                   - --host-interface=cni0

--- a/core/network/config/templates/stack-template.json
+++ b/core/network/config/templates/stack-template.json
@@ -172,20 +172,6 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "SecurityGroupControllerIngressFromWorkerToEtcd": {
-      "Properties": {
-        "FromPort": 2379,
-        "GroupId": {
-          "Ref": "SecurityGroupController"
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Ref": "SecurityGroupWorker"
-        },
-        "ToPort": 2379
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress"
-    },
     "SecurityGroupWorker": {
       "Properties": {
         "GroupDescription": {
@@ -332,20 +318,6 @@
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": {
           "Ref": "SecurityGroupController"
-        },
-        "ToPort": 2379
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress"
-    },
-    "SecurityGroupEtcdIngressFromWorkerToEtcd": {
-      "Properties": {
-        "FromPort": 2379,
-        "GroupId": {
-          "Ref": "SecurityGroupEtcd"
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Ref": "SecurityGroupWorker"
         },
         "ToPort": 2379
       },

--- a/core/nodepool/config/deployment.go
+++ b/core/nodepool/config/deployment.go
@@ -91,10 +91,7 @@ func (c DeploymentSettings) WithDefaultsFrom(main cfg.DeploymentSettings) Deploy
 	c.HyperkubeImage.MergeIfEmpty(main.HyperkubeImage)
 	c.HyperkubeImage.Tag = c.K8sVer
 	c.AWSCliImage.MergeIfEmpty(main.AWSCliImage)
-	c.CalicoCtlImage.MergeIfEmpty(main.CalicoCtlImage)
-	c.CalicoCniImage.MergeIfEmpty(main.CalicoCniImage)
 	c.PauseImage.MergeIfEmpty(main.PauseImage)
-	c.FlannelImage.MergeIfEmpty(main.FlannelImage)
 	c.JournaldCloudWatchLogsImage.MergeIfEmpty(main.JournaldCloudWatchLogsImage)
 
 	// Inherit main TLS bootstrap config

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -38,13 +38,6 @@ exec /usr/bin/coreos-cloudinit --from-file /var/run/coreos/$USERDATA_FILE
 coreos:
   update:
     reboot-strategy: "off"
-  {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-  flannel:
-    interface: $private_ipv4
-    etcd_cafile: /etc/kubernetes/ssl/etcd-trusted-ca.pem
-    etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
-    etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
-  {{- end }}
   units:
 {{if .DisableContainerLinuxAutomaticUpdates}}
     - name: disable-automatic-update.service
@@ -268,23 +261,6 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 {{end}}
-    {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-    - name: cfn-etcd-environment.service
-      enable: true
-      command: start
-      runtime: true
-      content: |
-        [Unit]
-        Description=Fetches etcd static IP addresses list from CF
-        After=network-online.target
-
-        [Service]
-        EnvironmentFile={{.StackNameEnvFileName}}
-        Restart=on-failure
-        RemainAfterExit=true
-        ExecStartPre=/opt/bin/cfn-etcd-environment
-        ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
-    {{ end }}
     - name: docker.service
       drop-ins:
 {{if .Experimental.EphemeralImageStorage.Enabled}}
@@ -304,18 +280,7 @@ coreos:
           content: |
             [Service]
             Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
-
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        - name: 40-flannel.conf
-          content: |
-            [Unit]
-            Wants=flanneld.service
-            [Service]
-            EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
-            ExecStartPre=/usr/bin/systemctl is-active flanneld.service
-        {{- end }}
     
-    {{ if .Kubernetes.Networking.SelfHosting.Enabled -}}
     - name: flanneld.service
       enable: false
     {{ if .AssetsEncryptionEnabled -}}
@@ -331,82 +296,11 @@ coreos:
         RemainAfterExit=true
         ExecStart=/opt/bin/decrypt-assets
     {{ end -}}
-    {{ else -}}
-    - name: net-migration-helper.path
-      enable: true
-      command: start
-      content: |
-        [Path]
-        PathExists=/etc/kubernetes/cni/net.d/net-migration
-    - name: net-migration-helper.service
-      enable: false
-      content: |
-        [Unit]
-        Description=Perform actions which help when migrating from legacy to selfhosted networking.
-        After=kubelet.service
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=true
-        ExecStartPre=-/bin/systemctl stop flanneld
-        ExecStartPre=-/bin/ip link delete cni0
-        ExecStartPre=-/bin/ip link delete flannel.1
-        ExecStart=/bin/true
-
-        [Install]
-        WantedBy=multi-user.target
-    - name: flanneld.service
-      drop-ins:
-        - name: 10-etcd.conf
-          content: |
-            [Unit]
-            Wants=cfn-etcd-environment.service
-            After=cfn-etcd-environment.service
-
-            [Service]
-            EnvironmentFile=-/etc/etcd-environment
-            EnvironmentFile=-/run/flannel/etcd-endpoints.opts
-            ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
-            ExecStartPre=/bin/sh -ec "echo FLANNELD_ETCD_ENDPOINTS=${ETCD_ENDPOINTS} >/run/flannel/etcd-endpoints.opts"
-            {{- if .AssetsEncryptionEnabled}}
-            ExecStartPre=/opt/bin/decrypt-assets
-            {{- end}}
-            Environment="ETCD_SSL_DIR=/etc/kubernetes/ssl"
-            TimeoutStartSec=120
-
-{{if .FlannelImage.RktPullDocker}}
-        - name: 20-flannel-custom-image.conf
-          content: |
-            [Unit]
-            PartOf=flanneld.service
-            Before=docker.service
-
-            [Service]
-            Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
-            Environment="RKT_RUN_ARGS={{.FlannelImage.Options}}"
-
-    - name: flannel-docker-opts.service
-      drop-ins:
-        - name: 10-flannel-docker-options.conf
-          content: |
-            [Unit]
-            PartOf=flanneld.service
-            Before=docker.service
-
-            [Service]
-            Environment="FLANNEL_IMAGE={{.FlannelImage.RktRepo}}"
-            Environment="RKT_RUN_ARGS={{.FlannelImage.Options}} --uuid-file-save=/var/lib/coreos/flannel-wrapper2.uuid"
-{{end}}
-    {{- end}}
     - name: kubelet.service
       command: start
       runtime: true
       content: |
         [Unit]
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        Wants=flanneld.service cfn-etcd-environment.service
-        After=cfn-etcd-environment.service
-        {{ end -}}
         Wants=rpc-statd.service        
         Wants=decrypt-assets.service
         After=decrypt-assets.service
@@ -418,19 +312,11 @@ coreos:
         [Service]
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/default/kubelet
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        EnvironmentFile=-/etc/etcd-environment
-        {{- end }}
         Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
         Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
         Environment="RKT_RUN_ARGS={{.HyperkubeImage.Options}}\
         --volume dns,kind=host,source=/etc/resolv.conf \
         --mount volume=dns,target=/etc/resolv.conf \
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        --set-env=ETCD_CA_CERT_FILE=/etc/kubernetes/ssl/etcd-trusted-ca.pem \
-        --set-env=ETCD_CERT_FILE=/etc/kubernetes/ssl/etcd-client.pem \
-        --set-env=ETCD_KEY_FILE=/etc/kubernetes/ssl/etcd-client-key.pem \
-        {{ end -}}
         {{ if eq .ContainerRuntime "rkt" -}}
         --volume rkt,kind=host,source=/opt/bin/host-rkt \
         --mount volume=rkt,target=/usr/bin/rkt \
@@ -441,49 +327,21 @@ coreos:
         {{ end -}}
         --volume var-lib-cni,kind=host,source=/var/lib/cni \
         --mount volume=var-lib-cni,target=/var/lib/cni \
-        {{ if .Kubernetes.Networking.SelfHosting.Enabled -}}
         --volume var-run-calico,kind=host,source=/var/run/calico \
         --mount volume=var-run-calico,target=/var/run/calico \
         --volume var-lib-calico,kind=host,source=/var/lib/calico \
         --mount volume=var-lib-calico,target=/var/lib/calico \
-        {{ end -}}
         --volume var-log,kind=host,source=/var/log \
         --mount volume=var-log,target=/var/log \
         --volume cni-bin,kind=host,source=/opt/cni/bin \
         --mount volume=cni-bin,target=/opt/cni/bin"
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        ExecStartPre=/usr/bin/systemctl is-active flanneld.service
-        ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
-        ExecStartPre=/usr/bin/etcdctl \
-                --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
-                --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
-                --cert-file /etc/kubernetes/ssl/etcd-client.pem \
-                --endpoints "${ETCD_ENDPOINTS}" \
-                cluster-health
-        {{ end -}}
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
-        {{ if .Kubernetes.Networking.SelfHosting.Enabled -}}
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
-        {{ end -}}
-        {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-        ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /etc/kubernetes/cni/net.d/  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
-        ExecStartPre=/usr/bin/etcdctl \
-                       --ca-file /etc/kubernetes/ssl/etcd-trusted-ca.pem \
-                       --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
-                       --cert-file /etc/kubernetes/ssl/etcd-client.pem \
-                       --endpoints "${ETCD_ENDPOINTS}" \
-                       cluster-health
-        {{if .UseCalico -}}
-        ExecStartPre=/usr/bin/docker run --rm -e SLEEP=false -e KUBERNETES_SERVICE_HOST= -e KUBERNETES_SERVICE_PORT= -v /opt/cni/bin:/host/opt/cni/bin {{ .CalicoCniImage.RepoWithTag }} /install-cni.sh
-        {{ else -}}
-        ExecStartPre=/usr/bin/docker run --rm -v /opt/cni/bin:/host/opt/cni/bin {{.HyperkubeImage.RepoWithTag}} /bin/sh -ec 'cp -rp /opt/cni/bin/* /host/opt/cni/bin'
-        {{ end -}}
-        {{ end -}}
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
         {{/* Work-around until https://github.com/kubernetes/kubernetes/issues/43967 is fixed via https://github.com/kubernetes/kubernetes/pull/43995 */ -}}
@@ -659,9 +517,6 @@ coreos:
         Type=oneshot
         EnvironmentFile={{.StackNameEnvFileName}}
         ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl  --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null ; then break ; fi;  done"
-        {{ if (and (not .Kubernetes.Networking.SelfHosting.Enabled) .UseCalico) -}}
-        ExecStartPre=/usr/bin/bash -c "until /usr/bin/docker run --net=host --pid=host --rm {{ .CalicoCtlImage.RepoWithTag }} node status > /dev/null; do sleep 3; done && echo Calico running"
-        {{- end }}
         ExecStart=/opt/bin/cfn-signal
 {{end}}
 
@@ -961,31 +816,6 @@ write_files:
 
       rkt rm --uuid-file=/var/run/coreos/cfn-signal.uuid || :
 
-  {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-  - path: /opt/bin/cfn-etcd-environment
-    owner: root:root
-    permissions: 0700
-    content: |
-      #!/bin/bash -e
-
-      rkt run \
-        --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
-        --mount volume=dns,target=/etc/resolv.conf \
-        --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false \
-        --mount volume=awsenv,target=/var/run/coreos \
-        --uuid-file-save=/var/run/coreos/cfn-etcd-environment.uuid \
-        --set-env={{.StackNameEnvVarName}}=${{.StackNameEnvVarName}} \
-        --net=host \
-        --trust-keys-from-https \
-        {{.AWSCliImage.Options}}{{.AWSCliImage.RktRepo}} --exec=/bin/bash -- \
-          -ec \
-          '
-            cfn-init -v -c "etcd-client" --region {{.Region}} --resource {{.LogicalName}} --stack '${{.StackNameEnvVarName}}'
-          '
-
-      rkt rm --uuid-file=/var/run/coreos/cfn-etcd-environment.uuid || :
-  {{- end }}
-
   - path: /etc/default/kubelet
     permissions: 0755
     owner: root:root
@@ -1263,49 +1093,6 @@ write_files:
           name: kubelet-context
         current-context: kubelet-context
 {{ end }}
-
-{{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-{{ if not .UseCalico }}
-  - path: /etc/kubernetes/cni/net.d/10-flannel.conf
-    content: |
-        {
-            "name": "podnet",
-            "type": "flannel",
-            "delegate": {
-                "isDefaultGateway": true
-            }
-        }
-
-{{ else }}
-
-  - path: /etc/kubernetes/cni/net.d/10-calico.conf
-    content: |
-      {
-        "name": "calico",
-        "type": "flannel",
-        "delegate": {
-          "type": "calico",
-          "etcd_endpoints": "#ETCD_ENDPOINTS#",
-          "etcd_key_file": "/etc/kubernetes/ssl/etcd-client-key.pem",
-          "etcd_cert_file": "/etc/kubernetes/ssl/etcd-client.pem",
-          "etcd_ca_cert_file": "/etc/kubernetes/ssl/etcd-trusted-ca.pem",
-          "log_level": "info",
-          "policy": {
-            "type": "k8s",
-            "k8s_api_root": "{{.APIEndpointURL}}/api/v1/",
-            {{- if .Experimental.TLSBootstrap.Enabled }}
-            "k8s_client_key": "/etc/kubernetes/ssl/kubelet-client.key",
-            "k8s_client_certificate": "/etc/kubernetes/ssl/kubelet-client.crt",
-            {{- else }}
-            "k8s_client_key": "/etc/kubernetes/ssl/worker-key.pem",
-            "k8s_client_certificate": "/etc/kubernetes/ssl/worker.pem",
-            {{- end }}
-            "k8s_certificate_authority": "/etc/kubernetes/ssl/ca.pem"
-          }
-        }
-      }
-{{ end }}
-{{- end }}
 
 {{ if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}
   - path: /etc/kubernetes/auth/kubelet-tls-bootstrap-token.tmp{{if .AssetsEncryptionEnabled}}.enc{{end}}

--- a/core/nodepool/config/templates/stack-template.json
+++ b/core/nodepool/config/templates/stack-template.json
@@ -1,43 +1,24 @@
 {{define "Metadata" -}}
 {
+  {{ if .AwsEnvironment.Enabled -}}
   "AWS::CloudFormation::Init" : {
     "configSets" : {
-      {{ if not .Kubernetes.Networking.SelfHosting.Enabled }}"etcd-client": [ "etcd-client-env" ]{{if .AwsEnvironment.Enabled}},{{end}}{{end}}
-      {{ if .AwsEnvironment.Enabled }}"aws-environment": [ "aws-environment-env" ]{{end}}
-    },
-    {{ if .AwsEnvironment.Enabled -}}
-    "aws-environment-env" : {
-      "commands": {
-         "write-environment": {
-          "command": {
-            "Fn::Join" : ["", [ "echo '",
-            {{range $variable, $function := .AwsEnvironment.Environment}}
-            "{{$variable}}=", {{$function}} , "\n",
-            {{end}}
-            "' > /etc/aws-environment" ] ]
+      "aws-environment-env" : {
+        "commands": {
+          "write-environment": {
+            "command": {
+              "Fn::Join" : ["", [ "echo '",
+              {{range $variable, $function := .AwsEnvironment.Environment}}
+              "{{$variable}}=", {{$function}} , "\n",
+              {{end}}
+              "' > /etc/aws-environment" ] ]
+            }
           }
         }
       }
-    }{{ if not .Kubernetes.Networking.SelfHosting.Enabled }},{{end}}
-    {{end -}}
-    {{ if not .Kubernetes.Networking.SelfHosting.Enabled -}}
-    "etcd-client-env": {
-      "files" : {
-        "/var/run/coreos/etcd-environment": {
-          "content": { "Fn::Join" : [ "", [
-            "ETCD_ENDPOINTS='",
-            {{range $index, $instance := $.EtcdNodes}}
-            {{if $index}}",", {{end}} "https://",
-            {{$instance.ImportedAdvertisedFQDNRef}},
-            ":2379",
-            {{end}}
-            "'\n"
-          ]]}
-        }
-      }
     }
-    {{end}}
   }
+  {{end -}}
 }
 {{end}}
 {{define "SpotFleet"}}
@@ -119,7 +100,7 @@
           {{end}}
         ]
       }
-    }{{ if or (not .Kubernetes.Networking.SelfHosting.Enabled) .AwsEnvironment.Enabled }},
+    }{{ if .AwsEnvironment.Enabled }},
     "Metadata": {{template "Metadata" .}}
     {{- end }}
   },
@@ -219,7 +200,7 @@
           "PauseTime": "PT2M"
           {{end}}
         }
-      }{{ if or (not .Kubernetes.Networking.SelfHosting.Enabled) .AwsEnvironment.Enabled }},
+      }{{ if .AwsEnvironment.Enabled }},
       "Metadata": {{template "Metadata" .}}
       {{- end }}
     },

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -509,20 +509,6 @@ func (c clusterImpl) LegacyUpdate(targets OperationTargets) (string, error) {
 
 func (c clusterImpl) update(cfSvc *cloudformation.CloudFormation, targets OperationTargets) (string, error) {
 
-	// Look at existing state of cloud formation and stacks to determine if we need to take special measures in migrating our etcd
-	// clusters from the control plane stack to their own Etcd stack.
-	exists, err := cfnstack.NestedStackExists(cfSvc, c.controlPlane.ClusterName, naming.FromStackToCfnResource(c.etcd.Etcd.LogicalName()))
-	if err != nil {
-		logger.Errorf("please check your AWS credentials/permissions")
-		return "", fmt.Errorf("can't lookup AWS CloudFormation stacks: %s", err)
-	}
-	if !exists {
-		if !c.controlPlane.Kubernetes.Networking.SelfHosting.Enabled {
-			return "", fmt.Errorf("sorry, you can only update an existing legacy cluster with Kubernetes.Networking.SelfHosting enabled")
-		}
-		logger.Warnf("your cluster does not have a separate etcd stack, this update will spin up a new etcd cluster and attempt to import your existing state.")
-	}
-
 	assets, err := c.generateAssets(c.operationTargetsFromUserInput([]OperationTargets{targets}))
 	if err != nil {
 		return "", err

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1036,30 +1036,6 @@ worker:
 #   tag: master
 #   rktPullDocker: false
 
-# Calico Node image repository to use.
-#calicoNodeImage:
-#  repo: quay.io/calico/node
-#  tag: v2.6.5
-#  rktPullDocker: false
-
-# Calico CNI image repository to use.
-#calicoCniImage:
-#  repo: quay.io/calico/cni
-#  tag: v1.11.2
-#  rktPullDocker: false
-
-# Calico Controller image repository to use.
-#calicoCtlImage:
-#  repo: calico/ctl
-#  tag: v1.6.3
-#  rktPullDocker: false
-
-# Calico Kube Controllers image repository to use.
-#calicoKubeControllersImage:
-#  repo: quay.io/calico/kube-controllers
-#  tag: v1.0.2
-#  rktPullDocker: false
-
 # Cluster Autoscaler image repository to use.
 #clusterAutoscalerImage:
 #  repo: k8s.gcr.io/cluster-autoscaler
@@ -1156,12 +1132,6 @@ worker:
 #  tag: 3.1
 #  rktPullDocker: false
 
-# Flannel image repository to use.This allow pulling flannel image from a docker repo.
-#flannelImage:
-#  repo: quay.io/coreos/flannel
-#  tag: v0.9.1
-#  rktPullDocker: false
-
 # JournaldCloudWatchLogsImage image repository to use. This sends journald logs to CloudWatch.
 #journaldCloudWatchLogsImage:
 #  repo: "jollinshead/journald-cloudwatch-logs"
@@ -1189,29 +1159,10 @@ kubernetes:
 # Kubernetes Self-hosted networking daemonsets
 # Choose either 'canal' (calico+flannel) or 'flannel'
 # (choose 'canal' if you require calico or kubernetes NetworkPolicy firewalling).
-# When enabled nodes no longer need to connect etcd and frees up node podCIDR leases faster resolving issue:
-# https://github.com/coreos/flannel/issues/954.
-#
 # Enable Typha if you have 50+ nodes in your cluster. Without Typha, the load on the API server and Felix’s CPU usage
-# increases substantially as the number of nodes is increased.  The legacy top-level 'useCalico' setting has no effect with selfHosting
-# enabled - use type 'canal' for calico+flannel.
-#
-# Notes on migrating between networking types: -
-# From Legacy Calico to self-hosted Canal - GOOD
-# From Legacy Calico to self-hosted Flannel - OK - ISSUES1
-# From self-hosted Flannel to self-hosted Canal - GOOD
-# From self-hosted Canal to self-hosted Flannel - OK - ISSUES1
-# From Legacy Flannel to self-hosted Canal or Flannel - ISSUES2
-# From self-hosted Canal or Flannel to legacy Flannel - ISSUES3
-#
-# ISSUES1 - calico iptables rules remain on the nodes, recycle nodes to remove.
-# ISSUES2 - Existing pod ip addresses are not tracked and can cause clashing ips - please cordon all nodes whilst
-# performing the upgrade until all workers/nodes have been recycyled - then it will be ok.
-# ISSUES3 - Rolling back to old networking will require all nodes are cycled/rolled and the network is disrupted throughout.
-
+# increases substantially as the number of nodes is increased.
   networking:
     selfHosting:
-      enabled: true    # false will fall back to legacy coreos flannel/etcd2 installation
       type: canal      # either "canal" or "flannel"
       typha: false     # enable for type 'canal' for 50+ node clusters
 #      calicoNodeImage:
@@ -1229,9 +1180,6 @@ kubernetes:
 #      typhaImage:
 #        repo: quay.io/calico/typha
 #        tag: v0.7.4
-
-# Use Calico for network policy (legacy setting - ignored if networking self-hosting is enabled)
-# useCalico: false
 
 # Create MountTargets to subnets managed by kube-aws for a pre-existing Elastic File System (Amazon EFS),
 # and then mount to every node.


### PR DESCRIPTION
The 0.11 release completed the migration from legacy flannel and calico networking to the newer Self Hosting 'canal' or 'flannel' networking daemonsets.

This change is clean up all of the **old code** for that supports the legacy flannel and calico installation and which enabled the migration from legacy to the network daemonsets and makes self-hosting always enabled.  The worker nodes no longer have to have any knowledge/access to the etcd servers as SelfHosting uses the kubernetes api for storage.

This simplifies kube-aws, which is always nice! :)