### PR TITLE
'AvailabilityZone' nodepool rolling strategy

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -302,12 +302,14 @@ worker:
 #  # Can be overriden per node pool by specifying `worker.nodePools[].apiEndpointName`
 #  apiEndpointName: versionedPublic
 #
-#  # Used to globally specify the strategy in which nodePools will roll out: in sequence or parallel
-#  # Default behaviour ('parallel') will roll out nodePools concurrently
-#  # If set to 'Sequential', the nodePools will roll out sequentially, in order of declaration
-#  # If set at a Worker level, it will only take effect if it is not set at a nodePool level
-#  # For finer grain control, declare it on a nodePool-by-nodePool basis
-#  nodePoolRollingStrategy: Sequential
+#  # 'nodePoolRollingStrategy' is used to globally specify the strategy in which nodePools will roll out: in 'Sequential', 'Parallel' or 'AvailabilityZone'
+#  # - 'Sequential' - roll each nodepool one-at-a-time in the order that they are listed in this file.
+#  # - 'Parallel' - roll each nodepool at the same time.
+#  # - 'AvailabilityZone' - roll the nodepools an AWS AvailabilityZone at-a-time.
+#  #     (multiple pools in the same availability zone are rolled in 'Parrallel')
+#  #     (only nodepools containing subnets within a single AWS AvailabilityZone can be rolled out using this strategy)
+#  # The default behaviour is to roll using 'Parallel'
+#  nodePoolRollingStrategy: Parrallel
 
   nodePools:
     - # Name of this node pool. Must be unique among all the node pools in this cluster
@@ -317,12 +319,12 @@ worker:
 #      # If omitted, public subnets are created by kube-aws and used for worker nodes
 #      subnets:
 #      - name: ManagedPublicSubnet1
-#      # Used to specify the strategy in which the nodePool will roll out: in sequence or parallel
-#      # By default (if not set at nodePool/worker level) the nodePool will roll out in parallel
-#      # If set to 'Sequential', the nodePools will roll out one-by-one in order of declaration
-#      # NOTICE: if there are multiple nodePool groups that will use both rolling strategies ('Sequential'/'Parallel')
-#      # the nodePools rolling out in sequence should be declared before those that roll out in parallel
-#      # otherwise, the first declared nodePool to roll out in sequence will depend on the last concurrent nodePool
+#
+#      # 'nodePoolRollingStrategy' is usually specified for all nodepools at the `worker` level but can be mix-and-matched on a per nodepool basis.
+#      # Please note when mixing:-
+#      # - A pool rolling out using the 'AvailabilityZone' strategy will only wait on other pools using the same strategy.
+#      # - When mixing 'Sequential` with other strategies define the `Sequential` nodepools first so that they don't wait unnecessarily for pools from the
+#      #   other strategies
 #      nodePoolRollingStrategy: Parallel
 #
 #      # Existing "glue" security groups attached to worker nodes which are typically used to allow

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -309,7 +309,7 @@ worker:
 #  #     (multiple pools in the same availability zone are rolled in 'Parrallel')
 #  #     (only nodepools containing subnets within a single AWS AvailabilityZone can be rolled out using this strategy)
 #  # The default behaviour is to roll using 'Parallel'
-#  nodePoolRollingStrategy: Parrallel
+#  nodePoolRollingStrategy: Parallel
 
   nodePools:
     - # Name of this node pool. Must be unique among all the node pools in this cluster

--- a/builtin/files/stack-templates/root.json.tmpl
+++ b/builtin/files/stack-templates/root.json.tmpl
@@ -109,6 +109,11 @@
           ,"{{ (index $.NodePools (sub $i 1)).Name}}"
           {{ end -}}
         {{ end -}}
+        {{ if eq $p.NodePoolRollingStrategy "AvailabilityZone" -}}
+          {{- if ne ($.NodePoolAvailabilityZoneDependencies $p $.Subnets) "" }}
+          ,{{ $.NodePoolAvailabilityZoneDependencies $p $.Subnets }}
+          {{- end }}
+        {{ end -}}
       ]
     }{{end}}
     {{range $n, $r := .ExtraCfnResources}}

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -1081,7 +1081,7 @@ write_files:
         users:
         - name: kubelet
           user:
