### PR TITLE
Make cluster-autoscaler resource request/limit configurable

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4574,11 +4574,11 @@ write_files:
                   name: cluster-autoscaler
                   resources:
                     limits:
-                      cpu: 100m
-                      memory: 300Mi
+                      cpu: {{ .ClusterAutoscaler.ComputeResources.Limits.Cpu }}
+                      memory: {{ .ClusterAutoscaler.ComputeResources.Limits.Memory }}
                     requests:
-                      cpu: 100m
-                      memory: 300Mi
+                      cpu: {{ .ClusterAutoscaler.ComputeResources.Requests.Cpu }}
+                      memory: {{ .ClusterAutoscaler.ComputeResources.Requests.Memory }}
                   command:
                     - ./cluster-autoscaler
                     - --v=4

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1040,7 +1040,7 @@ write_files:
         echo kube-proxy stared. apiserver should be responsive again.
       fi
       rbac=/srv/kubernetes/rbac
-      
+
       {{- if .Kubernetes.Networking.SelfHosting.Enabled }}
       # When using NetworkingDeamonSets ensure that all nodes
       # have a podCIDR attribute
@@ -1062,7 +1062,7 @@ write_files:
       applyall "${mfdir}/calico.yaml"
       {{- end }}
       {{- end }}
-      
+
       {{ if .Addons.MetricsServer.Enabled -}}
       applyall \
         "${mfdir}/metrics-server-sa.yaml" \
@@ -1073,12 +1073,12 @@ write_files:
         "${rbac}/role-bindings/metrics-server.yaml" \
         "${mfdir}/metrics-server-apisvc.yaml"
       {{- end }}
-      
+
       {{ if .KubernetesDashboard.Enabled }}
       # Secrets
       applyall "${mfdir}/kubernetes-dashboard-se.yaml"
       {{ end }}
-      
+
       # Configmaps
       applyall \
         "${mfdir}"/{kube-proxy,heapster-config}"-cm.yaml" \
@@ -1090,7 +1090,7 @@ write_files:
         "${mfdir}/{{ .KubeDns.Provider }}-sa.yaml" \
         "${mfdir}/kube-proxy-sa.yaml" \
         {{ if .KubernetesDashboard.Enabled }}"${mfdir}/kubernetes-dashboard-sa.yaml"{{ end }}
-      
+
       {{ if eq .KubeDns.Provider "coredns" -}}
       applyall \
         "${mfdir}/coredns-cr.yaml" \
