### PR TITLE
Capture failures in decrypting assets

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -2214,6 +2214,7 @@ write_files:
           -ec \
           'echo decrypting assets
            shopt -s nullglob
+           set -o pipefail
            for encKey in /etc/kubernetes/{ssl,additional-configs,{{ if or (.AssetsConfig.HasAuthTokens) ( and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken) }}auth{{end}}}/{,kiam/}*.enc; do
              if [ ! -f $encKey ]; then
                echo skipping non-existent file: $encKey 1>&2

--- a/core/etcd/config/templates/cloud-config-etcd
+++ b/core/etcd/config/templates/cloud-config-etcd
@@ -467,6 +467,7 @@ coreos:
             -ec \
             'echo decrypting tls assets; \
              shopt -s nullglob; \
+             set -o pipefail; \
              for encKey in /etc/ssl/certs/*.pem.enc; do \
              echo decrypting $encKey; \
              /usr/bin/aws \

--- a/core/nodepool/config/templates/cloud-config-worker
+++ b/core/nodepool/config/templates/cloud-config-worker
@@ -864,6 +864,7 @@ write_files:
           -ec \
           'echo decrypting assets
            shopt -s nullglob
+           set -o pipefail
            for encKey in /etc/kubernetes/{ssl,{{ if and .Experimental.TLSBootstrap.Enabled .AssetsConfig.HasTLSBootstrapToken }}auth{{end}}}/*.enc; do
              echo decrypting $encKey
              f=$(mktemp $encKey.XXXXXXXX)


### PR DESCRIPTION
"set -e" will capture when a line of code fails.  However, for a
pipeline such as "false | true", it will only handle the exit code
of the last command. In this case, the exit code will always be 0.

"set -o pipefail" will ensure that any failure in the pipeline results
in the whole line failing, which will then be handled correctly by
"set -e"

For example:
$ set +o pipefail ; false | true ; echo $?
0

$ set -o pipefail ; false | true ; echo $?
1