-            client-certificate: {{ if .Kubelet.RotateCerts.Enabled }}/etc/kubernetes/ssl/kubelet-client-current.pem{{else}}/etc/kubernetes/ssl/kubelet-client-current.pem{{end}}
+            client-certificate: /etc/kubernetes/ssl/kubelet-client-current.pem
             client-key: /etc/kubernetes/ssl/kubelet.key
         contexts:
         - context:

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -361,19 +361,19 @@ coreos:
         {{ end }}--cluster-domain=cluster.local \
         --cloud-provider=aws \
         --cert-dir=/etc/kubernetes/ssl \
-        {{- if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken (not .Kubelet.Kubeconfig)}}
+        {{- if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}
         --experimental-bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- if .Kubelet.RotateCerts.Enabled }}
         --rotate-certificates \
         {{- end }}
         {{- else }}
-        {{- if .Kubelet.Kubeconfig}}
-        --kubeconfig={{ .Kubelet.Kubeconfig }} \
-        {{- else }}
-        --kubeconfig=/etc/kubernetes/kubeconfig/worker.yaml \
         --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
         {{- end }}
+        {{- if .Kubelet.Kubeconfig }}
+        --kubeconfig={{ .Kubelet.Kubeconfig }} \
+        {{- else }}
+        --kubeconfig=/etc/kubernetes/kubeconfig/worker.yaml \
         {{- end }}
         {{- if .FeatureGates.Enabled }}
         --feature-gates=\"{{.FeatureGates.String}}\" \
@@ -1069,6 +1069,26 @@ write_files:
             user: tls-bootstrap
           name: tls-bootstrap-context
         current-context: tls-bootstrap-context
+  - path: /etc/kubernetes/kubeconfig/worker.yaml
+    content: |
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: local
+          cluster:
+            certificate-authority: /etc/kubernetes/ssl/ca.pem
+            server: {{.APIEndpointURL}}:443
+        users:
+        - name: kubelet
+          user:
+            client-certificate: {{ if .Kubelet.RotateCerts.Enabled }}/etc/kubernetes/ssl/kubelet-client-current.pem{{else}}/etc/kubernetes/ssl/kubelet-client-current.pem{{end}}
+            client-key: /etc/kubernetes/ssl/kubelet.key
+        contexts:
+        - context:
+            cluster: local
+            user: kubelet
+          name: kubelet-context
+        current-context: kubelet-context
 {{ else }}
   - path: /etc/kubernetes/kubeconfig/worker.yaml
     content: |