@@ -1154,7 +1154,7 @@ write_files:
       if ls ${mfdir}/custom/*.yaml &> /dev/null; then
         applyall ${mfdir}/custom/*.yaml
       fi
-      
+
       {{ if $.MigrateStacks -}}
       restore_webhooks() {
         local type=$1
@@ -3644,7 +3644,7 @@ write_files:
             requests:
               cpu: {{ if .Kubernetes.ControllerManager.ComputeResources.Requests.Cpu }}{{ .Kubernetes.ControllerManager.ComputeResources.Requests.Cpu }}{{ else }}100m{{ end }}
               memory: {{ if .Kubernetes.ControllerManager.ComputeResources.Requests.Memory }}{{ .Kubernetes.ControllerManager.ComputeResources.Requests.Memory }}{{ else }}100M{{ end }}
-              
+
             limits:
               cpu: {{ if .Kubernetes.ControllerManager.ComputeResources.Limits.Cpu }}{{ .Kubernetes.ControllerManager.ComputeResources.Limits.Cpu }}{{ else }}250m{{ end }}
               memory: {{ if .Kubernetes.ControllerManager.ComputeResources.Limits.Memory }}{{ .Kubernetes.ControllerManager.ComputeResources.Limits.Memory }}{{ else }}512M{{ end }}
@@ -4574,11 +4574,11 @@ write_files:
                   name: cluster-autoscaler
                   resources:
                     limits:
-                      cpu: {{ .ClusterAutoscaler.ComputeResources.Limits.Cpu }}
-                      memory: {{ .ClusterAutoscaler.ComputeResources.Limits.Memory }}
+                      cpu: {{ if .Addons.ClusterAutoscaler.ComputeResources.Limits.Cpu }}{{ .Addons.ClusterAutoscaler.ComputeResources.Limits.Cpu }}{{ else }}100m{{ end }}
+                      memory: {{ if .Addons.ClusterAutoscaler.ComputeResources.Limits.Memory }}{{ .Addons.ClusterAutoscaler.ComputeResources.Limits.Memory }}{{ else }}300Mi{{ end }}
                     requests:
-                      cpu: {{ .ClusterAutoscaler.ComputeResources.Requests.Cpu }}
-                      memory: {{ .ClusterAutoscaler.ComputeResources.Requests.Memory }}
+                      cpu: {{ if .Addons.ClusterAutoscaler.ComputeResources.Requests.Cpu }}{{ .Addons.ClusterAutoscaler.ComputeResources.Requests.Cpu }}{{ else }}100m{{ end }}
+                      memory: {{ if .Addons.ClusterAutoscaler.ComputeResources.Requests.Memory }}{{ .Addons.ClusterAutoscaler.ComputeResources.Requests.Memory }}{{ else }}300Mi{{ end }}
                   command:
                     - ./cluster-autoscaler
                     - --v=4

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1404,6 +1404,14 @@ addons:
   # If you want to run CA on worker nodes, turn on `worker.nodePools[].clusterAutoscalerSupport.enabled` for the node pool.
   clusterAutoscaler:
     enabled: false
+    resources:
+      # Increase these values substantially if running a cluster of 50+ nodes
+      limits:
+        cpu: 100m
+        memory: 300Mi
+      requests:
+        cpu: 100m
+        memory: 300Mi
     # Options below can be used to inject custom settings for the autoscaler.
     # Sensible defaults are already configured in the controller-cloud-config but if you wish to override them simply
     # add them here and they'll take precedence.

--- a/model/addons.go
+++ b/model/addons.go
@@ -10,9 +10,10 @@ type Addons struct {
 }
 
 type ClusterAutoscalerSupport struct {
-	Enabled     bool              `yaml:"enabled"`
-	Options     map[string]string `yaml:"options"`
-	UnknownKeys `yaml:",inline"`
+	Enabled          bool              `yaml:"enabled"`
+	ComputeResources ComputeResources  `yaml:"resources,omitempty"`
+	Options          map[string]string `yaml:"options"`
+	UnknownKeys      `yaml:",inline"`
 }
 
 type Rescheduler struct {

--- a/model/addons.go
+++ b/model/addons.go
@@ -34,3 +34,13 @@ type Prometheus struct {
 type APIServerAggregator struct {
 	Enabled bool `yaml:"enabled"`
 }
+
+type ComputeResources struct {
+	Limits   ResourceQuota `yaml:"limits,omitempty"`
+	Requests ResourceQuota `yaml:"requests,omitempty"`
+}
+
+type ResourceQuota struct {
+	Cpu    string `yaml:"cpu"`
+	Memory string `yaml:"memory"`
+}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -485,16 +485,6 @@ worker:
 						},
 						ClusterAutoscaler: model.ClusterAutoscalerSupport{
 							Enabled: true,
-							ComputeResources: api.ComputeResources{
-								Requests: api.ResourceQuota{
-									Cpu: "100m",
-									Memory: "300Mi",
-								},
-								Limits: api.ResourceQuota{
-									Cpu: "100m",
-									Memory: "300Mi",
-								},
-							},
 							Options: map[string]string{"v": "5", "test": "present"},
 						},
 						MetricsServer: model.MetricsServer{
@@ -1652,7 +1642,7 @@ experimental:
     image:
       repo: quay.io/uswitch/kiam
       tag: v2.6
-    sessionDuration: 30m	
+    sessionDuration: 30m
     serverAddresses:
       serverAddress: localhost
       agentAddress: kiam-server

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -485,6 +485,16 @@ worker:
 						},
 						ClusterAutoscaler: model.ClusterAutoscalerSupport{
 							Enabled: true,
+							ComputeResources: api.ComputeResources{
+								Requests: api.ResourceQuota{
+									Cpu: "100m",
+									Memory: "300Mi",
+								},
+								Limits: api.ResourceQuota{
+									Cpu: "100m",
+									Memory: "300Mi",
+								},
+							},
 							Options: map[string]string{"v": "5", "test": "present"},
 						},
 						MetricsServer: model.MetricsServer{


### PR DESCRIPTION
## What
We've exposed the cluster-autoscaler deployment resources and made them configurable via cluster.yaml using the same approach taken regarding the kube-dashboard

## Why
We've started to experience OOM issues & CPU throttling in our bigger environments.