### PR TITLE
Add a Pod Disruption Budget on kube-dns

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3881,7 +3881,7 @@ write_files:
         name: kube-dns
         namespace: kube-system
       spec:
-        minAvailable: 80%
+        maxUnavailable: 1
         selector:
           matchLabels:
             k8s-app: kube-dns

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -926,6 +926,7 @@ write_files:
         "${mfdir}/heapster-de.yaml" \
         "${mfdir}/kube-dns-autoscaler-de.yaml" \
         "${mfdir}/{{ .KubeDns.Provider }}-de.yaml" \
+        "${mfdir}/kube-dns-pdb.yaml" \
         {{ if .Addons.ClusterAutoscaler.Enabled }}"${mfdir}/cluster-autoscaler-de.yaml"{{ end }} \
         {{ if .Addons.Rescheduler.Enabled }}"${mfdir}/kube-rescheduler-de.yaml"{{ end }} \
         {{ if .Experimental.NodeDrainer.Enabled }}"${mfdir}/kube-node-drainer-asg-status-updater-de.yaml"{{ end }} \
@@ -3871,6 +3872,19 @@ write_files:
           - name: dns-tcp
             port: 53
             protocol: TCP
+
+  - path: /srv/kubernetes/manifests/kube-dns-pdb.yaml
+    content: |
+      apiVersion: policy/v1beta1
+      kind: PodDisruptionBudget
+      metadata:
+        name: kube-dns
+        namespace: kube-system
+      spec:
+        minAvailable: 80%
+        selector:
+          matchLabels:
+            k8s-app: kube-dns
 
   - path: /srv/kubernetes/manifests/heapster-sa.yaml
     content: |

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -826,6 +826,18 @@ write_files:
         kubectl delete --cascade=true --ignore-not-found=true -f $(echo "$@" | tr ' ' ',')
       }
 
+      # forceapply - remove and retry if apply fails (does not rely on the kubectl --force method)
+      # this is needed for allowing the updating of pod disruption budgets
+      forceapply() {
+        set +e
+        if ! kubectl apply -f $(echo "$@" | tr ' ' ','); then
+          set -e
+          kubectl delete --ignore-not-found=true -f $(echo "$@" | tr ' ' ',')
+          kubectl create -f $(echo "$@" | tr ' ' ',')
+        fi
+        set -e
+      }
+
       while ! kubectl get ns kube-system; do
         echo Waiting until kube-system created.
         sleep 3
@@ -926,12 +938,14 @@ write_files:
         "${mfdir}/heapster-de.yaml" \
         "${mfdir}/kube-dns-autoscaler-de.yaml" \
         "${mfdir}/{{ .KubeDns.Provider }}-de.yaml" \
-        "${mfdir}/kube-dns-pdb.yaml" \
         {{ if .Addons.ClusterAutoscaler.Enabled }}"${mfdir}/cluster-autoscaler-de.yaml"{{ end }} \
         {{ if .Addons.Rescheduler.Enabled }}"${mfdir}/kube-rescheduler-de.yaml"{{ end }} \
         {{ if .Experimental.NodeDrainer.Enabled }}"${mfdir}/kube-node-drainer-asg-status-updater-de.yaml"{{ end }} \
         {{ if .KubeResourcesAutosave.Enabled }}"${mfdir}/kube-resources-autosave-de.yaml"{{ end }} \
         {{ if .KubernetesDashboard.Enabled }}"${mfdir}/kubernetes-dashboard-de.yaml"{{ end }}
+
+      # Pod Disruption Budgets
+      forceapply "${mfdir}/kube-dns-pdb.yaml"
 
       # Services
       applyall \


### PR DESCRIPTION
Improve the handling of kube-dns during node drains / cluster rolls by defining a pod disruption budget that allows 1 instance to be down.