### PR TITLE
Allow plugins to add kube-controller-manager command line flags.

### DIFF
--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -163,6 +163,7 @@ func NewCluster(cfgRef *config.Cluster, opts config.StackTemplateOptions, plugin
 		return nil, fmt.Errorf("failed to load controller node extras from plugins: %v", err)
 	}
 	c.StackConfig.Config.APIServerFlags = append(c.StackConfig.Config.APIServerFlags, extraController.APIServerFlags...)
+	c.StackConfig.Config.ControllerFlags = append(c.StackConfig.Config.ControllerFlags, extraController.ControllerFlags...)
 	c.StackConfig.Config.APIServerVolumes = append(c.StackConfig.Config.APIServerVolumes, extraController.APIServerVolumes...)
 	c.StackConfig.Controller.CustomSystemdUnits = append(c.StackConfig.Controller.CustomSystemdUnits, extraController.SystemdUnits...)
 	c.StackConfig.Controller.CustomFiles = append(c.StackConfig.Controller.CustomFiles, extraController.Files...)

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -958,6 +958,7 @@ func (c Cluster) Config(extra ...[]*pluginmodel.Plugin) (*Config, error) {
 		KubeAwsPlugins:   pluginMap,
 		APIServerFlags:   pluginmodel.APIServerFlags{},
 		APIServerVolumes: pluginmodel.APIServerVolumes{},
+		ControllerFlags:  pluginmodel.ControllerFlags{},
 	}
 
 	if c.AmiId == "" {
@@ -1093,6 +1094,7 @@ type Config struct {
 
 	APIServerVolumes pluginmodel.APIServerVolumes
 	APIServerFlags   pluginmodel.APIServerFlags
+	ControllerFlags  pluginmodel.ControllerFlags
 }
 
 func (c Cluster) StackNameEnvFileName() string {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3177,6 +3177,9 @@ write_files:
           {{ if not .Addons.MetricsServer.Enabled -}}
           - --horizontal-pod-autoscaler-use-rest-clients=false
           {{end}}
+          {{range $f := .ControllerFlags -}}
+          - --{{$f.Name}}={{$f.Value}}
+          {{ end -}}
           resources:
             requests:
               cpu: {{ if .Kubernetes.ControllerManager.ComputeResources.Requests.Cpu }}{{ .Kubernetes.ControllerManager.ComputeResources.Requests.Cpu }}{{ else }}100m{{ end }}

--- a/plugin/pluginmodel/config.go
+++ b/plugin/pluginmodel/config.go
@@ -144,7 +144,8 @@ type HelmRelease struct {
 }
 
 type Kubernetes struct {
-	APIServer KubernetesAPIServer `yaml:"apiserver,omitempty"`
+	APIServer         KubernetesAPIServer         `yaml:"apiserver,omitempty"`
+	ControllerManager KubernetesControllerManager `yaml:"controller-manager,omitempty"`
 	// Manifests is a list of manifests to be installed to the cluster.
 	// Note that the list is sorted by their names by kube-aws so that it won't result in unnecessarily node replacements.
 	Manifests KubernetesManifests `yaml:"manifests,omitempty"`
@@ -168,10 +169,10 @@ type KubernetesAPIServer struct {
 	Volumes APIServerVolumes `yaml:"volumes,omitempty"`
 }
 
-type APIServerFlags []APIServerFlag
+type APIServerFlags []CommandLineFlag
 
-type APIServerFlag struct {
-	// Name is the name of a command-line flag passed to the k8s apiserver.
+type CommandLineFlag struct {
+	// Name is the name of a command-line flag passed to the k8s apiserver and controller-manager.
 	// For example, a name 	is "oidc-issuer-url" for the flag `--oidc-issuer-url`.
 	Name string `yaml:"name,omitempty"`
 	// Value is a golang text template resulting to the value of a command-line flag passed to the k8s apiserver
@@ -187,6 +188,12 @@ type APIServerVolume struct {
 	Path     string `yaml:"path,omitempty"`
 	ReadOnly bool   `yaml:"readOnly,omitempty"`
 }
+
+type KubernetesControllerManager struct {
+	Flags ControllerFlags `yaml:"flags,omitempty"`
+}
+
+type ControllerFlags []CommandLineFlag
 
 type KubernetesManifests []KubernetesManifest
 


### PR DESCRIPTION
Plugins can set apiserver command line flags but not kube-controller-manager flags.  This enables these as well.

Intended as part of moving some core functionality into plugins https://github.com/kubernetes-incubator/kube-aws/issues/1469