### PR TITLE
Revert etcd upgrade

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -734,6 +734,8 @@ worker:
 #      arn: "arn:aws:iam::YOURACCOUNTID:instance-profile/INSTANCEPROFILENAME"
 #
 #  # The version of etcd to be used. Set to e.g. "3.2.1" to use etcd3
+#  # CAUTION: Increasing etcd version will permanently change the state of etcd and a cloud formation rollback, will not succeed due to etcd 
+#  being unable to downgrade. 
 #  version: 3.2.13
 #
 #  snapshot:

--- a/builtin/files/etcdadm/README.md
+++ b/builtin/files/etcdadm/README.md
@@ -14,7 +14,7 @@ AWS_SECRET_ACCESS_KEY=... \
 ETCDADM_AWSCLI_DOCKER_IMAGE=quay.io/coreos/awscli \
 # Required settings
 AWS_DEFAULT_REGION=ap-northeast-1 \
-ETCD_VERSION=3.3.10 \
+ETCD_VERSION=3.2.13 \
 ETCD_DATA_DIR=/var/lib/etcd \
 ETCD_INITIAL_CLUSTER=etcd0=http://127.0.0.1:3080,etcd1=http://127.0.0.1:3180,etcd2=http://127.0.0.1:3280 \
 ETCDCTL_ENDPOINTS=http://127.0.0.1:3079,etcd1=http://127.0.0.1:3179,etcd2=http://127.0.0.1:3279, \

--- a/builtin/files/etcdadm/etcdadm
+++ b/builtin/files/etcdadm/etcdadm
@@ -85,7 +85,7 @@ config_etcd_endpoints() {
   echo "${ETCD_ENDPOINTS}"
 }
 
-etcd_version=${ETCD_VERSION:-3.3.10}
+etcd_version=${ETCD_VERSION:-3.2.13}
 etcd_aci_url="https://github.com/coreos/etcd/releases/download/v$etcd_version/etcd-v$etcd_version-linux-amd64.aci"
 
 member_count="${ETCDADM_MEMBER_COUNT:?missing required env}"

--- a/builtin/files/stack-templates/etcd.json.tmpl
+++ b/builtin/files/stack-templates/etcd.json.tmpl
@@ -578,6 +578,11 @@
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     }
     {{end}}
