### PR TITLE
WIP: Test preparation to allow legacy and plugins to co-exist using models

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -231,6 +231,16 @@ func NewDefaultCluster() *Cluster {
 						TyphaImage:      model.Image{Repo: "quay.io/calico/typha", Tag: kubeNetworkingSelfHostingDefaultTyphaImageTag, RktPullDocker: false},
 					},
 				},
+				FeatureGates: model.FeatureGates{},
+				AdmissionControllers: model.AdmissionControllers{
+					"NamespaceLifecycle":       10,
+					"LimitRanger":              20,
+					"ServiceAccount":           30,
+					"PersistentVolumeLabel":    40,
+					"DefaultStorageClass":      50,
+					"ResourceQuota":            90,
+					"DefaultTolerationSeconds": 130,
+				},
 			},
 			CloudFormationStreaming:            true,
 			HyperkubeImage:                     model.Image{Repo: "k8s.gcr.io/hyperkube-amd64", Tag: k8sVer, RktPullDocker: true},
@@ -770,9 +780,11 @@ type LocalStreaming struct {
 }
 
 type Kubernetes struct {
-	EncryptionAtRest  EncryptionAtRest  `yaml:"encryptionAtRest"`
-	Networking        Networking        `yaml:"networking,omitempty"`
-	ControllerManager ControllerManager `yaml:"controllerManager,omitempty"`
+	EncryptionAtRest     EncryptionAtRest           `yaml:"encryptionAtRest"`
+	Networking           Networking                 `yaml:"networking,omitempty"`
+	ControllerManager    ControllerManager          `yaml:"controllerManager,omitempty"`
+	FeatureGates         model.FeatureGates         `yaml:"featureGates,omitempty"`
+	AdmissionControllers model.AdmissionControllers `yaml:"admissionControllers,omitempty"`
 }
 
 type ControllerManager struct {

--- a/core/controlplane/config/legacy_mapping.go
+++ b/core/controlplane/config/legacy_mapping.go
@@ -1,0 +1,76 @@
+package config
+
+import "github.com/kubernetes-incubator/kube-aws/plugin/pluginmodel"
+
+func (c *Config) MapLegacySettings() error {
+	// Process/Map legacy Experimental settings into plugin friendly data structures....
+	if c.Cluster.KubeProxy.IPVSMode.Enabled {
+		c.Cluster.Kubernetes.FeatureGates["SupportIPVSProxyMode"] = true
+	}
+	if c.Cluster.Experimental.Admission.Priority.Enabled {
+		c.Cluster.Kubernetes.FeatureGates["PodPriority"] = true
+	}
+	if c.Cluster.Experimental.Admission.PersistentVolumeClaimResize.Enabled {
+		c.Cluster.Kubernetes.FeatureGates["ExpandPersistentVolumes"] = true
+		c.Cluster.Kubernetes.AdmissionControllers["PersistentVolumeClaimResize"] = 160
+	}
+
+	// handle all of the possible admission controllers so that we can just render out the line using the model
+	// instead of relaying on complex templating...
+	if c.Cluster.Experimental.Admission.PodSecurityPolicy.Enabled {
+		c.Cluster.Kubernetes.AdmissionControllers["PodSecurityPolicy"] = 60
+	}
+	if c.Cluster.Experimental.Admission.AlwaysPullImages.Enabled {
+		c.Cluster.Kubernetes.AdmissionControllers["AlwaysPullImages"] = 70
+	}
+	if c.Cluster.Experimental.NodeAuthorizer.Enabled {
+		c.Cluster.Kubernetes.AdmissionControllers["NodeRestriction"] = 80
+	}
+	if c.Cluster.Experimental.Admission.DenyEscalatingExec.Enabled {
+		c.Cluster.Kubernetes.AdmissionControllers["DenyEscalatingExec"] = 100
+	}
+	if c.Cluster.Experimental.Admission.Initializers.Enabled {
+		c.Cluster.Kubernetes.AdmissionControllers["Initializers"] = 110
+	}
+	if c.Cluster.Experimental.Admission.Priority.Enabled {
+		c.Cluster.Kubernetes.AdmissionControllers["Priority"] = 120
+	}
+	if c.Cluster.Experimental.Admission.MutatingAdmissionWebhook.Enabled {
+		c.Cluster.Kubernetes.AdmissionControllers["MutatingAdmissionWebhook"] = 140
+	}
+	if c.Cluster.Experimental.Admission.ValidatingAdmissionWebhook.Enabled {
+		c.Cluster.Kubernetes.AdmissionControllers["MutatingAdmissionWebhook"] = 150
+	}
+	if c.Cluster.Experimental.Admission.PersistentVolumeClaimResize.Enabled {
+		c.Cluster.Kubernetes.AdmissionControllers["MutatingAdmissionWebhook"] = 150
+	}
+
+	// PLEASE NOTE - I think we should move APIServerFlags into 'model' and then plugins should use it from model.
+	// Also I know that most of these features could be migrated out into core plugins -
+	// this is just a demonstration of moving the legacy settings from the rendering/template logic into models
+	// so that they can also be manipulated by plugins (i.e. a migration step)
+	if c.Cluster.Experimental.Oidc.Enabled {
+		c.APIServerFlags = append(c.APIServerFlags, pluginmodel.APIServerFlag{Name: "oidc-issuer-url", Value: c.Cluster.Experimental.Oidc.IssuerUrl},
+			pluginmodel.APIServerFlag{Name: "oidc-client-id", Value: c.Cluster.Experimental.Oidc.ClientId})
+		if c.Cluster.Experimental.Oidc.UsernameClaim != "" {
+			c.APIServerFlags = append(c.APIServerFlags, pluginmodel.APIServerFlag{Name: "oidc-username-claim", Value: c.Cluster.Experimental.Oidc.UsernameClaim})
+		}
+		if c.Cluster.Experimental.Oidc.GroupsClaim != "" {
+			c.APIServerFlags = append(c.APIServerFlags, pluginmodel.APIServerFlag{Name: "oidc-groups-claim", Value: c.Cluster.Experimental.Oidc.GroupsClaim})
+		}
+	}
+
+	if c.Cluster.Addons.APIServerAggregator.Enabled {
+		c.APIServerFlags = append(c.APIServerFlags,
+			pluginmodel.APIServerFlag{Name: "requestheader-client-ca-file", Value: "/etc/kubernetes/ssl/ca.pem"},
+			pluginmodel.APIServerFlag{Name: "requestheader-allowed-names", Value: "aggregator"},
+			pluginmodel.APIServerFlag{Name: "requestheader-extra-headers-prefix", Value: "X-Remote-Extra-"},
+			pluginmodel.APIServerFlag{Name: "requestheader-group-headers", Value: "X-Remote-Group"},
+			pluginmodel.APIServerFlag{Name: "requestheader-username-headers", Value: "X-Remote-User"},
+			pluginmodel.APIServerFlag{Name: "enable-aggregator-routing", Value: "false"},
+			pluginmodel.APIServerFlag{Name: "proxy-client-cert-file", Value: "/etc/kubernetes/ssl/apiserver-aggregator.pem"},
+			pluginmodel.APIServerFlag{Name: "proxy-client-key-fil", Value: "/etc/kubernetes/ssl/apiserver-aggregator-key.pem"})
+	}
+
+	return nil
+}

--- a/core/controlplane/config/legacy_mapping.go
+++ b/core/controlplane/config/legacy_mapping.go
@@ -39,10 +39,7 @@ func (c *Config) MapLegacySettings() error {
 		c.Cluster.Kubernetes.AdmissionControllers["MutatingAdmissionWebhook"] = 140
 	}
 	if c.Cluster.Experimental.Admission.ValidatingAdmissionWebhook.Enabled {
-		c.Cluster.Kubernetes.AdmissionControllers["MutatingAdmissionWebhook"] = 150
-	}
-	if c.Cluster.Experimental.Admission.PersistentVolumeClaimResize.Enabled {
-		c.Cluster.Kubernetes.AdmissionControllers["MutatingAdmissionWebhook"] = 150
+		c.Cluster.Kubernetes.AdmissionControllers["ValidatingAdmissionWebhook"] = 150
 	}
 
 	// PLEASE NOTE - I think we should move APIServerFlags into 'model' and then plugins should use it from model.

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2873,12 +2873,12 @@ write_files:
           clientConnection:
             kubeconfig: /etc/kubernetes/kubeconfig/kube-proxy.yaml
           clusterCIDR: {{.PodCIDR}}
-          {{if .KubeProxy.IPVSMode.Enabled -}}
+          {{if .Kubernetes.FeatureGates.Enabled -}}
           {{if checkVersion ">=1.10" .K8sVer -}}
           featureGates:
-            SupportIPVSProxyMode: true
+          {{- .Kubernetes.FeatureGates.ToYaml() | indent 12 }}
           {{else -}}
-          featureGates: "SupportIPVSProxyMode=true"
+          featureGates: {{ .Kubernetes.FeatureGates.CommandString }}
           {{end -}}
           mode: ipvs
           ipvs:
@@ -3004,18 +3004,7 @@ write_files:
           - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
           {{ end }}
           - --advertise-address=$private_ipv4
-          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }}{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{if .Experimental.NodeAuthorizer.Enabled}},NodeRestriction{{end}},ResourceQuota{{if .Experimental.Admission.DenyEscalatingExec.Enabled}},DenyEscalatingExec{{end}}{{if .Experimental.Admission.Initializers.Enabled}},Initializers{{end}}{{if .Experimental.Admission.Priority.Enabled}},Priority{{end}},DefaultTolerationSeconds{{if .Experimental.Admission.MutatingAdmissionWebhook.Enabled}},MutatingAdmissionWebhook{{end}}{{if .Experimental.Admission.ValidatingAdmissionWebhook.Enabled}},ValidatingAdmissionWebhook{{end}}{{if .Experimental.Admission.PersistentVolumeClaimResize.Enabled}},PersistentVolumeClaimResize{{end}}
           - --anonymous-auth=false
