### PR TITLE
The getting started guide should not recommend 2 controllers for HA

### DIFF
--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -3,7 +3,6 @@
 If you're deploying a cluster with kube-aws:
 
 * [EC2 instances whose types are larger than or equal to `t2.medium` should be chosen for the cluster to work reliably](https://github.com/kubernetes-incubator/kube-aws/issues/138)
-* [At least 3 etcd, 2 controller, 2 worker nodes are required to achieve high availability](https://github.com/kubernetes-incubator/kube-aws/issues/138#issuecomment-266432162)
 
 ## Deploying to an existing VPC
 


### PR DESCRIPTION
The doc recommends this:

> At least 3 etcd, 2 controller, 2 worker nodes are required to achieve high availability 

But the current (at the time of writing at least) [docs](https://kubernetes.io/docs/tasks/administer-cluster/highly-available-master/#best-practices-for-replicating-masters-for-ha-clusters) say this:

> Do not use a cluster with two master replicas. Consensus on a two-replica cluster requires both replicas running when changing persistent state. As a result, both replicas are needed and a failure of any replica turns cluster into majority failure state. A two-replica cluster is thus inferior, in terms of HA, to a single replica cluster.

My understanding is that this makes the "2 controller for HA" advice incorrect so it should be changed or removed.

My feeling is that HA Kubernetes controllers is probably out of the scope of a getting started guide so it should just be removed. If you would rather update the advice I think that would also work.