### PR TITLE
v0.12.x: Bump default Kubernetes Dashboard version and add AllowSkipLogin option

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -214,6 +214,7 @@ func NewDefaultCluster() *Cluster {
 			KubernetesDashboard: KubernetesDashboard{
 				AdminPrivileges: true,
 				InsecureLogin:   false,
+				AllowSkipLogin: false,
 				Enabled:         true,
 			},
 			Kubernetes: Kubernetes{
@@ -252,7 +253,7 @@ func NewDefaultCluster() *Cluster {
 			HeapsterImage:                      model.Image{Repo: "k8s.gcr.io/heapster", Tag: "v1.5.0", RktPullDocker: false},
 			MetricsServerImage:                 model.Image{Repo: "k8s.gcr.io/metrics-server-amd64", Tag: "v0.2.1", RktPullDocker: false},
 			AddonResizerImage:                  model.Image{Repo: "k8s.gcr.io/addon-resizer", Tag: "1.8.1", RktPullDocker: false},
-			KubernetesDashboardImage:           model.Image{Repo: "k8s.gcr.io/kubernetes-dashboard-amd64", Tag: "v1.8.3", RktPullDocker: false},
+			KubernetesDashboardImage:           model.Image{Repo: "k8s.gcr.io/kubernetes-dashboard-amd64", Tag: "v1.10.1", RktPullDocker: false},
 			PauseImage:                         model.Image{Repo: "k8s.gcr.io/pause-amd64", Tag: "3.1", RktPullDocker: false},
 			JournaldCloudWatchLogsImage:        model.Image{Repo: "jollinshead/journald-cloudwatch-logs", Tag: "0.1", RktPullDocker: true},
 		},
@@ -871,6 +872,7 @@ func (c *KubeDns) MergeIfEmpty(other KubeDns) {
 type KubernetesDashboard struct {
 	AdminPrivileges  bool             `yaml:"adminPrivileges"`
 	InsecureLogin    bool             `yaml:"insecureLogin"`
+	AllowSkipLogin bool `yaml:"allowSkipLogin"`
 	Enabled          bool             `yaml:"enabled"`
 	ComputeResources ComputeResources `yaml:"resources,omitempty"`
 }

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -214,7 +214,7 @@ func NewDefaultCluster() *Cluster {
 			KubernetesDashboard: KubernetesDashboard{
 				AdminPrivileges: true,
 				InsecureLogin:   false,
-				AllowSkipLogin: false,
+				AllowSkipLogin:  false,
 				Enabled:         true,
 			},
 			Kubernetes: Kubernetes{
@@ -872,7 +872,7 @@ func (c *KubeDns) MergeIfEmpty(other KubeDns) {
 type KubernetesDashboard struct {
 	AdminPrivileges  bool             `yaml:"adminPrivileges"`
 	InsecureLogin    bool             `yaml:"insecureLogin"`
-	AllowSkipLogin bool `yaml:"allowSkipLogin"`
+	AllowSkipLogin   bool             `yaml:"allowSkipLogin"`
 	Enabled          bool             `yaml:"enabled"`
 	ComputeResources ComputeResources `yaml:"resources,omitempty"`
 }

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4244,6 +4244,9 @@ write_files:
                   {{ else }}
                   - --auto-generate-certificates
                   {{ end }}
+                  {{ if .KubernetesDashboard.allowSkipLogin }}
+                  - --enable-skip-login
+                  {{ end }}
                 resources:
                   requests:
                     cpu: {{ if .KubernetesDashboard.ComputeResources.Requests.Cpu }}{{ .KubernetesDashboard.ComputeResources.Requests.Cpu }}{{ else }}100m{{ end }}

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4244,7 +4244,7 @@ write_files:
                   {{ else }}
                   - --auto-generate-certificates
                   {{ end }}
-                  {{ if .KubernetesDashboard.allowSkipLogin }}
+                  {{ if .KubernetesDashboard.AllowSkipLogin }}
                   - --enable-skip-login
                   {{ end }}
                 resources:

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1144,7 +1144,7 @@ worker:
 # Kube Dashboard image repository to use.
 #kubernetesDashboardImage:
 #  repo: k8s.gcr.io/kubernetes-dashboard-amd64
-#  tag: v1.8.3
+#  tag: v1.10.1
 #  rktPullDocker: false
 
 # Pause image repository to use.This works only if you are deploying your cluster in "cn-north-1" region.
@@ -1271,6 +1271,7 @@ kubeSystemNamespaceLabels:
 kubernetesDashboard:
   adminPrivileges: true
   insecureLogin: false
+  allowSkipLogin: false # Only set to true when using dashboard image version v1.10.1+
   enabled: true
 # # Optional resource change for Dashboard can be done via using the resources block below and changing the values.
 # # Values below are the default already if not set.

--- a/docs/advanced-topics/kubernetes-dashboard.md
+++ b/docs/advanced-topics/kubernetes-dashboard.md
@@ -6,6 +6,7 @@
 kubernetesDashboard:
   adminPrivileges: true
   insecureLogin: false
+  allowSkipLogin: false # Only set to true when using dashboard image version v1.10.1+
   enabled: true
   resources:
     requests:
@@ -59,6 +60,7 @@ You can override these by changing the values as necessary.
 kubernetesDashboard:
   adminPrivileges: false
   insecureLogin: false
+  allowSkipLogin: false # Only set to true when using dashboard image version v1.10.1+
 ```
 
 Ex.
@@ -90,6 +92,7 @@ spec:
 kubernetesDashboard:
   adminPrivileges: false
   insecureLogin: true
+  allowSkipLogin: false # Only set to true when using dashboard image version v1.10.1+
 ```
 
 Ex.
@@ -126,6 +129,7 @@ spec:
     kubernetesDashboard:
       adminPrivileges: false
       insecureLogin: true
+      allowSkipLogin: false # Only set to true when using dashboard image version v1.10.1+
 ```
 Ex.
 


### PR DESCRIPTION
We ran into some issues with the dashboard being slow at version v1.8.3 and these seem to have gone away in v1.10.1

However in v1.10.1 the skip login option is now disabled by default and requires the use of --enable-skip-login flag to bring it back. This has been added in as an option AllowSkipLogin in the KubernetesDashboard struct and takes a default value of false