### PR TITLE
Fix for using StrictName to define a specific Controller Role Name

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -115,7 +115,7 @@ func (c Controller) InstanceProfileRoles() string {
 }
 
 func (c Controller) InstanceProfileRole() string {
-	if c.IAMConfig.Role.StrictName && c.IAMConfig.Role.Name != "" {
+	if c.IAMConfig.Role.ManageExternally && c.IAMConfig.Role.Name != "" {
 		return fmt.Sprintf(`"%s"`, c.IAMConfig.Role.Name)
 	} else {
 		return `{"Ref":"IAMRoleController"}`


### PR DESCRIPTION
Correction/Bug - the IAMRoleController should always be a reference to the cloudformation role object unless it is managed externally, not just because we have used a strict name.