### PR TITLE
Allow disabling of the OOM killer

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -805,8 +805,9 @@ type SelfHosting struct {
 }
 
 type HostOS struct {
-	BashPrompt model.BashPrompt `yaml:"bashPrompt,omitempty"`
-	MOTDBanner model.MOTDBanner `yaml:"motdBanner,omitempty"`
+	BashPrompt       model.BashPrompt `yaml:"bashPrompt,omitempty"`
+	MOTDBanner       model.MOTDBanner `yaml:"motdBanner,omitempty"`
+	DisableOOMKiller bool             `yaml:"disableOOMKiller,omitempty"`
 }
 
 func (c *LocalStreaming) Interval() int64 {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -156,6 +156,24 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 {{- end }}
+{{- if .HostOS.DisableOOMKiller }}
+    - name: disable-oom-killer.service
+      enable: true
+      command: start
+      content: |
+        [Unit]
+        Description=Disables the kernel OOM Killer
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/sbin/sysctl -w vm.overcommit_memory=2
+        ExecStart=/usr/sbin/sysctl -w vm.overcommit_ratio=100
+        ExecStart=/bin/bash -c "echo -e \"vm.overcommit_memory = 2\nvm.overcommit_ratio = 100\" >/etc/sysctl.d/10-disable-oom-killer"
+
+        [Install]
+        WantedBy=multi-user.target
+{{- end }}
 {{if and (.AmazonSsmAgent.Enabled) (ne .AmazonSsmAgent.DownloadUrl "")}}
     - name: amazon-ssm-agent.service
       command: start

--- a/core/etcd/config/templates/cloud-config-etcd
+++ b/core/etcd/config/templates/cloud-config-etcd
@@ -156,6 +156,24 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 {{- end }}
+{{- if .HostOS.DisableOOMKiller }}
+    - name: disable-oom-killer.service
+      enable: true
+      command: start
+      content: |
+        [Unit]
+        Description=Disables the kernel OOM Killer
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/sbin/sysctl -w vm.overcommit_memory=2
+        ExecStart=/usr/sbin/sysctl -w vm.overcommit_ratio=100
+        ExecStart=/bin/bash -c "echo -e \"vm.overcommit_memory = 2\nvm.overcommit_ratio = 100\" >/etc/sysctl.d/10-disable-oom-killer"
+
+        [Install]
+        WantedBy=multi-user.target
+{{- end }}
 {{if and (.AmazonSsmAgent.Enabled) (ne .AmazonSsmAgent.DownloadUrl "")}}
     - name: amazon-ssm-agent.service
       command: start

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -210,6 +210,24 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 {{- end }}
+{{- if .HostOS.DisableOOMKiller }}
+    - name: disable-oom-killer.service
+      enable: true
+      command: start
+      content: |
+        [Unit]
+        Description=Disables the kernel OOM Killer
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/sbin/sysctl -w vm.overcommit_memory=2
+        ExecStart=/usr/sbin/sysctl -w vm.overcommit_ratio=100
+        ExecStart=/bin/bash -c "echo -e \"vm.overcommit_memory = 2\nvm.overcommit_ratio = 100\" >/etc/sysctl.d/10-disable-oom-killer"
+
+        [Install]
+        WantedBy=multi-user.target
+{{- end }}
 {{if and (.AmazonSsmAgent.Enabled) (ne .AmazonSsmAgent.DownloadUrl "")}}
     - name: amazon-ssm-agent.service
       command: start

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1555,3 +1555,7 @@ hostOS:
 #    kubernetes-colour: light-blue
 #    kube-aws-colour: light-blue
 
+# disableOOMKiller - [experimental] disable the linux kernel "Out Of Memory" process killer
+# Warning: Disabling this could result in system freezes in low memory situations
+#  disableOOMKiller: false
+


### PR DESCRIPTION
For the users that want to - allow the disabling of the OOM Killer (Out of memory manager)
Whilst I believe that the OOM killer can prevent systems for locking up through memory exhaustion I am deeply uncomfortable at the way it chooses processes for termination, often killing vital system components.  I would rather let the kubelet manage low memory scenarios and let processes receive "OUT OF MEMORY" errors than have the OS start killing things off at random.

This PR allows us to turn off the OOM killer (for testing this configuration) and does not make this the default configuration.
