### PR TITLE
feat: add CF stackNameOverride in cluster.yaml

### DIFF
--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -137,7 +137,7 @@ func NewCluster(cfgRef *config.Cluster, opts config.StackTemplateOptions, plugin
 	clusterRef := newClusterRef(cfg, session)
 	// TODO Do this in a cleaner way e.g. in config.go
 	clusterRef.KubeResourcesAutosave.S3Path = model.NewS3Folders(cfg.DeploymentSettings.S3URI, clusterRef.ClusterName).ClusterBackups().Path()
-	stackConfig, err := clusterRef.StackConfig(config.ControlPlaneStackName, opts, session, plugins)
+	stackConfig, err := clusterRef.StackConfig(clusterRef.ControlPlaneStackName(), opts, session, plugins)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (c *Cluster) Validate() error {
 
 // NestedStackName returns a sanitized name of this control-plane which is usable as a valid cloudformation nested stack name
 func (c Cluster) NestedStackName() string {
-	return naming.FromStackToCfnResource(config.ControlPlaneStackName)
+	return naming.FromStackToCfnResource(c.ControlPlaneStackName())
 }
 
 func (c *Cluster) String() string {
@@ -287,7 +287,7 @@ func (c *Cluster) String() string {
 }
 
 func (c *ClusterRef) Destroy() error {
-	return cfnstack.NewDestroyer(config.ControlPlaneStackName, c.session, c.CloudFormation.RoleARN).Destroy()
+	return cfnstack.NewDestroyer(c.Cluster.ControlPlaneStackName(), c.session, c.CloudFormation.RoleARN).Destroy()
 }
 
 func (c *ClusterRef) validateKeyPair(ec2Svc ec2Service) error {

--- a/core/controlplane/cluster/cluster_test.go
+++ b/core/controlplane/cluster/cluster_test.go
@@ -182,12 +182,13 @@ func TestStackNameDefaults(t *testing.T) {
 	assert.Equal(t, "etcd", c.EtcdStackName(), "Invalid Etcd Stackname, should be set to 'etcd' if no override is provided.")
 }
 
-func TestStackNameOverride(t *testing.T) {
+func TestStackNameOverrides(t *testing.T) {
 	stackNameOverrideConfig := `
-stackNameOverride:
-  controlPlane: "control-plane-override"
-  network: "network-override"
-  etcd: "etcd-override"
+cloudformation:
+  stackNameOverrides:
+    controlPlane: "control-plane-override"
+    network: "network-override"
+    etcd: "etcd-override"
 `
 	configBody := defaultConfigValues(t, stackNameOverrideConfig)
 	clusterConfig, err := config.ClusterFromBytes([]byte(configBody))

--- a/core/controlplane/cluster/cluster_test.go
+++ b/core/controlplane/cluster/cluster_test.go
@@ -169,6 +169,38 @@ func (svc dummyEC2Service) DescribeKeyPairs(input *ec2.DescribeKeyPairsInput) (*
 	return output, nil
 }
 
+func TestStackNameDefaults(t *testing.T) {
+	configBody := defaultConfigValues(t, "")
+	clusterConfig, err := config.ClusterFromBytes([]byte(configBody))
+	if err != nil {
+		t.Errorf("could not get valid cluster config in `%s`: %v", configBody, err)
+	}
+	c := &ClusterRef{Cluster: clusterConfig}
+
+	assert.Equal(t, "control-plane", c.ControlPlaneStackName(), "Invalid ControlPlane Stackname, should be set to 'control-plane' if no override is provided.")
+	assert.Equal(t, "network", c.NetworkStackName(), "Invalid Network Stackname, should be set to 'network' if no override is provided.")
+	assert.Equal(t, "etcd", c.EtcdStackName(), "Invalid Etcd Stackname, should be set to 'etcd' if no override is provided.")
+}
+
+func TestStackNameOverride(t *testing.T) {
+	stackNameOverrideConfig := `
+stackNameOverride:
+  controlPlane: "control-plane-override"
+  network: "network-override"
+  etcd: "etcd-override"
+`
+	configBody := defaultConfigValues(t, stackNameOverrideConfig)
+	clusterConfig, err := config.ClusterFromBytes([]byte(configBody))
+	if err != nil {
+		t.Errorf("could not get valid cluster config in `%s`: %v", configBody, err)
+	}
+	c := &ClusterRef{Cluster: clusterConfig}
+
+	assert.Equal(t, "control-plane-override", c.ControlPlaneStackName(), "Invalid ControlPlane Stackname, should be overridden with 'control-plane-override'.")
+	assert.Equal(t, "network-override", c.NetworkStackName(), "Invalid Network Stackname, should overridden to 'network-override'.")
+	assert.Equal(t, "etcd-override", c.EtcdStackName(), "Invalid Etcd Stackname, should be overridden with 'etcd-override'.")
+}
+
 func TestExistingVPCValidation(t *testing.T) {
 
 	goodExistingVPCConfigs := []string{

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -45,7 +45,10 @@ const (
 	// This is not needed to be unique in an AWS account because the actual name of a nested stack is generated randomly
 	// by CloudFormation by including the logical name.
 	// This is NOT intended to be used to reference stack name from cloud-config as the target of awscli or cfn-bootstrap-tools commands e.g. `cfn-init` and `cfn-signal`
-	ControlPlaneStackName = "control-plane"
+	// These names can be overridden in cluster.yaml
+	controlPlaneStackName = "control-plane"
+	networkStackName      = "network"
+	etcdStackName         = "etcd"
 )
 
 func NewDefaultCluster() *Cluster {
@@ -486,19 +489,20 @@ type ComputedDeploymentSettings struct {
 // Though it is highly configurable, it's basically users' responsibility to provide `correct` values if they're going beyond the defaults.
 type DeploymentSettings struct {
 	ComputedDeploymentSettings
-	CloudFormation                        model.CloudFormation  `yaml:"cloudformation,omitempty"`
-	ClusterName                           string                `yaml:"clusterName,omitempty"`
-	S3URI                                 string                `yaml:"s3URI,omitempty"`
-	DisableContainerLinuxAutomaticUpdates string                `yaml:"disableContainerLinuxAutomaticUpdates,omitempty"`
-	KeyName                               string                `yaml:"keyName,omitempty"`
-	Region                                model.Region          `yaml:",inline"`
-	AvailabilityZone                      string                `yaml:"availabilityZone,omitempty"`
-	ReleaseChannel                        string                `yaml:"releaseChannel,omitempty"`
-	AmiId                                 string                `yaml:"amiId,omitempty"`
-	DeprecatedVPCID                       string                `yaml:"vpcId,omitempty"`
-	VPC                                   model.VPC             `yaml:"vpc,omitempty"`
-	DeprecatedInternetGatewayID           string                `yaml:"internetGatewayId,omitempty"`
-	InternetGateway                       model.InternetGateway `yaml:"internetGateway,omitempty"`
+	CloudFormation                        model.CloudFormation    `yaml:"cloudformation,omitempty"`
+	ClusterName                           string                  `yaml:"clusterName,omitempty"`
+	StackNameOverride                     model.StackNameOverride `yaml:"stackNameOverride,omitempty"`
+	S3URI                                 string                  `yaml:"s3URI,omitempty"`
+	DisableContainerLinuxAutomaticUpdates string                  `yaml:"disableContainerLinuxAutomaticUpdates,omitempty"`
+	KeyName                               string                  `yaml:"keyName,omitempty"`
+	Region                                model.Region            `yaml:",inline"`
+	AvailabilityZone                      string                  `yaml:"availabilityZone,omitempty"`
+	ReleaseChannel                        string                  `yaml:"releaseChannel,omitempty"`
+	AmiId                                 string                  `yaml:"amiId,omitempty"`
+	DeprecatedVPCID                       string                  `yaml:"vpcId,omitempty"`
+	VPC                                   model.VPC               `yaml:"vpc,omitempty"`
+	DeprecatedInternetGatewayID           string                  `yaml:"internetGatewayId,omitempty"`
+	InternetGateway                       model.InternetGateway   `yaml:"internetGateway,omitempty"`
 	// Required for validations like e.g. if instance cidr is contained in vpc cidr
 	VPCCIDR                   string `yaml:"vpcCIDR,omitempty"`
 	InstanceCIDR              string `yaml:"instanceCIDR,omitempty"`
@@ -1097,6 +1101,27 @@ type Config struct {
 	ControllerFlags  pluginmodel.ControllerFlags
 }
 
+func (c Cluster) ControlPlaneStackName() string {
+	if c.StackNameOverride.ControlPlane != "" {
+		return c.StackNameOverride.ControlPlane
+	}
+	return controlPlaneStackName
+}
+
+func (c Cluster) NetworkStackName() string {
+	if c.StackNameOverride.Network != "" {
+		return c.StackNameOverride.Network
+	}
+	return networkStackName
+}
+
+func (c Cluster) EtcdStackName() string {
+	if c.StackNameOverride.Etcd != "" {
+		return c.StackNameOverride.Etcd
+	}
+	return etcdStackName
+}
+
 func (c Cluster) StackNameEnvFileName() string {
 	return "/etc/environment"
 }
@@ -1277,7 +1302,7 @@ func (c Cluster) validate() error {
 
 	clusterNamePlaceholder := "<my-cluster-name>"
 	nestedStackNamePlaceHolder := "<my-nested-stack-name>"
-	replacer := strings.NewReplacer(clusterNamePlaceholder, "", nestedStackNamePlaceHolder, ControlPlaneStackName)
+	replacer := strings.NewReplacer(clusterNamePlaceholder, "", nestedStackNamePlaceHolder, c.ControlPlaneStackName())
 	simulatedLcName := fmt.Sprintf("%s-%s-1N2C4K3LLBEDZ-%sLC-BC2S9P3JG2QD", clusterNamePlaceholder, nestedStackNamePlaceHolder, c.Controller.LogicalName())
 	limit := 63 - len(replacer.Replace(simulatedLcName))
 	if c.Experimental.AwsNodeLabels.Enabled && len(c.ClusterName) > limit {
@@ -1293,7 +1318,7 @@ func (c Cluster) validate() error {
 			return e
 		}
 	} else {
-		if e := cfnresource.ValidateUnstableRoleNameLength(c.ClusterName, naming.FromStackToCfnResource(ControlPlaneStackName), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
+		if e := cfnresource.ValidateUnstableRoleNameLength(c.ClusterName, naming.FromStackToCfnResource(c.ControlPlaneStackName()), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
 			return e
 		}
 	}

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -489,20 +489,19 @@ type ComputedDeploymentSettings struct {
 // Though it is highly configurable, it's basically users' responsibility to provide `correct` values if they're going beyond the defaults.
 type DeploymentSettings struct {
 	ComputedDeploymentSettings
-	CloudFormation                        model.CloudFormation    `yaml:"cloudformation,omitempty"`
-	ClusterName                           string                  `yaml:"clusterName,omitempty"`
-	StackNameOverride                     model.StackNameOverride `yaml:"stackNameOverride,omitempty"`
-	S3URI                                 string                  `yaml:"s3URI,omitempty"`
-	DisableContainerLinuxAutomaticUpdates string                  `yaml:"disableContainerLinuxAutomaticUpdates,omitempty"`
-	KeyName                               string                  `yaml:"keyName,omitempty"`
-	Region                                model.Region            `yaml:",inline"`
-	AvailabilityZone                      string                  `yaml:"availabilityZone,omitempty"`
-	ReleaseChannel                        string                  `yaml:"releaseChannel,omitempty"`
-	AmiId                                 string                  `yaml:"amiId,omitempty"`
-	DeprecatedVPCID                       string                  `yaml:"vpcId,omitempty"`
-	VPC                                   model.VPC               `yaml:"vpc,omitempty"`
-	DeprecatedInternetGatewayID           string                  `yaml:"internetGatewayId,omitempty"`
-	InternetGateway                       model.InternetGateway   `yaml:"internetGateway,omitempty"`
+	CloudFormation                        model.CloudFormation  `yaml:"cloudformation,omitempty"`
+	ClusterName                           string                `yaml:"clusterName,omitempty"`
+	S3URI                                 string                `yaml:"s3URI,omitempty"`
+	DisableContainerLinuxAutomaticUpdates string                `yaml:"disableContainerLinuxAutomaticUpdates,omitempty"`
+	KeyName                               string                `yaml:"keyName,omitempty"`
+	Region                                model.Region          `yaml:",inline"`
+	AvailabilityZone                      string                `yaml:"availabilityZone,omitempty"`
+	ReleaseChannel                        string                `yaml:"releaseChannel,omitempty"`
+	AmiId                                 string                `yaml:"amiId,omitempty"`
+	DeprecatedVPCID                       string                `yaml:"vpcId,omitempty"`
+	VPC                                   model.VPC             `yaml:"vpc,omitempty"`
+	DeprecatedInternetGatewayID           string                `yaml:"internetGatewayId,omitempty"`
+	InternetGateway                       model.InternetGateway `yaml:"internetGateway,omitempty"`
 	// Required for validations like e.g. if instance cidr is contained in vpc cidr
 	VPCCIDR                   string `yaml:"vpcCIDR,omitempty"`
 	InstanceCIDR              string `yaml:"instanceCIDR,omitempty"`
@@ -1102,22 +1101,22 @@ type Config struct {
 }
 
 func (c Cluster) ControlPlaneStackName() string {
-	if c.StackNameOverride.ControlPlane != "" {
-		return c.StackNameOverride.ControlPlane
+	if c.CloudFormation.StackNameOverrides.ControlPlane != "" {
+		return c.CloudFormation.StackNameOverrides.ControlPlane
 	}
 	return controlPlaneStackName
 }
 
 func (c Cluster) NetworkStackName() string {
-	if c.StackNameOverride.Network != "" {
-		return c.StackNameOverride.Network
+	if c.CloudFormation.StackNameOverrides.Network != "" {
+		return c.CloudFormation.StackNameOverrides.Network
 	}
 	return networkStackName
 }
 
 func (c Cluster) EtcdStackName() string {
-	if c.StackNameOverride.Etcd != "" {
-		return c.StackNameOverride.Etcd
+	if c.CloudFormation.StackNameOverrides.Etcd != "" {
+		return c.CloudFormation.StackNameOverrides.Etcd
 	}
 	return etcdStackName
 }

--- a/core/etcd/cluster/cluster.go
+++ b/core/etcd/cluster/cluster.go
@@ -143,7 +143,7 @@ func NewCluster(cfgRef *controlplaneconfig.Cluster, opts controlplaneconfig.Stac
 	clusterRef.KubeAWSVersion = controlplanecluster.VERSION
 	clusterRef.HostOS = cfgRef.HostOS
 
-	cpStackConfig, err := clusterRef.StackConfig("etcd", opts, session, plugins)
+	cpStackConfig, err := clusterRef.StackConfig(cfgRef.EtcdStackName(), opts, session, plugins)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func (c *Cluster) String() string {
 }
 
 func (c *ClusterRef) Destroy() error {
-	return cfnstack.NewDestroyer("etcd", c.session, c.CloudFormation.RoleARN).Destroy()
+	return cfnstack.NewDestroyer(c.EtcdStackName(), c.session, c.CloudFormation.RoleARN).Destroy()
 }
 
 // lookupExistingEtcdEndpoints supports the migration from embedded etcd servers to their own stack

--- a/core/network/cluster/cluster.go
+++ b/core/network/cluster/cluster.go
@@ -119,7 +119,7 @@ func NewCluster(cfgRef *config.Cluster, opts config.StackTemplateOptions, plugin
 	// TODO Do this in a cleaner way e.g. in config.go
 	clusterRef.KubeResourcesAutosave.S3Path = model.NewS3Folders(cfg.DeploymentSettings.S3URI, clusterRef.ClusterName).ClusterBackups().Path()
 
-	stackConfig, err := clusterRef.StackConfig("network", opts, session, plugins)
+	stackConfig, err := clusterRef.StackConfig(cfgRef.NetworkStackName(), opts, session, plugins)
 	if err != nil {
 		return nil, err
 	}
@@ -215,5 +215,5 @@ func (c *Cluster) String() string {
 }
 
 func (c *ClusterRef) Destroy() error {
-	return cfnstack.NewDestroyer("network", c.session, c.CloudFormation.RoleARN).Destroy()
+	return cfnstack.NewDestroyer(c.NetworkStackName(), c.session, c.CloudFormation.RoleARN).Destroy()
 }

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -19,6 +19,21 @@ amiId: "{{.AmiId}}"
 # Container Linux has automatic updates https://coreos.com/os/docs/latest/update-strategies.html. This can be a risk in certain situations and this is why is disabled by default and you can enable it by setting this param to false.
 disableContainerLinuxAutomaticUpdates: true
 
+# Override the CloudFormation logical sub-stack names of control plane, etcd and/or network.
+# Changing these names causes CF to delete the old and create a new stack and thus deleting and recreating all components in the stack.
+#
+# From kube-aws 0.11.x and onwards, separate networking and etcd CF stacks have been introduced.
+# Because CF does not support migration of resources between stacks (or renaming stacks), a new VPC will be created if you upgrade an existing 0.10.x cluster.
+# Creating a new VPC and deleting the old one can cause a lot of issues and might not be desired.
+# To make this migration more feasible it is posible to change the name of the network stack to the old controleplane stack to keep the vpc components in the same stack. This way CF will not create a new vpc.
+# In this scenario the name of the networkstack becomes "ControlPlane". (which is the name of the stack which holds the vpc components in a kube-aws pre 0.11 cluster)
+# For clearity it is advised also rename the stack of the controlPlane components to, for example, "masters"
+# Note that this will keep some legacy naming around in your configs and CF stacks...
+#stackNameOverride:
+#  controlPlane: "control-plane"
+#  network: "network"
+#  etcd: "etcd"
+
 # The ID of hosted zone to add the externalDNSName to.
 # Either specify hostedZoneId or hostedZone, but not both
 #hostedZoneId: ""

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -29,10 +29,11 @@ disableContainerLinuxAutomaticUpdates: true
 # In this scenario the name of the networkstack becomes "ControlPlane". (which is the name of the stack which holds the vpc components in a kube-aws pre 0.11 cluster)
 # For clearity it is advised also rename the stack of the controlPlane components to, for example, "masters"
 # Note that this will keep some legacy naming around in your configs and CF stacks...
-#stackNameOverride:
-#  controlPlane: "control-plane"
-#  network: "network"
-#  etcd: "etcd"
+#cloudformation:
+#  stackNameOverrides:
+#    controlPlane: "control-plane"
+#    network: "network"
+#    etcd: "etcd"
 
 # The ID of hosted zone to add the externalDNSName to.
 # Either specify hostedZoneId or hostedZone, but not both

--- a/model/cloudformation.go
+++ b/model/cloudformation.go
@@ -1,5 +1,6 @@
 package model
 
 type CloudFormation struct {
-	RoleARN string `yaml:"roleARN,omitempty"`
+	RoleARN            string             `yaml:"roleARN,omitempty"`
+	StackNameOverrides StackNameOverrides `yaml:"stackNameOverrides,omitempty"`
 }

--- a/model/stack_name_override.go
+++ b/model/stack_name_override.go
@@ -1,0 +1,7 @@
+package model
+
+type StackNameOverride struct {
+	ControlPlane string `yaml:"controlPlane,omitempty"`
+	Network      string `yaml:"network,omitempty"`
+	Etcd         string `yaml:"etcd,omitempty"`
+}

--- a/model/stack_name_overrides.go
+++ b/model/stack_name_overrides.go
@@ -1,6 +1,6 @@
 package model
 
-type StackNameOverride struct {
+type StackNameOverrides struct {
 	ControlPlane string `yaml:"controlPlane,omitempty"`
 	Network      string `yaml:"network,omitempty"`
 	Etcd         string `yaml:"etcd,omitempty"`


### PR DESCRIPTION
Kube-aws 0.11.x introduced a separate CloudFormation network stack. AWS VPCs are not movable between two CloudFormation stacks. This means that Kube-aws 0.11.x will create a new VPC when upgrading.

Because we added some extra LoadBalancers and RDS Databases that we cannot easily migrate to another VPC without downtime, creating a new VPC is not desired for us.

Therefore, we decided to keep the network stack in the original control plane stack and instead moved the control plane to a new separate stack. This means that we can stick with the original VPC.

The easiest way to do this with Kube-aws without adding legacy code, is by allowing the user to override the CF stacks names of the control plane, network and etcd stacks in cluster.yaml.

This PR adds an option in cluster.yaml to override the name of the CF controlPlane,
network and etcd stacks.