### PR TITLE
BUGFIX: kubeletOptions not applied on controller nodes.

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -310,6 +310,7 @@ coreos:
         # EnvironmentFile=/etc/environment allows the reading of COREOS_PRIVATE_IPV4
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/etcd-environment
+        EnvironmentFile=-/etc/default/kubelet
         Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
         Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
         Environment="RKT_RUN_ARGS={{.HyperkubeImage.Options}}\


### PR DESCRIPTION
kubeletOptions can be set at the cluster level, then they are injected on a file /etc/default/kubelet that is referenced on the kubelet systemd unit. Although the file gets created in the controller nodes, it is never referenced on the systemd unit. Hence kubeletOptions does not really work on Controllers.