### PR TITLE
Fixes #463 issue

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -46,7 +46,7 @@ func init() {
 
 	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.GenerateCA, "generate-ca", false, "if generating credentials, generate root CA key and cert. NOT RECOMMENDED FOR PRODUCTION USE- use '-ca-key-path' and '-ca-cert-path' options to provide your own certificate authority assets")
 	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CaKeyPath, "ca-key-path", "./credentials/ca-key.pem", "path to pem-encoded CA RSA key")
-	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CommonName, "cn", "kube-ca", "FQDN for CN in the generated CA certificate")
+	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CommonName, "cn", "kube-ca", "FQDN for CN in the self-generate CA certificate")
 	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CaCertPath, "ca-cert-path", "./credentials/ca.pem", "path to pem-encoded CA x509 certificate")
 	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.KIAM, "kiam", true, "generate TLS assets for kiam")
 	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.AwsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -46,6 +46,7 @@ func init() {
 
 	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.GenerateCA, "generate-ca", false, "if generating credentials, generate root CA key and cert. NOT RECOMMENDED FOR PRODUCTION USE- use '-ca-key-path' and '-ca-cert-path' options to provide your own certificate authority assets")
 	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CaKeyPath, "ca-key-path", "./credentials/ca-key.pem", "path to pem-encoded CA RSA key")
+	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CommonName, "cn", "kube-ca", "FQDN for CN in the generated CA certificate")
 	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CaCertPath, "ca-cert-path", "./credentials/ca.pem", "path to pem-encoded CA x509 certificate")
 	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.KIAM, "kiam", true, "generate TLS assets for kiam")
 	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.AwsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")

--- a/credential/generator.go
+++ b/credential/generator.go
@@ -4,12 +4,13 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
-	"github.com/kubernetes-incubator/kube-aws/logger"
-	"github.com/kubernetes-incubator/kube-aws/netutil"
-	"github.com/kubernetes-incubator/kube-aws/pki"
 	"io/ioutil"
 	"net"
 	"time"
+
+	"github.com/kubernetes-incubator/kube-aws/logger"
+	"github.com/kubernetes-incubator/kube-aws/netutil"
+	"github.com/kubernetes-incubator/kube-aws/pki"
 )
 
 type Generator struct {
@@ -28,6 +29,7 @@ type GeneratorOptions struct {
 	GenerateCA bool
 	CaKeyPath  string
 	CaCertPath string
+	CommonName string
 	// KIAM is set to true when you want kube-aws to render TLS assets for uswitch/kiam
 	KIAM bool
 }
@@ -38,7 +40,7 @@ func (c Generator) GenerateAssetsOnDisk(dir string, o GeneratorOptions) (*RawAss
 	var caCert *x509.Certificate
 	if o.GenerateCA {
 		var err error
-		caKey, caCert, err = pki.NewCA(c.TLSCADurationDays)
+		caKey, caCert, err = pki.NewCA(c.TLSCADurationDays, o.CommonName)
 		if err != nil {
 			return nil, fmt.Errorf("failed generating cluster CA: %v", err)
 		}

--- a/credential/generator.go
+++ b/credential/generator.go
@@ -4,13 +4,12 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
-	"net"
-	"time"
-
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/kubernetes-incubator/kube-aws/netutil"
 	"github.com/kubernetes-incubator/kube-aws/pki"
+	"io/ioutil"
+	"net"
+	"time"
 )
 
 type Generator struct {

--- a/pki/ca.go
+++ b/pki/ca.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func NewCA(caDurationDays int) (*rsa.PrivateKey, *x509.Certificate, error) {
+func NewCA(caDurationDays int, CommonName string) (*rsa.PrivateKey, *x509.Certificate, error) {
 	caKey, err := NewPrivateKey()
 	if err != nil {
 		return nil, nil, err
@@ -16,7 +16,7 @@ func NewCA(caDurationDays int) (*rsa.PrivateKey, *x509.Certificate, error) {
 	caDuration := time.Duration(caDurationDays) * 24 * time.Hour
 
 	caConfig := CACertConfig{
-		CommonName:   "kube-ca",
+		CommonName:   CommonName,
 		Organization: "kube-aws",
 		Duration:     caDuration,
 	}


### PR DESCRIPTION
cmd package: add the cn flag

all self-signed CA have the same CN and this can confuse clients like Chrome. Now we can set different CN.

Fixes #463