### PR TITLE
Master: Add DnsMasq (node local resolver) command-line arguments/options

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1319,6 +1319,10 @@ kubeDns:
   # When enabled, will enable a DNS-masq DaemonSet to make PODs to resolve DNS names via locally running dnsmasq
   # It is disabled by default.
   # nodeLocalResolver: false
+  # Extra DnsMasq options to use when running the nodeLocalResolver
+  # nodeLocalResolverOptions:
+  # - --neg-ttl=10
+  # - --no-ping
 
   # When enabled, will deploy kube-dns to K8s controllers instead of workers.
   # deployToControllers: false

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3625,6 +3625,7 @@ write_files:
                 - -k
                 - --min-port=1024
                 - --cache-size=1000
+                - --server=//{{.DNSServiceIP}}
                 - --server=/cluster.local/{{.DNSServiceIP}}
                 - --server=/in-addr.arpa/{{.DNSServiceIP}}
                 - --server=/ip6.arpa/{{.DNSServiceIP}}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3630,6 +3630,11 @@ write_files:
                 - --server=/in-addr.arpa/{{.DNSServiceIP}}
                 - --server=/ip6.arpa/{{.DNSServiceIP}}
                 - --log-facility=-
+                {{- if ne (len .KubeDns.NodeLocalResolverOptions) 0 }}
+                  {{- range .KubeDns.NodeLocalResolverOptions }}
+                - {{.}}
+                  {{- end }}
+                {{- end }}
                 ports:
                 - containerPort: 53
                   name: dns

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -246,10 +246,11 @@ type KubeDnsAutoscaler struct {
 }
 
 type KubeDns struct {
-	Provider            string            `yaml:"provider"`
-	NodeLocalResolver   bool              `yaml:"nodeLocalResolver"`
-	DeployToControllers bool              `yaml:"deployToControllers"`
-	Autoscaler          KubeDnsAutoscaler `yaml:"autoscaler"`
+	Provider                 string            `yaml:"provider"`
+	NodeLocalResolver        bool              `yaml:"nodeLocalResolver"`
+	NodeLocalResolverOptions []string          `yaml:"nodeLocalResolverOptions"`
+	DeployToControllers      bool              `yaml:"deployToControllers"`
+	Autoscaler               KubeDnsAutoscaler `yaml:"autoscaler"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {


### PR DESCRIPTION
After some issues with DNS in our AWS environments we noticed that we were caching negative DNS responses for longer than we would have expected.  This PR is quite general in that it allows us to add our own options for the node local dnsmasq daemonset (which allows us to fine tune our settings, such as the negative ttl setting).

```
kubeDns:
  nodeLocalResolver: true
  nodeLocalResolverOptions:
  - --neg-ttl=10
```