### PR TITLE
Minor fixes in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,15 @@ Generate `cluster.yaml`:
 ```
 $ mkdir my-cluster
 $ cd my-cluster
-$ kube-aws init --cluster-name=my-cluster \
---s3-uri=s3://examplebucket/mydir \
---external-dns-name=<my-cluster-endpoint> \
+$ kube-aws init \
+--cluster-name=my-cluster \
 --region=us-west-1 \
 --availability-zone=us-west-1c \
+--hosted-zone-id=<my-hosted-zone> \
+--external-dns-name=<my-cluster-endpoint> \
 --key-name=<key-pair-name> \
---kms-key-arn="arn:aws:kms:us-west-1:xxxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
+--kms-key-arn="arn:aws:kms:us-west-1:xxxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx" \
+--s3-uri=s3://examplebucket/mydir
 ```
 
 Here `us-west-1c` is used for parameter `--availability-zone`, but supported availability zone varies among AWS accounts.

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -37,7 +37,7 @@ First run `init` using the information from the pre-requisites section. For exam
   --hosted-zone-id=ZBN159WIK8JJD \
   --external-dns-name=quick-start-k8s.mycompany.com \
   --key-name=ec2-key-pair-name \
-  --kms-key-arn="arn:aws:kms:us-west-1:123456789012:key/c4f79cb0-f9fb-434a-ac3c-47c5697d51e6"
+  --kms-key-arn="arn:aws:kms:us-west-1:123456789012:key/c4f79cb0-f9fb-434a-ac3c-47c5697d51e6" \
   --s3-uri=s3://kube-aws-assets/
 ```
 


### PR DESCRIPTION
* Add missing backslash to multi-line command
* Reorder kube-aws commands in README to match Quick Start
* Newline end of file