+    {{range $n, $r := .ExtraCfnResources}}
+    ,
+    {{quote $n}}: {{toJSON $r}}
+    {{end}}
+    
   },
   "Outputs": {
     {{range $index, $etcdInstance := $.EtcdNodes}}

--- a/pkg/api/etcd.go
+++ b/pkg/api/etcd.go
@@ -205,7 +205,7 @@ func (e Etcd) Version() EtcdVersion {
 	if e.Cluster.Version != "" {
 		return e.Cluster.Version
 	}
-	return "3.3.10"
+	return "3.2.13"
 }
 
 func (v EtcdVersion) Is3() bool {

--- a/pkg/api/etcd_test.go
+++ b/pkg/api/etcd_test.go
@@ -36,8 +36,8 @@ func TestEtcd(t *testing.T) {
 		t.Errorf("name tag key incorrect, expected: kube-aws:etcd:name, got: %s", etcdTest.NameTagKey())
 	}
 
-	if etcdTest.Version() != "3.3.10" {
-		t.Errorf("etcd version incorrect, epxected: 3.3.10, got: %s", etcdTest.Version())
+	if etcdTest.Version() != "3.2.13" {
+		t.Errorf("etcd version incorrect, epxected: 3.2.13, got: %s", etcdTest.Version())
 	}
 
 	if !etcdTest.NodeShouldHaveEIP() {

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -92,10 +92,10 @@ type CloudFormationSpec struct {
 
 type Stacks struct {
 	Root         Stack `yaml:"root,omitempty"`
+	Network      Stack `yaml:"network,omitempty"`
 	ControlPlane Stack `yaml:"controlPlane,omitempty"`
 	Etcd         Stack `yaml:"etcd,omitempty"`
 	NodePool     Stack `yaml:"nodePool,omitempty"`
-	Network      Stack `yaml:"network,omitempty"`
 }
 
 // Stack represents a set of customizations to a CloudFormation stack template

--- a/pkg/model/stack_new.go
+++ b/pkg/model/stack_new.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+
 	"github.com/kubernetes-incubator/kube-aws/credential"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/kubernetes-incubator/kube-aws/pkg/api"
@@ -124,6 +125,11 @@ func NewNetworkStack(conf *Config, nodePools []*Stack, opts api.StackTemplateOpt
 			}, nil
 		},
 		func(stack *Stack) error {
+			extraStack, err := extras.NetworkStack(stack)
+			if err != nil {
+				return fmt.Errorf("failed to load network stack extras from plugins: %v", err)
+			}
+			stack.ExtraCfnResources = extraStack.Resources
 			return nil
 		},
 	)

--- a/plugin/clusterextension/extras.go
+++ b/plugin/clusterextension/extras.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubernetes-incubator/kube-aws/plugin/pluginutil"
 	"github.com/kubernetes-incubator/kube-aws/provisioner"
 	"github.com/kubernetes-incubator/kube-aws/tmpl"
+
 	//"os"
 	"path/filepath"
 
@@ -56,6 +57,12 @@ func (e ClusterExtension) KeyPairSpecs() []api.KeyPairSpec {
 func (e ClusterExtension) RootStack(config interface{}) (*stack, error) {
 	return e.stackExt("root", config, func(p *api.Plugin) api.Stack {
 		return p.Spec.Cluster.CloudFormation.Stacks.Root
+	})
+}
+
+func (e ClusterExtension) NetworkStack(config interface{}) (*stack, error) {
+	return e.stackExt("network", config, func(p *api.Plugin) api.Stack {
+		return p.Spec.Cluster.CloudFormation.Stacks.Network
 	})
 }
 

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -269,6 +269,7 @@ spec:
 					cp := c.ControlPlane()
 					np := c.NodePools()[0]
 					etcd := c.Etcd()
+					network := c.Network()
 
 					{
 						e := api.CustomFile{
@@ -407,6 +408,35 @@ spec:
 					}
 					if !strings.Contains(controlPlaneStackTemplate, `"Action":["ec2:Describe*"]`) {
 						t.Errorf("Invalid control-plane stack template: missing iam policy statement ec2:Describe*: %v", controlPlaneStackTemplate)
+					}
+
+					// A kube-aws plugin can inject custom cfn stack resources into the etcd stack
+					etcdStackTemplate, err := etcd.RenderStackTemplateAsString()
+
+					if err != nil {
+						t.Errorf("failed to render control-plane stack template: %v", err)
+					}
+					if !strings.Contains(etcdStackTemplate, "QueueFromMyPlugin") {
+						t.Errorf("Invalid etcd stack template: missing resource QueueFromMyPlugin: %v", etcdStackTemplate)
+					}
+					if !strings.Contains(etcdStackTemplate, `"QueueName":"baz1"`) {
+						t.Errorf("Invalid etcd stack template: missing QueueName baz1: %v", etcdStackTemplate)
+					}
+					if !strings.Contains(etcdStackTemplate, `"Action":["ec2:Describe*"]`) {
+						t.Errorf("Invalid etcd stack template: missing iam policy statement ec2:Describe*: %v", etcdStackTemplate)
+					}
+
+					// A kube-aws plugin can inject custom cfn stack resources into the network stack
+					networkStackTemplate, err := network.RenderStackTemplateAsString()
+
+					if err != nil {
+						t.Errorf("failed to render control-plane stack template: %v", err)
+					}
+					if !strings.Contains(networkStackTemplate, "QueueFromMyPlugin") {
+						t.Errorf("Invalid networks stack template: missing resource QueueFromMyPlugin: %v", networkStackTemplate)
+					}
+					if !strings.Contains(networkStackTemplate, `"QueueName":"baz1"`) {
+						t.Errorf("Invalid network stack template: missing QueueName baz1: %v", networkStackTemplate)
 					}
 
 					rootStackTemplate, err := c.RenderStackTemplateAsString()


### PR DESCRIPTION
Etcd was upgraded from version 3.2.13 to version 3.3.10 on this PR https://github.com/kubernetes-incubator/kube-aws/commit/e8b7380d95c30239f252eb7ebad7586dd03b0716.

After testing an upgrade from a cluster created with kube-aws 0.12.X to kube-aws master, we have found that, if there is a problem during the upgrade, cloud formation is not able to rollback cleanly, and etcd cluster is left on an unavailable state due to being unable to downgrade etcd.

This is PR Is to revert the etcd upgrade version back to 3.2.13 until a two ways migration is implemented.

![kube_aws_etcd_rollback_failed](https://user-images.githubusercontent.com/551844/52641288-5d9a9d80-2ed0-11e9-8580-cfad65d29116.png)
