### PR TITLE
Allow user control over controller.iam.role.name

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -213,7 +213,7 @@
     "IAMInstanceProfileController": {
       "Properties": {
 		"Path": "/",
-		{{ if and (.Controller.IAMConfig.Role.UseStrict) (.Controller.IAMConfig.Role.Name) }}
+		{{ if and (.Controller.IAMConfig.Role.ManageExternally) (.Controller.IAMConfig.Role.Name) }}
 		"Roles": [
 			"{{.Controller.IAMConfig.Role.Name}}"
 		]
@@ -232,7 +232,7 @@
       "Properties" : {
         "Description" : "Policy for managing kube-aws k8s controllers",
 				"Path" : "/",
-				{{ if and (.Controller.IAMConfig.Role.UseStrict) (.Controller.IAMConfig.Role.Name) }}
+				{{ if and (.Controller.IAMConfig.Role.ManageExternally) (.Controller.IAMConfig.Role.Name) }}
 				"Roles" : [
            "{{.Controller.IAMConfig.Role.Name}}"
 				],
@@ -455,9 +455,13 @@
           "Version": "2012-10-17"
         },
         "Path": "/",
-        {{if and (.Controller.IAMConfig.Role.Name) (not .Controller.IAMConfig.Role.UseStrict) }}
-        "RoleName":  {"Fn::Join": ["-", ["{{$.ClusterName}}", {"Ref": "AWS::Region"}, "{{.Controller.IAMConfig.Role.Name}}"]]},
-        {{end}}
+        {{ if and (.Controller.IAMConfig.Role.Name) (not .Controller.IAMConfig.Role.ManageExternally) -}}
+        "RoleName":  {{if .Controller.IAMConfig.Role.StrictName -}}
+        "{{ .Controller.IAMConfig.Role.Name }}",
+        {{ else -}}
+        {"Fn::Join": ["-", ["{{ $.ClusterName }}", {"Ref": "AWS::Region"}, "{{ .Controller.IAMConfig.Role.Name }}"]]},
+        {{ end -}}
+        {{ end -}}
         "ManagedPolicyArns": [
           {{range $policyIndex, $policyArn := .Controller.IAMConfig.Role.ManagedPolicies }}
             "{{$policyArn.Arn}}",

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -218,10 +218,15 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #      # the Statements included in the ManagedPolicy are the minimun ones required for the Controllers to run.
 #      name: "yourManagedRole"
 #
-#	   # If useStrict is enabled (i.e set to true), kube-aws will not create a new IAM role and will instead use an existing one.
-#	   # The existing role name must be set under iam.role.name and must exist on AWS before the cluster is rolled out.
-#	   # By default, useStrict is disabled (i.e set to false)
-#	   useStrict: true   
+#      # If strictName is enabled then the name specified above in "name" is not not altered by kube-aws.
+#      # strictName is "false" by default which means that kube-aws will prepend the ian role name with the result of "ClusterName-AWSRegion-"
+#      # strictName: true
+#
+#	     # If manageExternally is enabled (i.e set to true), kube-aws will not create a new IAM role and will instead use an existing one.
+#	     # The existing role name must be set under iam.role.name and must exist on AWS before the cluster is rolled out.
+#      # When using manageExternally, strictName is also assumed by kube-aws
+#	     # By default, manageExternally is disabled (i.e set to false)
+#	     manageExternally: true   
 #
 #      # If you set managedPolicies here it will be attached in addition to the created managedPolicy in kube-aws for the cluster.
 #      # CAUTION: if you attach a more restrictive policy in some resources (i.e ec2:* Deny) you can make kube-aws fail.

--- a/model/iamconfig.go
+++ b/model/iamconfig.go
@@ -14,10 +14,11 @@ type IAMConfig struct {
 }
 
 type IAMRole struct {
-	ARN             `yaml:",inline"`
-	Name            string             `yaml:"name,omitempty"`
-	UseStrict       bool               `yaml:"useStrict,omitempty"`
-	ManagedPolicies []IAMManagedPolicy `yaml:"managedPolicies,omitempty"`
+	ARN              `yaml:",inline"`
+	Name             string             `yaml:"name,omitempty"`
+	StrictName       bool               `yaml:"strictName,omitempty"`
+	ManageExternally bool               `yaml:"manageExternally,omitempty"`
+	ManagedPolicies  []IAMManagedPolicy `yaml:"managedPolicies,omitempty"`
 }
 
 type IAMManagedPolicy struct {

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1744,38 +1744,57 @@ worker:
 			},
 		},
 		{
-			context:    "WithControllerIAMDefaultUseStrict",
+			context:    "WithControllerIAMDefaultManageExternally",
 			configYaml: minimalValidConfigYaml,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
 					expectedValue := false
 
-					if c.Controller.IAMConfig.Role.UseStrict != expectedValue {
-						t.Errorf("controller's iam.role.useStrict didn't match : expected=%v actual=%v", expectedValue, c.Controller.IAMConfig.Role.UseStrict)
+					if c.Controller.IAMConfig.Role.ManageExternally != expectedValue {
+						t.Errorf("controller's iam.role.manageExternally didn't match : expected=%v actual=%v", expectedValue, c.Controller.IAMConfig.Role.ManageExternally)
 					}
 				},
 			},
 		},
 		{
-			context: "WithControllerIAMEnabledUseStrict",
+			context: "WithControllerIAMEnabledManageExternally",
 			configYaml: minimalValidConfigYaml + `
 controller:
   iam:
    role:
      name: myrole1
-     useStrict: true
+     manageExternally: true
 `,
 			assertConfig: []ConfigTester{
 				func(c *config.Config, t *testing.T) {
-					expectedUseStrict := true
+					expectedManageExternally := true
 					expectedRoleName := "myrole1"
 
 					if expectedRoleName != c.Controller.IAMConfig.Role.Name {
 						t.Errorf("controller's iam.role.name didn't match : expected=%v actual=%v", expectedRoleName, c.Controller.IAMConfig.Role.Name)
 					}
 
-					if expectedUseStrict != c.Controller.IAMConfig.Role.UseStrict {
-						t.Errorf("controller's iam.role.useStrict didn't matchg : expected=%v actual=%v", expectedUseStrict, c.Controller.IAMConfig.Role.UseStrict)
+					if expectedManageExternally != c.Controller.IAMConfig.Role.ManageExternally {
+						t.Errorf("controller's iam.role.manageExternally didn't match : expected=%v actual=%v", expectedManageExternally, c.Controller.IAMConfig.Role.ManageExternally)
+					}
+				},
+			},
+		},
+		{
+			context: "WithControllerIAMEnabledStrictName",
+			configYaml: minimalValidConfigYaml + `
+controller:
+  iam:
+   role:
+     name: myrole1
+     strictName: true
+`,
+			assertConfig: []ConfigTester{
+				func(c *config.Config, t *testing.T) {
+					expectedRoleName := "myrole1"
+
+					if expectedRoleName != c.Controller.IAMConfig.Role.Name {
+						t.Errorf("controller's iam.role.name didn't match : expected=%v actual=%v", expectedRoleName, c.Controller.IAMConfig.Role.Name)
 					}
 				},
 			},
@@ -1814,7 +1833,7 @@ waitSignal:
 			context: "WithNodePoolWithWaitSignalDisabled",
 			configYaml: minimalValidConfigYaml + `
 worker:
-  nodePools:
+  nodePools:F
   - name: pool1
     waitSignal:
       enabled: false


### PR DESCRIPTION
We would like to control the name of the controller's IAM role without having to move its management outside of `kube-aws`.  Originally when we proposed the `useStrict` feature we were not aware of the powerful `kube-aws` plugins model - now we would like to add our `Kiam` policies through `kube-aws` plugins.  `useStrict` really means `manageExternally` and we would like a new `strictName` which can be `false` by default but if consciously set to `true` takes the name specified in `controller.iam.role.name` without pre-pending ClusterName-AWSRegion to the front of it.

e.g.
Default behavoir: -
```
controller:
  iam:
   role:
     name: myrole1
```
will result in a controller role something like `mycluster-us-west-2-myrole1`

```
controller:
  iam:
   role:
     name: myrole1
     strictName: true
```
will generate a controller role named `myrole1`