-          {{if .Experimental.Oidc.Enabled}}
-          - --oidc-issuer-url={{.Experimental.Oidc.IssuerUrl}}
-          - --oidc-client-id={{.Experimental.Oidc.ClientId}}
-          {{if .Experimental.Oidc.UsernameClaim}}
-          - --oidc-username-claim={{.Experimental.Oidc.UsernameClaim}}
-          {{ end -}}
-          {{if .Experimental.Oidc.GroupsClaim}}
-          - --oidc-groups-claim={{.Experimental.Oidc.GroupsClaim}}
-          {{ end -}}
-          {{ end -}}
           {{if .Kubernetes.EncryptionAtRest.Enabled}}
           - --experimental-encryption-provider-config=/etc/kubernetes/additional-configs/encryption-config.yaml
           {{end}}
@@ -3025,20 +3014,13 @@ write_files:
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
           - --runtime-config=extensions/v1beta1/networkpolicies=true{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},extensions/v1beta1/podsecuritypolicy=true{{ end }}{{if .Experimental.Admission.Initializers.Enabled}},admissionregistration.k8s.io/v1alpha1{{end}}{{if .Experimental.Admission.Priority.Enabled}},scheduling.k8s.io/v1alpha1=true{{end}}
-         {{if or (.Experimental.Admission.Priority.Enabled) (.Experimental.Admission.PersistentVolumeClaimResize.Enabled)}}
-          - --feature-gates=PodPriority={{.Experimental.Admission.Priority.Enabled}},ExpandPersistentVolumes={{.Experimental.Admission.PersistentVolumeClaimResize.Enabled}}
-         {{end}}
-          - --cloud-provider=aws
-          {{ if .Addons.APIServerAggregator.Enabled -}}
-          - --requestheader-client-ca-file=/etc/kubernetes/ssl/ca.pem
-          - --requestheader-allowed-names=aggregator
-          - --requestheader-extra-headers-prefix=X-Remote-Extra-
-          - --requestheader-group-headers=X-Remote-Group
-          - --requestheader-username-headers=X-Remote-User
-          - --enable-aggregator-routing=false
-          - --proxy-client-cert-file=/etc/kubernetes/ssl/apiserver-aggregator.pem
-          - --proxy-client-key-file=/etc/kubernetes/ssl/apiserver-aggregator-key.pem
+          {{ if .Kubernetes.AdmissionControllers.Enabled -}}
+          - --admission-control={{ .Kubernetes.AdmissionControllers.CommandString }}
           {{ end -}}
