### PR TITLE
CA self-genereted cert: add the cn flag

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -46,6 +46,7 @@ func init() {
 
 	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.GenerateCA, "generate-ca", false, "if generating credentials, generate root CA key and cert. NOT RECOMMENDED FOR PRODUCTION USE- use '-ca-key-path' and '-ca-cert-path' options to provide your own certificate authority assets")
 	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CaKeyPath, "ca-key-path", "./credentials/ca-key.pem", "path to pem-encoded CA RSA key")
+	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CommonName, "cn", "kube-ca", "FQDN for CN in the self-generate CA certificate")
 	cmdRenderCredentials.Flags().StringVar(&renderCredentialsOpts.CaCertPath, "ca-cert-path", "./credentials/ca.pem", "path to pem-encoded CA x509 certificate")
 	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.KIAM, "kiam", true, "generate TLS assets for kiam")
 	cmdRenderCredentials.Flags().BoolVar(&renderCredentialsOpts.AwsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")

--- a/credential/generator.go
+++ b/credential/generator.go
@@ -28,6 +28,7 @@ type GeneratorOptions struct {
 	GenerateCA bool
 	CaKeyPath  string
 	CaCertPath string
+	CommonName string
 	// KIAM is set to true when you want kube-aws to render TLS assets for uswitch/kiam
 	KIAM bool
 }
@@ -38,7 +39,7 @@ func (c Generator) GenerateAssetsOnDisk(dir string, o GeneratorOptions) (*RawAss
 	var caCert *x509.Certificate
 	if o.GenerateCA {
 		var err error
-		caKey, caCert, err = pki.NewCA(c.TLSCADurationDays)
+		caKey, caCert, err = pki.NewCA(c.TLSCADurationDays, o.CommonName)
 		if err != nil {
 			return nil, fmt.Errorf("failed generating cluster CA: %v", err)
 		}

--- a/pkg/model/credentials_test.go
+++ b/pkg/model/credentials_test.go
@@ -4,10 +4,11 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"testing"
+
 	"github.com/kubernetes-incubator/kube-aws/credential"
 	"github.com/kubernetes-incubator/kube-aws/pkg/api"
 	"github.com/kubernetes-incubator/kube-aws/pki"
-	"testing"
 )
 
 func genAssets(t *testing.T) *credential.RawAssetsOnMemory {
@@ -16,7 +17,7 @@ func genAssets(t *testing.T) *credential.RawAssetsOnMemory {
 		t.Fatalf("failed generating config: %v", err)
 	}
 
-	caKey, caCert, err := pki.NewCA(c.TLSCADurationDays)
+	caKey, caCert, err := pki.NewCA(c.TLSCADurationDays, "kube-ca")
 	if err != nil {
 		t.Fatalf("failed generating tls ca: %v", err)
 	}

--- a/pki/ca.go
+++ b/pki/ca.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func NewCA(caDurationDays int) (*rsa.PrivateKey, *x509.Certificate, error) {
+func NewCA(caDurationDays int, CommonName string) (*rsa.PrivateKey, *x509.Certificate, error) {
 	caKey, err := NewPrivateKey()
 	if err != nil {
 		return nil, nil, err
@@ -16,7 +16,7 @@ func NewCA(caDurationDays int) (*rsa.PrivateKey, *x509.Certificate, error) {
 	caDuration := time.Duration(caDurationDays) * 24 * time.Hour
 
 	caConfig := CACertConfig{
-		CommonName:   "kube-ca",
+		CommonName:   CommonName,
 		Organization: "kube-aws",
 		Duration:     caDuration,
 	}


### PR DESCRIPTION
CA self-genereted cert: add the cn flag

all self-signed CA have the samee CN and this can confuse clients like
Chrome. Now we can set different CN

Fixes #463