--- a/core/root/rolling_strategy.go
+++ b/core/root/rolling_strategy.go
@@ -1,0 +1,99 @@
+package root
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubernetes-incubator/kube-aws/logger"
+	"github.com/kubernetes-incubator/kube-aws/pkg/api"
+)
+
+// returns NodePoolRolling strategy string to be used in stack-template
+func (p nodePool) NodePoolRollingStrategy() string {
+	return p.nodePool.NodePoolConfig.WorkerNodePool.NodePoolRollingStrategy
+}
+
+// NodePoolAvailabilityZoneDependencies produces a list of NodePool logical names that the present nodepool depends upon
+// when using the 'AvailabilityZone' NodePoolRollingStrategy.
+// Only other pools using the 'AvailabilityZone' strategy are considered.
+// Only nodepools containing a single AZ can use this strategy!
+// Returns a comma separated quoted list, e.g. "pool1","pool2","pool3"
+func (c Cluster) nodePoolAvailabilityZoneDependencies(pool nodePool, subnets api.Subnets) (string, error) {
+	poolConfig := pool.nodePool.NodePoolConfig
+
+	var order []string
+	order, err := c.azOrder()
+	if err != nil {
+		return "", fmt.Errorf("can't resolve nodepool availability zone ordering dependencies for %s: %v", poolConfig.NodePoolName, err)
+	}
+	logger.Debugf("AZ Rollout order: %v", order)
+
+	// only the first subnet is used to determine the az asscociated with the nodepool.
+	position, err := azPosition(order, poolConfig.Subnets[0].AvailabilityZone)
+	if err != nil {
+		logger.Debugf("There was the following error looking up nodepool azPosition: %v", err)
+		return "", err
+	}
+	if position == 0 {
+		// a nodePool with position 0 doesn't have any other nodepool dependencies
+		logger.Debugf("The AZ for nodepool %s is first in the list, so it does not have any dependencies", poolConfig.NodePoolName)
+		return "", nil
+	}
+
+	return `"` + strings.Join(c.allNodePoolLogicalNamesinAZ(order[position-1]), `","`) + `"`, nil
+}
+
+// rolloutAZOrder works out an order for availability zones from the order of the nodepool stacks were loaded from the cluster.yaml.
+// It also provides some validation - preventing users from selecting subnets in separate az's which would be impossible to order by placing dependencies
+// at the nodepool stack level.
+func (c Cluster) azOrder() ([]string, error) {
+	var azOrder []string
+	seen := make(map[string]bool)
+	for _, pool := range c.nodePoolStacks {
+		poolConfig := pool.NodePoolConfig
+		if poolConfig.NodePoolRollingStrategy == "AvailabilityZone" {
+			if len(poolConfig.Subnets) == 0 {
+				return azOrder, fmt.Errorf("worker nodepool %s has 'AvailabilityZone' rolling strategy but has no subnets", poolConfig.NodePoolName)
+			}
+			for _, subnet := range poolConfig.Subnets {
+				if subnet.AvailabilityZone == "" {
+					return azOrder, fmt.Errorf("worker nodepool %s can not use the 'AvailabilityZone' rolling strategy because its subnet %s has an empty availability zone", poolConfig.NodePoolName, subnet.Name)
+				}
+				if subnet.AvailabilityZone != poolConfig.Subnets[0].AvailabilityZone {
+					return azOrder, fmt.Errorf("worker nodepool %s can't have subnets in different availability zones and also use the 'AvailabilityZone' rolling strategy", poolConfig.NodePoolName)
+				}
+				if !seen[subnet.AvailabilityZone] {
+					logger.Debugf("added new az %s to azdeployment order", subnet.AvailabilityZone)
+					azOrder = append(azOrder, subnet.AvailabilityZone)
+					seen[subnet.AvailabilityZone] = true
+				}
+			}
+		}
+	}
+	return azOrder, nil
+}
+
+// azPosition tells us which integer position a particular az lies within an list
+func azPosition(azList []string, az string) (int, error) {
+	for index, value := range azList {
+		if value == az {
+			logger.Debugf("az %s is position %d in the azorder", az, index)
+			return index, nil
+		}
+	}
+	return 0, fmt.Errorf("could not find az %s in the azorder list: %v", az, azList)
+}
+
+// allNodePoolsinAZ returns a slice of nodepool names with subnets within a given availability zone
+func (c Cluster) allNodePoolLogicalNamesinAZ(az string) []string {
+	var poolNames []string
+	for _, pool := range c.nodePoolStacks {
+		poolConfig := pool.NodePoolConfig
+		logger.Debugf("found the following AZ in nodepool %s: '%s'", poolConfig.NodePoolName, poolConfig.Subnets[0].AvailabilityZone)
+		if poolConfig.NodePoolRollingStrategy == "AvailabilityZone" && poolConfig.Subnets[0].AvailabilityZone == az {
+			poolNames = append(poolNames, poolConfig.NodePoolLogicalName())
+		}
+	}
+	logger.Debugf("The following nodepools are in AZ %s: %v", az, poolNames)
+	return poolNames
+}

--- a/core/root/template_params.go
+++ b/core/root/template_params.go
@@ -165,35 +165,38 @@ func (p nodePool) NeedToExportIAMroles() bool {
 	return p.nodePool.NodePoolConfig.IAMConfig.InstanceProfile.Arn == ""
 }
 
