### PR TITLE
IAM Role name length checks need to account for StrictName usage...

### DIFF
--- a/cfnresource/naming.go
+++ b/cfnresource/naming.go
@@ -4,22 +4,36 @@ import (
 	"fmt"
 )
 
-func ValidateUnstableRoleNameLength(clusterName string, nestedStackLogicalName string, managedIAMRoleName string, region string) error {
-	name := fmt.Sprintf("%s-%s-PRK1CVQNY7XZ-%s-%s", clusterName, nestedStackLogicalName, region, managedIAMRoleName)
-	if len(name) > 64 {
-		limit := 64 - len(name) + len(clusterName) + len(nestedStackLogicalName) + len(managedIAMRoleName)
-		return fmt.Errorf("IAM role name(=%s) will be %d characters long. It exceeds the AWS limit of 64 characters: cluster name(=%s) + nested stack name(=%s) + managed iam role name(=%s) should be less than or equal to %d", name, len(name), clusterName, nestedStackLogicalName, managedIAMRoleName, limit)
+func ValidateUnstableRoleNameLength(clusterName string, nestedStackLogicalName string, managedIAMRoleName string, region string, strict bool) error {
+	if strict {
+		name := managedIAMRoleName
+		if len(name) > 64 {
+			return fmt.Errorf("IAM role name(=%s) will be %d characters long. It exceeds the AWS limit of 64 characters", name, len(name))
+		}
+	} else {
+		name := fmt.Sprintf("%s-%s-PRK1CVQNY7XZ-%s-%s", clusterName, nestedStackLogicalName, region, managedIAMRoleName)
+		if len(name) > 64 {
+			limit := 64 - len(name) + len(clusterName) + len(nestedStackLogicalName) + len(managedIAMRoleName)
+			return fmt.Errorf("IAM role name(=%s) will be %d characters long. It exceeds the AWS limit of 64 characters: cluster name(=%s) + nested stack name(=%s) + managed iam role name(=%s) should be less than or equal to %d", name, len(name), clusterName, nestedStackLogicalName, managedIAMRoleName, limit)
+		}
 	}
 	return nil
 }
 
-func ValidateStableRoleNameLength(clusterName string, managedIAMRoleName string, region string) error {
+func ValidateStableRoleNameLength(clusterName string, managedIAMRoleName string, region string, strict bool) error {
 	// include cluster name in the managed role
 	// enables multiple clusters in the same account and region to have mirrored configuration without clashes
-	name := fmt.Sprintf("%s-%s-%s", clusterName, region, managedIAMRoleName)
-	if len(name) > 64 {
-		limit := 64 - len(name) + len(managedIAMRoleName)
-		return fmt.Errorf("IAM role name(=%s) will be %d characters long. It exceeds the AWS limit of 64 characters: clusterName(=%s) + region name(=%s) + managed iam role name(=%s) should be less than or equal to %d", name, len(name), clusterName, region, managedIAMRoleName, limit)
+	if strict {
+		name := managedIAMRoleName
+		if len(name) > 64 {
+			return fmt.Errorf("IAM role name(=%s) will be %d characters long. It exceeds the AWS limit of 64 characters", name, len(name))
+		}
+	} else {
+		name := fmt.Sprintf("%s-%s-%s", clusterName, region, managedIAMRoleName)
+		if len(name) > 64 {
+			limit := 64 - len(name) + len(managedIAMRoleName)
+			return fmt.Errorf("IAM role name(=%s) will be %d characters long. It exceeds the AWS limit of 64 characters: clusterName(=%s) + region name(=%s) + managed iam role name(=%s) should be less than or equal to %d", name, len(name), clusterName, region, managedIAMRoleName, limit)
+		}
 	}
 	return nil
 }

--- a/cfnresource/naming_test.go
+++ b/cfnresource/naming_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 func TestValidateRoleNameLength(t *testing.T) {
 	t.Run("WhenMax", func(t *testing.T) {
-		if e := ValidateUnstableRoleNameLength("my-firstcluster", "prodWorkerks", "prod-workers", "us-east-1"); e != nil {
+		if e := ValidateUnstableRoleNameLength("my-firstcluster", "prodWorkerks", "prod-workers", "us-east-1", false); e != nil {
 			t.Errorf("expected validation to succeed but failed: %v", e)
 		}
 	})
 	t.Run("WhenTooLong", func(t *testing.T) {
-		if e := ValidateUnstableRoleNameLength("my-secondcluster", "prodWorkerks", "prod-workers", "us-east-1"); e == nil {
+		if e := ValidateUnstableRoleNameLength("my-secondcluster", "prodWorkerks", "prod-workers", "us-east-1", false); e == nil {
 			t.Error("expected validation to fail but succeeded")
 		}
 	})
@@ -17,12 +17,25 @@ func TestValidateRoleNameLength(t *testing.T) {
 
 func TestValidateManagedRoleNameLength(t *testing.T) {
 	t.Run("WhenMax", func(t *testing.T) {
-		if e := ValidateStableRoleNameLength("prod", "workers", "ap-southeast-1"); e != nil {
+		if e := ValidateStableRoleNameLength("prod", "workers", "ap-southeast-1", false); e != nil {
 			t.Errorf("expected validation to succeed but failed: %v", e)
 		}
 	})
 	t.Run("WhenTooLong", func(t *testing.T) {
-		if e := ValidateStableRoleNameLength("prod", "workers-role-with-very-very-very-very-very-long-name", "ap-southeast-1"); e == nil {
+		if e := ValidateStableRoleNameLength("prod", "workers-role-with-very-very-very-very-very-long-name", "ap-southeast-1", false); e == nil {
+			t.Error("expected validation to fail but succeeded")
+		}
+	})
+}
+
+func TestValidateManagedRoleStrictNameLength(t *testing.T) {
+	t.Run("WhenMax", func(t *testing.T) {
+		if e := ValidateStableRoleNameLength("prod", "workers-role-with-very-very-very-very-very-long-name", "ap-southeast-1", true); e != nil {
+			t.Errorf("expected validation to succeed but failed: %v", e)
+		}
+	})
+	t.Run("WhenTooLong", func(t *testing.T) {
+		if e := ValidateStableRoleNameLength("prod", "workers-role-with-very-very-very-very-very-long-name-very-very-very-very-very-long-name", "ap-southeast-1", true); e == nil {
 			t.Error("expected validation to fail but succeeded")
 		}
 	})

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -3,15 +3,16 @@ package api
 import (
 	"errors"
 	"fmt"
+	"net"
+	"regexp"
+	"sort"
+	"strings"
+
 	"github.com/Masterminds/semver"
 	"github.com/kubernetes-incubator/kube-aws/cfnresource"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/kubernetes-incubator/kube-aws/naming"
 	"github.com/kubernetes-incubator/kube-aws/netutil"
-	"net"
-	"regexp"
-	"sort"
-	"strings"
 )
 
 const (
@@ -756,11 +757,11 @@ func (c Cluster) validate(cpStackName string) error {
 	}
 
 	if len(c.Controller.IAMConfig.Role.Name) > 0 {
-		if e := cfnresource.ValidateStableRoleNameLength(c.ClusterName, c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
+		if e := cfnresource.ValidateStableRoleNameLength(c.ClusterName, c.Controller.IAMConfig.Role.Name, c.Region.String(), c.Controller.IAMConfig.Role.StrictName); e != nil {
 			return e
 		}
 	} else {
-		if e := cfnresource.ValidateUnstableRoleNameLength(c.ClusterName, naming.FromStackToCfnResource(cpStackName), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
+		if e := cfnresource.ValidateUnstableRoleNameLength(c.ClusterName, naming.FromStackToCfnResource(cpStackName), c.Controller.IAMConfig.Role.Name, c.Region.String(), c.Controller.IAMConfig.Role.StrictName); e != nil {
 			return e
 		}
 	}

--- a/pkg/model/node_pool_config.go
+++ b/pkg/model/node_pool_config.go
@@ -126,11 +126,11 @@ func (c NodePoolConfig) Validate() error {
 	}
 
 	if len(c.WorkerNodePool.IAMConfig.Role.Name) > 0 {
-		if e := cfnresource.ValidateStableRoleNameLength(c.ClusterName, c.WorkerNodePool.IAMConfig.Role.Name, c.Region.String()); e != nil {
+		if e := cfnresource.ValidateStableRoleNameLength(c.ClusterName, c.WorkerNodePool.IAMConfig.Role.Name, c.Region.String(), c.WorkerNodePool.IAMConfig.Role.StrictName); e != nil {
 			return e
 		}
 	} else {
-		if e := cfnresource.ValidateUnstableRoleNameLength(c.ClusterName, c.NestedStackName(), c.WorkerNodePool.IAMConfig.Role.Name, c.Region.String()); e != nil {
+		if e := cfnresource.ValidateUnstableRoleNameLength(c.ClusterName, c.NestedStackName(), c.WorkerNodePool.IAMConfig.Role.Name, c.Region.String(), c.WorkerNodePool.IAMConfig.Role.StrictName); e != nil {
 			return e
 		}
 	}


### PR DESCRIPTION
When you are using StrictName for IAMRole names then you should have the full 64 characters to play with, but `kube-aws` was still checking the length against the generated name.