### PR TITLE
Etcd 3.3.10, compaction and defrag

### DIFF
--- a/builtin/files/etcdadm/README.md
+++ b/builtin/files/etcdadm/README.md
@@ -14,7 +14,7 @@ AWS_SECRET_ACCESS_KEY=... \
 ETCDADM_AWSCLI_DOCKER_IMAGE=quay.io/coreos/awscli \
 # Required settings
 AWS_DEFAULT_REGION=ap-northeast-1 \
-ETCD_VERSION=3.2.13 \
+ETCD_VERSION=3.3.10 \
 ETCD_DATA_DIR=/var/lib/etcd \
 ETCD_INITIAL_CLUSTER=etcd0=http://127.0.0.1:3080,etcd1=http://127.0.0.1:3180,etcd2=http://127.0.0.1:3280 \
 ETCDCTL_ENDPOINTS=http://127.0.0.1:3079,etcd1=http://127.0.0.1:3179,etcd2=http://127.0.0.1:3279, \
@@ -39,6 +39,9 @@ save it in S3
 * `etcdadm replace` is used to manually recover from an etcd member from a permanent failure. It resets the etcd member running on the same node as etcdadm by:
   1. clearing the contents of the etcd data dir
   2. removing and then re-adding the etcd member by running `etcdctl member remove` and then `etcdctl memer add`
+* `etcdadm compact` performs a compaction of the etcd cluster (i.e. removes all version history of the keys leaving the last one) - warning, the operation can adversely affect etcd cluster performance whilst it is running.
+* `etcdadm defrag` performed a de-fragmentation operation on the current etcd servers datastore (does not perform this cluster-wide) - - warning, the operation can adversely affect etcd cluster performance whilst it is running.
+
 
 ## Pre-requisites
 

--- a/builtin/files/etcdadm/etcdadm
+++ b/builtin/files/etcdadm/etcdadm
@@ -85,7 +85,7 @@ config_etcd_endpoints() {
   echo "${ETCD_ENDPOINTS}"
 }
 
-etcd_version=${ETCD_VERSION:-3.2.13}
+etcd_version=${ETCD_VERSION:-3.3.10}
 etcd_aci_url="https://github.com/coreos/etcd/releases/download/v$etcd_version/etcd-v$etcd_version-linux-amd64.aci"
 
 member_count="${ETCDADM_MEMBER_COUNT:?missing required env}"
@@ -221,6 +221,14 @@ cluster_check() {
   else
     cluster_failure_beginning_time_record
   fi
+}
+
+cluster_compact() {
+  member_etcdctl compact 1
+}
+
+member_defrag() {
+  member_etcdctl defrag --command-timeout=60s --debug
 }
 
 member_next_index() {
@@ -914,6 +922,12 @@ etcdadm_main() {
       ;;
     "check" )
       cluster_check
+      ;;
+    "compact" )
+      cluster_compact
+      ;;
+    "defrag" )
+      member_defrag
       ;;
     * )
       if [ "$(type -t "$cmd")" == "function" ]; then

--- a/builtin/files/stack-templates/node-pool.json.tmpl
+++ b/builtin/files/stack-templates/node-pool.json.tmpl
@@ -294,7 +294,7 @@
       "Properties": {
         "Path": "/",
         "Roles": [
-          {"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackName}-{{.NodePoolName}}IAMRoleWorker"}}
+          {"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackName}-{{.NodePoolLogicalName}}IAMRoleWorker"}}
         ]
       },
       "Type": "AWS::IAM::InstanceProfile"
@@ -338,7 +338,7 @@
     {{if not .IAMConfig.InstanceProfile.Arn }}
     "WorkerIAMRoleArn": {
       "Description": "The ARN of the IAM role for this Node Pool",
-      "Value": {"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackName}-{{.NodePoolName}}IAMRoleWorkerArn"}},
+      "Value": {"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackName}-{{.NodePoolLogicalName}}IAMRoleWorkerArn"}},
       "Export": { "Name": { "Fn::Sub": "${AWS::StackName}-WorkerIAMRoleArn" } }
     },
     {{end}}

--- a/builtin/files/userdata/cloud-config-etcd
+++ b/builtin/files/userdata/cloud-config-etcd
@@ -409,6 +409,10 @@ coreos:
           content: |
             [Service]
             Environment="ETCD_IMAGE_TAG=v{{.Etcd.Version}}"
+        - name: 40-auto-compaction.conf
+          content: |
+            [Service]
+            Environment="ETCD_AUTO_COMPACTION_RETENTION=1"
         {{end}}
       enable: true
       command: start

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -115,7 +115,7 @@ func (c Controller) InstanceProfileRoles() string {
 }
 
 func (c Controller) InstanceProfileRole() string {
-	if c.IAMConfig.Role.StrictName && c.IAMConfig.Role.Name != "" {
+	if c.IAMConfig.Role.ManageExternally && c.IAMConfig.Role.Name != "" {
 		return fmt.Sprintf(`"%s"`, c.IAMConfig.Role.Name)
 	} else {
 		return `{"Ref":"IAMRoleController"}`

--- a/pkg/api/etcd.go
+++ b/pkg/api/etcd.go
@@ -205,7 +205,7 @@ func (e Etcd) Version() EtcdVersion {
 	if e.Cluster.Version != "" {
 		return e.Cluster.Version
 	}
-	return "3.2.13"
+	return "3.3.10"
 }
 
 func (v EtcdVersion) Is3() bool {

--- a/pkg/api/etcd_test.go
+++ b/pkg/api/etcd_test.go
@@ -36,8 +36,8 @@ func TestEtcd(t *testing.T) {
 		t.Errorf("name tag key incorrect, expected: kube-aws:etcd:name, got: %s", etcdTest.NameTagKey())
 	}
 
-	if etcdTest.Version() != "3.2.13" {
-		t.Errorf("etcd version incorrect, epxected: 3.2.13, got: %s", etcdTest.Version())
+	if etcdTest.Version() != "3.3.10" {
+		t.Errorf("etcd version incorrect, epxected: 3.3.10, got: %s", etcdTest.Version())
 	}
 
 	if !etcdTest.NodeShouldHaveEIP() {


### PR DESCRIPTION
- Bump etcd version to 3.3.10
- Enable auto-compaction at 1hour by default
- Add etcdadm *compact* and *defrag* commands to allow cluster admins to manually clean up their etcd instances