### PR TITLE
Remove LaunchTemplateName from the LaunchTemplate

### DIFF
--- a/builtin/files/stack-templates/node-pool.json.tmpl
+++ b/builtin/files/stack-templates/node-pool.json.tmpl
@@ -265,7 +265,6 @@
     {{end}}
     "{{.LaunchTemplateLogicalName}}": {
       "Properties": {
-        "LaunchTemplateName": "{{.NodePoolName}}",
         "LaunchTemplateData": {
           "BlockDeviceMappings": [
             {


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/kube-aws/issues/1581 introduced by https://github.com/kubernetes-incubator/kube-aws/pull/1531

Removed LaunchTemplateName from the LaunchTemplate. LaunchTemplateName must be unique pr AWS account pr region.