### PR TITLE
Fix for kubelet startup on nodes when using TLS bootstrapping

### DIFF
--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -1081,7 +1081,7 @@ write_files:
         users:
         - name: kubelet
           user:
-            client-certificate: {{ if .Kubelet.RotateCerts.Enabled }}/etc/kubernetes/ssl/kubelet-client-current.pem{{else}}/etc/kubernetes/ssl/kubelet-client-current.pem{{end}}
+            client-certificate: /etc/kubernetes/ssl/kubelet-client-current.pem
             client-key: /etc/kubernetes/ssl/kubelet.key
         contexts:
         - context:

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -361,19 +361,19 @@ coreos:
         {{ end }}--cluster-domain=cluster.local \
         --cloud-provider=aws \
         --cert-dir=/etc/kubernetes/ssl \
-        {{- if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken (not .Kubelet.Kubeconfig)}}
+        {{- if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}
         --experimental-bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- if .Kubelet.RotateCerts.Enabled }}
         --rotate-certificates \
         {{- end }}
         {{- else }}
-        {{- if .Kubelet.Kubeconfig}}
-        --kubeconfig={{ .Kubelet.Kubeconfig }} \
-        {{- else }}
-        --kubeconfig=/etc/kubernetes/kubeconfig/worker.yaml \
         --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
         --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
         {{- end }}
+        {{- if .Kubelet.Kubeconfig }}
+        --kubeconfig={{ .Kubelet.Kubeconfig }} \
+        {{- else }}
+        --kubeconfig=/etc/kubernetes/kubeconfig/worker.yaml \
         {{- end }}
         {{- if .FeatureGates.Enabled }}
         --feature-gates=\"{{.FeatureGates.String}}\" \
@@ -1069,6 +1069,26 @@ write_files:
             user: tls-bootstrap
           name: tls-bootstrap-context
         current-context: tls-bootstrap-context
+  - path: /etc/kubernetes/kubeconfig/worker.yaml
+    content: |
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - name: local
+          cluster:
+            certificate-authority: /etc/kubernetes/ssl/ca.pem
+            server: {{.APIEndpointURL}}:443
+        users:
+        - name: kubelet
+          user:
+            client-certificate: {{ if .Kubelet.RotateCerts.Enabled }}/etc/kubernetes/ssl/kubelet-client-current.pem{{else}}/etc/kubernetes/ssl/kubelet-client-current.pem{{end}}
+            client-key: /etc/kubernetes/ssl/kubelet.key
+        contexts:
+        - context:
+            cluster: local
+            user: kubelet
+          name: kubelet-context
+        current-context: kubelet-context
 {{ else }}
   - path: /etc/kubernetes/kubeconfig/worker.yaml
     content: |


### PR DESCRIPTION
Always write a kubeconfig file - even when using the TLS bootstrapping feature
Failure to specify a kubeconfig file will result in a failed startup and cryptic "file not found" error message on the kubelet.