### PR TITLE
v0.11.x: Add DnsMasq (node local resolver) command-line arguments/options

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -865,10 +865,11 @@ type KubeDnsAutoscaler struct {
 }
 
 type KubeDns struct {
-	Provider            string            `yaml:"provider"`
-	NodeLocalResolver   bool              `yaml:"nodeLocalResolver"`
-	DeployToControllers bool              `yaml:"deployToControllers"`
-	Autoscaler          KubeDnsAutoscaler `yaml:"autoscaler"`
+	Provider                 string            `yaml:"provider"`
+	NodeLocalResolver        bool              `yaml:"nodeLocalResolver"`
+	NodeLocalResolverOptions []string          `yaml:"nodeLocalResolverOptions"`
+	DeployToControllers      bool              `yaml:"deployToControllers"`
+	Autoscaler               KubeDnsAutoscaler `yaml:"autoscaler"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3991,6 +3991,11 @@ write_files:
                 - --server=/in-addr.arpa/{{.DNSServiceIP}}
                 - --server=/ip6.arpa/{{.DNSServiceIP}}
                 - --log-facility=-
+                {{- if ne (len .KubeDns.NodeLocalResolverOptions) 0 }}
+                  {{- range .KubeDns.NodeLocalResolverOptions }}
+                - {{.}}
+                  {{- end }}
+                {{- end }}
                 ports:
                 - containerPort: 53
                   name: dns

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1363,6 +1363,10 @@ kubeDns:
   # When enabled, will enable a DNS-masq DaemonSet to make PODs to resolve DNS names via locally running dnsmasq
   # It is disabled by default.
   # nodeLocalResolver: false
+  # Extra DnsMasq options to use when running the nodeLocalResolver
+  # nodeLocalResolverOptions:
+  # - --neg-ttl=10
+  # - --no-ping
 
   # When enabled, will deploy kube-dns to K8s controllers instead of workers.
   # deployToControllers: false


### PR DESCRIPTION
After some issues with DNS in our AWS environments we noticed that we were caching negative DNS responses for longer than we would have expected. This PR is quite general in that it allows us to add our own options for the node local dnsmasq daemonset (which allows us to fine tune our settings, such as the negative ttl setting).

```
kubeDns:
  nodeLocalResolver: true
  nodeLocalResolverOptions:
  - --neg-ttl=10
```