### PR TITLE
Make cluster-autoscaler resource request/limit configurable

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4143,11 +4143,11 @@ write_files:
                   name: cluster-autoscaler
                   resources:
                     limits:
-                      cpu: 100m
-                      memory: 300Mi
+                      cpu: {{ .ClusterAutoscaler.ComputeResources.Limits.Cpu }}
+                      memory: {{ .ClusterAutoscaler.ComputeResources.Limits.Memory }}
                     requests:
-                      cpu: 100m
-                      memory: 300Mi
+                      cpu: {{ .ClusterAutoscaler.ComputeResources.Requests.Cpu }}
+                      memory: {{ .ClusterAutoscaler.ComputeResources.Requests.Memory }}
                   command:
                     - ./cluster-autoscaler
                     - --v=4

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4148,10 +4148,6 @@ write_files:
                     requests:
                       cpu: {{ if .Addons.ClusterAutoscaler.ComputeResources.Requests.Cpu }}{{ .Addons.ClusterAutoscaler.ComputeResources.Requests.Cpu }}{{ else }}100m{{ end }}
                       memory: {{ if .Addons.ClusterAutoscaler.ComputeResources.Requests.Memory }}{{ .Addons.ClusterAutoscaler.ComputeResources.Requests.Memory }}{{ else }}300Mi{{ end }}
-                command:
-                  - ./cluster-autoscaler
-                  - --v=4
-
                   command:
                     - ./cluster-autoscaler
                     - --v=4

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -4143,11 +4143,15 @@ write_files:
                   name: cluster-autoscaler
                   resources:
                     limits:
-                      cpu: {{ .ClusterAutoscaler.ComputeResources.Limits.Cpu }}
-                      memory: {{ .ClusterAutoscaler.ComputeResources.Limits.Memory }}
+                      cpu: {{ if .Addons.ClusterAutoscaler.ComputeResources.Limits.Cpu }}{{ .Addons.ClusterAutoscaler.ComputeResources.Limits.Cpu }}{{ else }}100m{{ end }}
+                      memory: {{ if .Addons.ClusterAutoscaler.ComputeResources.Limits.Memory }}{{ .Addons.ClusterAutoscaler.ComputeResources.Limits.Memory }}{{ else }}300Mi{{ end }}
                     requests:
-                      cpu: {{ .ClusterAutoscaler.ComputeResources.Requests.Cpu }}
-                      memory: {{ .ClusterAutoscaler.ComputeResources.Requests.Memory }}
+                      cpu: {{ if .Addons.ClusterAutoscaler.ComputeResources.Requests.Cpu }}{{ .Addons.ClusterAutoscaler.ComputeResources.Requests.Cpu }}{{ else }}100m{{ end }}
+                      memory: {{ if .Addons.ClusterAutoscaler.ComputeResources.Requests.Memory }}{{ .Addons.ClusterAutoscaler.ComputeResources.Requests.Memory }}{{ else }}300Mi{{ end }}
+                command:
+                  - ./cluster-autoscaler
+                  - --v=4
+
                   command:
                     - ./cluster-autoscaler
                     - --v=4

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1352,6 +1352,14 @@ addons:
   # If you want to run CA on worker nodes, turn on `worker.nodePools[].clusterAutoscalerSupport.enabled` for the node pool.
   clusterAutoscaler:
     enabled: false
+    resources:
+      # Increase these values substantially if running a cluster of 50+ nodes
+      limits:
+        cpu: 100m
+        memory: 300Mi
+      requests:
+        cpu: 100m
+        memory: 300Mi
     # Options below can be used to inject custom settings for the autoscaler.
     # Sensible defaults are already configured in the controller-cloud-config but if you wish to override them simply
     # add them here and they'll take precedence.

--- a/model/addons.go
+++ b/model/addons.go
@@ -10,9 +10,10 @@ type Addons struct {
 }
 
 type ClusterAutoscalerSupport struct {
-	Enabled     bool              `yaml:"enabled"`
-	Options     map[string]string `yaml:"options"`
-	UnknownKeys `yaml:",inline"`
+	Enabled          bool              `yaml:"enabled"`
+	ComputeResources ComputeResources  `yaml:"resources,omitempty"`
+	Options          map[string]string `yaml:"options"`
+	UnknownKeys      `yaml:",inline"`
 }
 
 type Rescheduler struct {

--- a/model/addons.go
+++ b/model/addons.go
@@ -34,3 +34,13 @@ type Prometheus struct {
 type APIServerAggregator struct {
 	Enabled bool `yaml:"enabled"`
 }
+
+type ComputeResources struct {
+	Limits   ResourceQuota `yaml:"limits,omitempty"`
+	Requests ResourceQuota `yaml:"requests,omitempty"`
+}
+
+type ResourceQuota struct {
+	Cpu    string `yaml:"cpu"`
+	Memory string `yaml:"memory"`
+}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -485,16 +485,6 @@ worker:
 						},
 						ClusterAutoscaler: model.ClusterAutoscalerSupport{
 							Enabled: true,
-							ComputeResources: api.ComputeResources{
-								Requests: api.ResourceQuota{
-									Cpu: "100m",
-									Memory: "300Mi",
-								},
-								Limits: api.ResourceQuota{
-									Cpu: "100m",
-									Memory: "300Mi",
-								},
-							},
 							Options: map[string]string{"v": "5", "test": "present"},
 						},
 						MetricsServer: model.MetricsServer{
@@ -1652,7 +1642,7 @@ experimental:
     image:
       repo: quay.io/uswitch/kiam
       tag: v2.6
-    sessionDuration: 30m	
+    sessionDuration: 30m
     serverAddresses:
       serverAddress: localhost
       agentAddress: kiam-server

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -485,6 +485,16 @@ worker:
 						},
 						ClusterAutoscaler: model.ClusterAutoscalerSupport{
 							Enabled: true,
+							ComputeResources: api.ComputeResources{
+								Requests: api.ResourceQuota{
+									Cpu: "100m",
+									Memory: "300Mi",
+								},
+								Limits: api.ResourceQuota{
+									Cpu: "100m",
+									Memory: "300Mi",
+								},
+							},
 							Options: map[string]string{"v": "5", "test": "present"},
 						},
 						MetricsServer: model.MetricsServer{


### PR DESCRIPTION
## What
We've exposed the cluster-autoscaler deployment resources and made them configurable via cluster.yaml using the same approach taken regarding the kube-dashboard

## Why
We've started to experience OOM issues & CPU throttling in our bigger environments.