### PR TITLE
Master: Bump default Kubernetes Dashboard version and add AllowSkipLogin option

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1152,7 +1152,7 @@ worker:
 # Kube Dashboard image repository to use.
 #kubernetesDashboardImage:
 #  repo: k8s.gcr.io/kubernetes-dashboard-amd64
-#  tag: v1.8.3
+#  tag: v1.10.1
 #  rktPullDocker: false
 
 # Pause image repository to use.This works only if you are deploying your cluster in "cn-north-1" region.
@@ -1279,6 +1279,7 @@ kubeSystemNamespaceLabels:
 kubernetesDashboard:
   adminPrivileges: true
   insecureLogin: false
+  allowSkip: false
   enabled: true
 # # Optional resource change for Dashboard can be done via using the resources block below and changing the values.
 # # Values below are the default already if not set.

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1279,7 +1279,7 @@ kubeSystemNamespaceLabels:
 kubernetesDashboard:
   adminPrivileges: true
   insecureLogin: false
-  allowSkip: false
+  allowSkipLogin: false
   enabled: true
 # # Optional resource change for Dashboard can be done via using the resources block below and changing the values.
 # # Values below are the default already if not set.

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4327,7 +4327,7 @@ write_files:
                   {{ else }}
                   - --auto-generate-certificates
                   {{ end }}
-                  {{ if .KubernetesDashboard.AllowSkip }}
+                  {{ if .KubernetesDashboard.AllowSkipLogin }}
                   - --enable-skip-login
                   {{ end }}
                 resources:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4327,6 +4327,9 @@ write_files:
                   {{ else }}
                   - --auto-generate-certificates
                   {{ end }}
+                  {{ if .KubernetesDashboard.AllowSkip }}
+                  - --enable-skip-login
+                  {{ end }}
                 resources:
                   requests:
                     cpu: {{ if .KubernetesDashboard.ComputeResources.Requests.Cpu }}{{ .KubernetesDashboard.ComputeResources.Requests.Cpu }}{{ else }}100m{{ end }}

--- a/docs/advanced-topics/kubernetes-dashboard.md
+++ b/docs/advanced-topics/kubernetes-dashboard.md
@@ -6,6 +6,7 @@
 kubernetesDashboard:
   adminPrivileges: true
   insecureLogin: false
+  allowSkipLogin: false # Only set to true when using dashboard image version v1.10.1+
   enabled: true
   resources:
     requests:
@@ -59,6 +60,7 @@ You can override these by changing the values as necessary.
 kubernetesDashboard:
   adminPrivileges: false
   insecureLogin: false
+  allowSkipLogin: false # Only set to true when using dashboard image version v1.10.1+
 ```
 
 Ex.
@@ -90,6 +92,7 @@ spec:
 kubernetesDashboard:
   adminPrivileges: false
   insecureLogin: true
+  allowSkipLogin: false # Only set to true when using dashboard image version v1.10.1+
 ```
 
 Ex.
@@ -126,6 +129,7 @@ spec:
     kubernetesDashboard:
       adminPrivileges: false
       insecureLogin: true
+      allowSkipLogin: false # Only set to true when using dashboard image version v1.10.1+
 ```
 Ex.
 

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -189,7 +189,7 @@ func NewDefaultCluster() *Cluster {
 			KubernetesDashboard: KubernetesDashboard{
 				AdminPrivileges: true,
 				InsecureLogin:   false,
-				AllowSkip:       false,
+				AllowSkipLogin:  false,
 				Enabled:         true,
 			},
 			Kubernetes: Kubernetes{
@@ -541,7 +541,7 @@ type Cluster struct {
 type KubernetesDashboard struct {
 	AdminPrivileges  bool             `yaml:"adminPrivileges"`
 	InsecureLogin    bool             `yaml:"insecureLogin"`
-	AllowSkip        bool             `yaml:"allowSkip"`
+	AllowSkipLogin   bool             `yaml:"allowSkipLogin"`
 	Enabled          bool             `yaml:"enabled"`
 	ComputeResources ComputeResources `yaml:"resources,omitempty"`
 }

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -189,6 +189,7 @@ func NewDefaultCluster() *Cluster {
 			KubernetesDashboard: KubernetesDashboard{
 				AdminPrivileges: true,
 				InsecureLogin:   false,
+				AllowSkip:       false,
 				Enabled:         true,
 			},
 			Kubernetes: Kubernetes{
@@ -233,7 +234,7 @@ func NewDefaultCluster() *Cluster {
 			HeapsterImage:                      Image{Repo: "k8s.gcr.io/heapster", Tag: "v1.5.0", RktPullDocker: false},
 			MetricsServerImage:                 Image{Repo: "k8s.gcr.io/metrics-server-amd64", Tag: "v0.2.1", RktPullDocker: false},
 			AddonResizerImage:                  Image{Repo: "k8s.gcr.io/addon-resizer", Tag: "1.8.1", RktPullDocker: false},
-			KubernetesDashboardImage:           Image{Repo: "k8s.gcr.io/kubernetes-dashboard-amd64", Tag: "v1.8.3", RktPullDocker: false},
+			KubernetesDashboardImage:           Image{Repo: "k8s.gcr.io/kubernetes-dashboard-amd64", Tag: "v1.10.1", RktPullDocker: false},
 			PauseImage:                         Image{Repo: "k8s.gcr.io/pause-amd64", Tag: "3.1", RktPullDocker: false},
 			JournaldCloudWatchLogsImage:        Image{Repo: "jollinshead/journald-cloudwatch-logs", Tag: "0.1", RktPullDocker: true},
 		},
@@ -540,6 +541,7 @@ type Cluster struct {
 type KubernetesDashboard struct {
 	AdminPrivileges  bool             `yaml:"adminPrivileges"`
 	InsecureLogin    bool             `yaml:"insecureLogin"`
+	AllowSkip        bool             `yaml:"allowSkip"`
 	Enabled          bool             `yaml:"enabled"`
 	ComputeResources ComputeResources `yaml:"resources,omitempty"`
 }


### PR DESCRIPTION
We ran into some issues with the dashboard being slow at version v1.8.3 and these seem to have gone away in v1.10.1

However in v1.10.1 the skip login option is now disabled by default and requires the use of `--enable-skip-login` flag to bring it back. This has been added in as an option `AllowSkip` in the `KubernetesDashboard` struct and takes a default value of `false`