### PR TITLE
Do not leak unqualified dns requests to upstream dns servers

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3933,6 +3933,7 @@ write_files:
                 - -k
                 - --min-port=1024
                 - --cache-size=1000
+                - --server=//{{.DNSServiceIP}}
                 - --server=/cluster.local/{{.DNSServiceIP}}
                 - --server=/in-addr.arpa/{{.DNSServiceIP}}
                 - --server=/ip6.arpa/{{.DNSServiceIP}}


### PR DESCRIPTION
When running a cluster with the node based dnsmasq resolver enabled, `nodeLocalResolver: true` it is possible that some unqualified names are sent to the upstream name servers for resolution.  This happens when the unqualified name does not match anything in kubernetes.

The `/etc/resolv.conf` in each pod looks like this when using this feature (assuming we're in the default namespace): -

```
nameserver 10.29.15.242
search default.svc.cluster.local svc.cluster.local cluster.local us-west-2.compute.internal
options ndots:5
```

And the `dnsmasq-node` is configured with the following settings: -
```
      containers:
      - args:
        - -v=2
        - -logtostderr
        - -configDir=/etc/k8s/dns/dnsmasq-nanny
        - -restartDnsmasq=true
        - --
        - -k
        - --min-port=1024
        - --cache-size=1000
        - --server=/cluster.local/192.168.0.3
        - --server=/in-addr.arpa/192.168.0.3
        - --server=/ip6.arpa/192.168.0.3
        - --log-facility=-
```

So if I try and resolve the host `picard` then because it contains less than 5 dots it will first try to resolve locally by combining with each search path in turn: -

1.  `picard.default.svc.cluster.local` is forwarded to the kube-cluster dns and "not found" is returned
2. `picard.svc.cluster.local` is forwarded to the kube-cluster dns and  "not found" is returned
3. `picard.cluster.local` is forwarded to the kube-cluster dns and  "not found" is returned
4. `picard.us-west-2.compute.internal` is forwarded to the upstream dns and  "not found" is returned.
5. `picard` is sent to the upstream dns and "not found" is returned.

All 5 lookups are performed and two against the upstream dns infrastructure before it is determined that the host is unknown.  This can generate a lot of noise and we would like to contain this traffic within the kubernetes cluster as much as possible (given that we can end up putting a load on the external dns infrastructure).

It does not make sense to send unqualified hosts upstream, we should keep them within the cluster.  Adding the following setting to *dnsmasq* will have the desired effect: -

```
--server=//192.168.0.3
```  

We should also probably do something about the extra `picard.us-west-2.compute.internal` lookup but this is less obvious as we would probably want this to forward to the Amazon VPC dns resolver that usually listens on .2 ip address in the VPC.