-// returns NodePoolRolling strategy string to be used in stack-template
-func (p nodePool) NodePoolRollingStrategy() string {
-	return p.nodePool.NodePoolConfig.WorkerNodePool.NodePoolRollingStrategy
-}
-
-func (c TemplateParams) ControlPlane() controlPlane {
+func (p TemplateParams) ControlPlane() controlPlane {
 	return controlPlane{
-		controlPlane: c.cluster.controlPlaneStack,
+		controlPlane: p.cluster.controlPlaneStack,
 	}
 }
 
-func (c TemplateParams) Etcd() etcdStack {
+func (p TemplateParams) Etcd() etcdStack {
 	return etcdStack{
-		etcd: c.cluster.Etcd(),
+		etcd: p.cluster.Etcd(),
 	}
 }
 
-func (c TemplateParams) Network() networkStack {
+func (p TemplateParams) Network() networkStack {
 	return networkStack{
-		network: c.cluster.Network(),
+		network: p.cluster.Network(),
 	}
 }
 
-func (c TemplateParams) NodePools() []nodePool {
+func (p TemplateParams) NodePools() []nodePool {
 	nps := []nodePool{}
-	for _, np := range c.cluster.nodePoolStacks {
+	for _, np := range p.cluster.nodePoolStacks {
 		nps = append(nps, nodePool{
 			nodePool: np,
 		})
 	}
 	return nps
+}
+
+func (p TemplateParams) Subnets() api.Subnets {
+	return p.cluster.Cfg.Subnets
+}
+
+func (p TemplateParams) NodePoolAvailabilityZoneDependencies(pool nodePool, subnets api.Subnets) (string, error) {
+	return p.cluster.nodePoolAvailabilityZoneDependencies(pool, subnets)
 }

--- a/pkg/model/compiler.go
+++ b/pkg/model/compiler.go
@@ -2,10 +2,11 @@ package model
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/kubernetes-incubator/kube-aws/coreos/amiregistry"
 	"github.com/kubernetes-incubator/kube-aws/pkg/api"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 func Compile(cfgRef *api.Cluster, opts api.ClusterOptions) (*Config, error) {
@@ -121,8 +122,8 @@ func Compile(cfgRef *api.Cluster, opts api.ClusterOptions) (*Config, error) {
 			}
 		}
 
-		if np.NodePoolRollingStrategy != "Parallel" && np.NodePoolRollingStrategy != "Sequential" {
-			if c.Worker.NodePoolRollingStrategy != "" && (c.Worker.NodePoolRollingStrategy == "Sequential" || c.Worker.NodePoolRollingStrategy == "Parallel") {
+		if np.NodePoolRollingStrategy != "Parallel" && np.NodePoolRollingStrategy != "Sequential" && np.NodePoolRollingStrategy != "AvailabilityZone" {
+			if c.Worker.NodePoolRollingStrategy != "" && (c.Worker.NodePoolRollingStrategy == "Sequential" || c.Worker.NodePoolRollingStrategy == "Parallel" || c.Worker.NodePoolRollingStrategy == "AvailabilityZone") {
 				np.NodePoolRollingStrategy = c.Worker.NodePoolRollingStrategy
 			} else {
 				np.NodePoolRollingStrategy = "Parallel"


### PR DESCRIPTION
The default 'Parallel' nodepool rolling strategy is a bit dangerous because it can take down nodes across multiple availability zones and so, if you are unlucky and have an application with only a 1, 2 or 3 pods the parallel roll could take down all of your instances of at the same time - which is definitely not desirable!

The 'Sequential' nodepool rolling strategy is a lot safer because it will only roll a single nodepool at a time, but is slow as a result.  When you have multiple different node pools, or large clusters, you may find that your rolls, although safe, take a long time to complete.

The new 'AvailabilityZone' nodepool rolling strategy fits between the two.  It will roll all of nodepools that belong to the same AWS AvailabilityZone at the same time and roll the availability zones in order.  Example: -

```
worker:
  nodePoolRollingStrategy: AvailabilityZone
  nodePools:
    "TestA":
       subnet: a (in availability zone us-west-2a)
    "TestB":
      subnet: b (in availability zone us-west-2b)
    "TestC":
       subnet: a (in availability zone us-west-2a)
    "TestD":
      subnet: b (in availability zone us-west-2b)
```
In config above, "TestA" and "TestC" will roll in parallel with each other first (because they are both availability zone `us-west-2a`), then once they have finished rolling, "TestB" and "TestD" will roll in parallel.

Note: Only nodepools containing subnets in the same aws availability zone can be rolled using this strategy otherwise you will get an error when rendering the root cloud-formation stack.