### PR TITLE
bug: Nodepool stack needs to use the nodepool logical name

### DIFF
--- a/builtin/files/stack-templates/node-pool.json.tmpl
+++ b/builtin/files/stack-templates/node-pool.json.tmpl
@@ -294,7 +294,7 @@
       "Properties": {
         "Path": "/",
         "Roles": [
-          {"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackName}-{{.NodePoolName}}IAMRoleWorker"}}
+          {"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackName}-{{.NodePoolLogicalName}}IAMRoleWorker"}}
         ]
       },
       "Type": "AWS::IAM::InstanceProfile"
@@ -338,7 +338,7 @@
     {{if not .IAMConfig.InstanceProfile.Arn }}
     "WorkerIAMRoleArn": {
       "Description": "The ARN of the IAM role for this Node Pool",
-      "Value": {"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackName}-{{.NodePoolName}}IAMRoleWorkerArn"}},
+      "Value": {"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackName}-{{.NodePoolLogicalName}}IAMRoleWorkerArn"}},
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-WorkerIAMRoleArn" } }
     },
     {{end}}


### PR DESCRIPTION
Found an issue where the network and nodepool stacks are using not using the same name for the worker arn.  Correct by using santized name for both.