### PR TITLE
Fixes typo initizlie -> initialize

### DIFF
--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -235,7 +235,7 @@ func (cl *Cluster) ensureNestedStacksLoaded() error {
 
 	net, err := model.NewNetworkStack(cfg, nodePools, netOpts, extras, assetsConfig)
 	if err != nil {
-		return fmt.Errorf("failed to initizlie network stack: %v", err)
+		return fmt.Errorf("failed to initialize network stack: %v", err)
 	}
 
 	cl.etcdStack = etcd


### PR DESCRIPTION
Hello, I saw this typo when I encountered a problem when running `kube-aws validate`. 😇 

<img width="688" alt="screen shot 2019-01-03 at 5 40 46 pm" src="https://user-images.githubusercontent.com/2811885/50631363-f3144a80-0f7e-11e9-8f53-3efcf4eb6258.png">