### PR TITLE
Fixing adding cf resources to etcd and networking stack - master

### DIFF
--- a/builtin/files/stack-templates/etcd.json.tmpl
+++ b/builtin/files/stack-templates/etcd.json.tmpl
@@ -578,6 +578,11 @@
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     }
     {{end}}
+    {{range $n, $r := .ExtraCfnResources}}
+    ,
+    {{quote $n}}: {{toJSON $r}}
+    {{end}}
+    
   },
   "Outputs": {
     {{range $index, $etcdInstance := $.EtcdNodes}}

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -92,10 +92,10 @@ type CloudFormationSpec struct {
 
 type Stacks struct {
 	Root         Stack `yaml:"root,omitempty"`
+	Network      Stack `yaml:"network,omitempty"`
 	ControlPlane Stack `yaml:"controlPlane,omitempty"`
 	Etcd         Stack `yaml:"etcd,omitempty"`
 	NodePool     Stack `yaml:"nodePool,omitempty"`
-	Network      Stack `yaml:"network,omitempty"`
 }
 
 // Stack represents a set of customizations to a CloudFormation stack template

--- a/pkg/model/stack_new.go
+++ b/pkg/model/stack_new.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+
 	"github.com/kubernetes-incubator/kube-aws/credential"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/kubernetes-incubator/kube-aws/pkg/api"
@@ -124,6 +125,11 @@ func NewNetworkStack(conf *Config, nodePools []*Stack, opts api.StackTemplateOpt
 			}, nil
 		},
 		func(stack *Stack) error {
+			extraStack, err := extras.NetworkStack(stack)
+			if err != nil {
+				return fmt.Errorf("failed to load network stack extras from plugins: %v", err)
+			}
+			stack.ExtraCfnResources = extraStack.Resources
 			return nil
 		},
 	)

--- a/plugin/clusterextension/extras.go
+++ b/plugin/clusterextension/extras.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubernetes-incubator/kube-aws/plugin/pluginutil"
 	"github.com/kubernetes-incubator/kube-aws/provisioner"
 	"github.com/kubernetes-incubator/kube-aws/tmpl"
+
 	//"os"
 	"path/filepath"
 
@@ -56,6 +57,12 @@ func (e ClusterExtension) KeyPairSpecs() []api.KeyPairSpec {
 func (e ClusterExtension) RootStack(config interface{}) (*stack, error) {
 	return e.stackExt("root", config, func(p *api.Plugin) api.Stack {
 		return p.Spec.Cluster.CloudFormation.Stacks.Root
+	})
+}
+
+func (e ClusterExtension) NetworkStack(config interface{}) (*stack, error) {
+	return e.stackExt("network", config, func(p *api.Plugin) api.Stack {
+		return p.Spec.Cluster.CloudFormation.Stacks.Network
 	})
 }
 

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -269,6 +269,7 @@ spec:
 					cp := c.ControlPlane()
 					np := c.NodePools()[0]
 					etcd := c.Etcd()
+					network := c.Network()
 
 					{
 						e := api.CustomFile{
@@ -407,6 +408,35 @@ spec:
 					}
 					if !strings.Contains(controlPlaneStackTemplate, `"Action":["ec2:Describe*"]`) {
 						t.Errorf("Invalid control-plane stack template: missing iam policy statement ec2:Describe*: %v", controlPlaneStackTemplate)
+					}
+
+					// A kube-aws plugin can inject custom cfn stack resources into the etcd stack
+					etcdStackTemplate, err := etcd.RenderStackTemplateAsString()
+
+					if err != nil {
+						t.Errorf("failed to render control-plane stack template: %v", err)
+					}
+					if !strings.Contains(etcdStackTemplate, "QueueFromMyPlugin") {
+						t.Errorf("Invalid etcd stack template: missing resource QueueFromMyPlugin: %v", etcdStackTemplate)
+					}
+					if !strings.Contains(etcdStackTemplate, `"QueueName":"baz1"`) {
+						t.Errorf("Invalid etcd stack template: missing QueueName baz1: %v", etcdStackTemplate)
+					}
+					if !strings.Contains(etcdStackTemplate, `"Action":["ec2:Describe*"]`) {
+						t.Errorf("Invalid etcd stack template: missing iam policy statement ec2:Describe*: %v", etcdStackTemplate)
+					}
+
+					// A kube-aws plugin can inject custom cfn stack resources into the network stack
+					networkStackTemplate, err := network.RenderStackTemplateAsString()
+
+					if err != nil {
+						t.Errorf("failed to render control-plane stack template: %v", err)
+					}
+					if !strings.Contains(networkStackTemplate, "QueueFromMyPlugin") {
+						t.Errorf("Invalid networks stack template: missing resource QueueFromMyPlugin: %v", networkStackTemplate)
+					}
+					if !strings.Contains(networkStackTemplate, `"QueueName":"baz1"`) {
+						t.Errorf("Invalid network stack template: missing QueueName baz1: %v", networkStackTemplate)
 					}
 
 					rootStackTemplate, err := c.RenderStackTemplateAsString()


### PR DESCRIPTION
Based on the existing test, it seems that the intent was that etcd and networking stacks both could benefit from the cloud formation resources included in the plugins. Unfortunately, there was a bug in the template (in the case of etcd) and missing logic in the case of the networking stack that prevented it from happening.

- Enable plugin cf resources for networking stack
- Fixing etcd template to add plugin cf resources