### PR TITLE
Fixing adding cf resources to etcd and networking stack v.0.12.x

### DIFF
--- a/core/etcd/config/templates/stack-template.json
+++ b/core/etcd/config/templates/stack-template.json
@@ -578,6 +578,11 @@
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     }
     {{end}}
+    {{range $n, $r := .ExtraCfnResources}}
+    ,
+    {{quote $n}}: {{toJSON $r}}
+    {{end}}
+    
   },
   "Outputs": {
     {{range $index, $etcdInstance := $.EtcdNodes}}

--- a/core/network/cluster/cluster.go
+++ b/core/network/cluster/cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/kubernetes-incubator/kube-aws/model"
 	"github.com/kubernetes-incubator/kube-aws/naming"
+	"github.com/kubernetes-incubator/kube-aws/plugin/clusterextension"
 	"github.com/kubernetes-incubator/kube-aws/plugin/pluginmodel"
 )
 
@@ -128,6 +129,14 @@ func NewCluster(cfgRef *config.Cluster, opts config.StackTemplateOptions, plugin
 		ClusterRef:  clusterRef,
 		StackConfig: stackConfig,
 	}
+
+	extras := clusterextension.NewExtrasFromPlugins(plugins, c.PluginConfigs)
+
+	extraStack, err := extras.NetworkStack()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load network stack extras from plugins: %v", err)
+	}
+	c.StackConfig.ExtraCfnResources = extraStack.Resources
 
 	c.assets, err = c.buildAssets()
 

--- a/plugin/pluginmodel/config.go
+++ b/plugin/pluginmodel/config.go
@@ -90,6 +90,7 @@ type CloudFormation struct {
 
 type Stacks struct {
 	Root         Stack `yaml:"root,omitempty"`
+	Network      Stack `yaml:"network,omitempty"`
 	ControlPlane Stack `yaml:"controlPlane,omitempty"`
 	Etcd         Stack `yaml:"etcd,omitempty"`
 	NodePool     Stack `yaml:"nodePool,omitempty"`

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -281,6 +281,7 @@ spec:
 					cp := c.ControlPlane()
 					np := c.NodePools()[0]
 					etcd := c.Etcd()
+					network := c.Network()
 
 					{
 						e := model.CustomFile{
@@ -419,6 +420,35 @@ spec:
 					}
 					if !strings.Contains(controlPlaneStackTemplate, `"Action":["ec2:Describe*"]`) {
 						t.Errorf("Invalid control-plane stack template: missing iam policy statement ec2:Describe*: %v", controlPlaneStackTemplate)
+					}
+
+					// A kube-aws plugin can inject custom cfn stack resources into the etcd stack
+					etcdStackTemplate, err := etcd.RenderStackTemplateAsString()
+
+					if err != nil {
+						t.Errorf("failed to render control-plane stack template: %v", err)
+					}
+					if !strings.Contains(etcdStackTemplate, "QueueFromMyPlugin") {
+						t.Errorf("Invalid etcd stack template: missing resource QueueFromMyPlugin: %v", etcdStackTemplate)
+					}
+					if !strings.Contains(etcdStackTemplate, `"QueueName":"baz1"`) {
+						t.Errorf("Invalid etcd stack template: missing QueueName baz1: %v", etcdStackTemplate)
+					}
+					if !strings.Contains(etcdStackTemplate, `"Action":["ec2:Describe*"]`) {
+						t.Errorf("Invalid etcd stack template: missing iam policy statement ec2:Describe*: %v", etcdStackTemplate)
+					}
+
+					// A kube-aws plugin can inject custom cfn stack resources into the network stack
+					networkStackTemplate, err := network.RenderStackTemplateAsString()
+
+					if err != nil {
+						t.Errorf("failed to render control-plane stack template: %v", err)
+					}
+					if !strings.Contains(networkStackTemplate, "QueueFromMyPlugin") {
+						t.Errorf("Invalid networks stack template: missing resource QueueFromMyPlugin: %v", networkStackTemplate)
+					}
+					if !strings.Contains(networkStackTemplate, `"QueueName":"baz1"`) {
+						t.Errorf("Invalid network stack template: missing QueueName baz1: %v", networkStackTemplate)
 					}
 
 					rootStackTemplate, err := c.RenderStackTemplateAsString()


### PR DESCRIPTION
Based on the existing test, it seems that the intent was that etcd and networking stacks both could benefit from the cloud formation resources included in the plugins. Unfortunately, there was a bug in the template (in the case of etcd) and missing logic in the case of the networking stack that prevented it from happening.

This PR aims to fix both issues:
- Enable plugin cf resources for networking stack
- Fixing etcd template to add plugin cf resources