### PR TITLE
v0.10.x Allow smoother migration to v0.11.x

### DIFF
--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -1278,6 +1278,15 @@
             "ToPort": 22
           },
           {{end -}}
+          {{ $ports := splitList "," "5473,8472,10250,4194,10255,9100" -}}
+          {{ range $_, $port := $ports -}}
+          {
+            "CidrIp": "{{ $.VPCCIDR }}",
+            "FromPort": {{ $port }},
+            "IpProtocol": "tcp",
+            "ToPort": {{ $port }}
+          },
+          {{ end -}}
           {
             "CidrIp": "0.0.0.0/0",
             "FromPort": -1,


### PR DESCRIPTION
Makes the migration from a v0.10.x cluster to v0.11.x smoother by allowing new kubernetes apiservers to connect to the existing nodes - despite them being in a different security group.  The relaxation of the security rules is intended only as a step to then migrating to the 0.11.x release.