### PR TITLE
Adding davidmccormick as a maintainer of kube-aws

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,10 +4,12 @@
 reviewers:
 - c-knowles
 - danielfm
+- davidmccormick
 - mumoshu
 - redbaron
 approvers:
 - c-knowles
 - danielfm
+- davidmccormick
 - mumoshu
 - redbaron


### PR DESCRIPTION
When he kindly proposed himself as a maintainer, I couldn't agree more!

@davidmccormick is a long-time contributor to the kube-aws project who has contributed many user-support efforts and patches, enchancements, features, and so on. 

I officially express my appreciation to him and his efforts made so far and my wish that we could together and better maintain kube-aws. Let's add him to the list of approvers and reviewers now. Welcome David!