+          {{if .Kubernetes.FeatureGates.Enabled -}}
+          - --feature-gates={{ .Kubernetes.FeatureGates.CommandString }}
+          {{end -}}
+          - --cloud-provider=aws
           {{range $f := .APIServerFlags}}
           - --{{$f.Name}}={{$f.Value}}
           {{ end -}}
@@ -3177,6 +3159,9 @@ write_files:
           {{ if not .Addons.MetricsServer.Enabled -}}
           - --horizontal-pod-autoscaler-use-rest-clients=false
           {{end}}
+          {{if .Kubernetes.FeatureGates.Enabled -}}
+          - --feature-gates={{ .Kubernetes.FeatureGates.CommandString }}
+          {{end -}}
           resources:
             requests:
               cpu: {{ if .Kubernetes.ControllerManager.ComputeResources.Requests.Cpu }}{{ .Kubernetes.ControllerManager.ComputeResources.Requests.Cpu }}{{ else }}100m{{ end }}
@@ -3242,9 +3227,9 @@ write_files:
           - scheduler
           - --kubeconfig=/etc/kubernetes/kubeconfig/kube-scheduler.yaml
           - --leader-elect=true
-         {{if or (.Experimental.Admission.Priority.Enabled) (.Experimental.Admission.PersistentVolumeClaimResize.Enabled)}}
-          - --feature-gates=PodPriority={{.Experimental.Admission.Priority.Enabled}},ExpandPersistentVolumes={{.Experimental.Admission.PersistentVolumeClaimResize.Enabled}}
-         {{end}}
+          {{if .Kubernetes.FeatureGates.Enabled -}}
+          - --feature-gates={{ .Kubernetes.FeatureGates.CommandString }}
+          {{end -}}
           resources:
             requests:
               cpu: 100m

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -370,7 +370,7 @@ coreos:
         {{- end }}
         --kubeconfig=/etc/kubernetes/kubeconfig/worker.yaml \
         {{- if .FeatureGates.Enabled }}
-        --feature-gates=\"{{.FeatureGates.String}}\" \
+        --feature-gates=\"{{ .FeatureGates.CommandString }}\" \
         {{- end }}
         {{- if .Kubelet.SystemReservedResources }}
         --system-reserved={{ .Kubelet.SystemReservedResources }} \

--- a/model/admission_controllers.go
+++ b/model/admission_controllers.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	"strings"
+)
+
+// AdmissionControllers are modelled as a set of string names mapping to a positional integer
+// the resultant list is ordered lowest -> highest positional value
+type AdmissionControllers map[string]int
+
+func (a AdmissionControllers) Enabled() bool {
+	return len(a) > 0
+}
+
+// CommandString renders the admission controllers in the order defined by their integer positional values first
+// and alphabetically should they have the same positional value
+func (a AdmissionControllers) CommandString() string {
+	var ordered []string
+	var lowest int
+	var nextkey string
+
+	work := make(AdmissionControllers)
+	for k, v := range a {
+		work[k] = v
+	}
+	for n := 0; n < len(a); n++ {
+		nextkey = ""
+		for k, v := range work {
+			if nextkey == "" {
+				nextkey = k
+				lowest = v
+				continue
+			}
+			if v < lowest {
+				lowest = v
+				nextkey = k
+				continue
+			}
+			if v == lowest {
+				if strings.Compare(k, nextkey) == -1 {
+					nextkey = k
+					continue
+				}
+			}
+		}
+		ordered = append(ordered, nextkey)
+		delete(work, nextkey)
+	}
+	return strings.Join(ordered, ",")
+}

--- a/model/feature_gates.go
+++ b/model/feature_gates.go
@@ -4,29 +4,30 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 )
 
-type FeatureGates map[string]string
+type FeatureGates map[string]bool
 
 func (l FeatureGates) Enabled() bool {
 	return len(l) > 0
 }
 
 // Returns key=value pairs separated by ',' to be passed to kubelet's `--feature-gates` flag
-func (l FeatureGates) String() string {
-	labels := []string{}
-	keys := []string{}
-	for k, _ := range l {
-		keys = append(keys, k)
+func (l FeatureGates) CommandString() string {
+	g := []string{}
+	for k, v := range l {
+		g = append(g, fmt.Sprintf("%s=%v", k, v))
 	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		v := l[k]
-		if len(v) > 0 {
-			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
-		} else {
-			labels = append(labels, fmt.Sprintf("%s", k))
-		}
+	sort.Strings(g)
+	return strings.Join(g, ",")
+}
+
+func (l FeatureGates) ToYaml() string {
+	y, err := yaml.Marshal(l)
+	if err != nil {
+		return ""
 	}
-	return strings.Join(labels, ",")
+	return string(y)
 }

--- a/plugin/clusterextension/extras.go
+++ b/plugin/clusterextension/extras.go
@@ -61,12 +61,14 @@ type worker struct {
 }
 
 type controller struct {
-	APIServerFlags      pluginmodel.APIServerFlags
-	APIServerVolumes    pluginmodel.APIServerVolumes
-	Files               []model.CustomFile
-	SystemdUnits        []model.CustomSystemdUnit
-	IAMPolicyStatements []model.IAMPolicyStatement
-	NodeLabels          model.NodeLabels
+	APIServerFlags       pluginmodel.APIServerFlags
+	APIServerVolumes     pluginmodel.APIServerVolumes
+	Files                []model.CustomFile
+	SystemdUnits         []model.CustomSystemdUnit
+	IAMPolicyStatements  []model.IAMPolicyStatement
+	NodeLabels           model.NodeLabels
+	FeatureGates         model.FeatureGates
+	AdmissionControllers model.AdmissionControllers
 }
 
 type etcd struct {
@@ -212,6 +214,8 @@ func (e ClusterExtension) Controller() (*controller, error) {
 	files := []model.CustomFile{}
 	iamStatements := model.IAMPolicyStatements{}
 	nodeLabels := model.NodeLabels{}
+	featureGates := model.FeatureGates{}
+	admissionControllers := model.AdmissionControllers{}
 
 	for _, p := range e.plugins {
 		if enabled, pc := p.EnabledIn(e.configs); enabled {
@@ -265,16 +269,25 @@ func (e ClusterExtension) Controller() (*controller, error) {
 			for k, v := range p.Spec.Node.Roles.Controller.Kubelet.NodeLabels {
 				nodeLabels[k] = v
 			}
+
+			for k, v := range p.Spec.Kubernetes.FeatureGates {
+				featureGates[k] = v
+			}
+			for k, v := range p.Spec.Kubernetes.APIServer.AdmissionControllers {
+				admissionControllers[k] = v
+			}
 		}
 	}
 
 	return &controller{
-		APIServerFlags:      apiServerFlags,
-		APIServerVolumes:    apiServerVolumes,
-		Files:               files,
-		SystemdUnits:        systemdUnits,
-		IAMPolicyStatements: iamStatements,
-		NodeLabels:          nodeLabels,
+		APIServerFlags:       apiServerFlags,
+		APIServerVolumes:     apiServerVolumes,
+		Files:                files,
+		SystemdUnits:         systemdUnits,
+		IAMPolicyStatements:  iamStatements,
+		NodeLabels:           nodeLabels,
+		FeatureGates:         featureGates,
+		AdmissionControllers: admissionControllers,
 	}, nil
 }
 

--- a/plugin/pluginmodel/config.go
+++ b/plugin/pluginmodel/config.go
@@ -147,7 +147,8 @@ type Kubernetes struct {
 	APIServer KubernetesAPIServer `yaml:"apiserver,omitempty"`
 	// Manifests is a list of manifests to be installed to the cluster.
 	// Note that the list is sorted by their names by kube-aws so that it won't result in unnecessarily node replacements.
-	Manifests KubernetesManifests `yaml:"manifests,omitempty"`
+	Manifests    KubernetesManifests `yaml:"manifests,omitempty"`
+	FeatureGates model.FeatureGates  `yaml:"featureGates,omitempty"`
 }
 
 func (k *Kubernetes) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -164,8 +165,9 @@ func (k *Kubernetes) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 type KubernetesAPIServer struct {
-	Flags   APIServerFlags   `yaml:"flags,omitempty"`
-	Volumes APIServerVolumes `yaml:"volumes,omitempty"`
+	Flags                APIServerFlags             `yaml:"flags,omitempty"`
+	Volumes              APIServerVolumes           `yaml:"volumes,omitempty"`
+	AdmissionControllers model.AdmissionControllers `yaml:"admissionControllers,omitempty"`
 }
 
 type APIServerFlags []APIServerFlag
@@ -270,8 +272,8 @@ type SystemdUnit struct {
 // Keys must be included in: nodeLabels, featureGates, etc
 // kubelet can be configured per-node-pool-basic hence a part of WorkerSettings
 type Kubelet struct {
-	FeatureGates FeatureGates `yaml:"featureGates,omitempty"`
-	NodeLabels   NodeLabels   `yaml:"nodeLabels,omitempty"`
+	FeatureGates model.FeatureGates `yaml:"featureGates,omitempty"`
+	NodeLabels   NodeLabels         `yaml:"nodeLabels,omitempty"`
 }
 
 type FeatureGates map[string]string


### PR DESCRIPTION
Re-implement control plane feature gates (now applying them to apiserver, controller and scheduler and kube-proxy as set).  The main difference is that they can now be set via plugins.  There has also been a refactor to show how logic can be removed from the cloud-config templating and moved elsewhere to provide backwards compatibility but still allow a migration to moving into plugins).

If model more of the state in the models package then the legacy config can be mapped to it as well as the plugins - then we simplify the render (see in this example how the complexity of cloud-config-controller is being reduced) from the model - removing as much logic as we can (this will eventually all live in core plugins).

@mumoshu - what do you think of these general ideas/direction?  