### PR TITLE
Enable detailed monitoring

### DIFF
--- a/builtin/files/stack-templates/node-pool.json.tmpl
+++ b/builtin/files/stack-templates/node-pool.json.tmpl
@@ -265,7 +265,6 @@
     {{end}}
     "{{.LaunchTemplateLogicalName}}": {
       "Properties": {
-        "LaunchTemplateName": "{{.NodePoolName}}",
         "LaunchTemplateData": {
           "BlockDeviceMappings": [
             {

--- a/builtin/files/stack-templates/node-pool.json.tmpl
+++ b/builtin/files/stack-templates/node-pool.json.tmpl
@@ -308,6 +308,7 @@
           },
           "ImageId": "{{.AMI}}",
           "InstanceType": "{{.InstanceType}}",
+          "Monitoring": {"Enabled": "true"},
           {{if .KeyName}}"KeyName": "{{.KeyName}}",{{end}}
           "SecurityGroupIds": [
             {{range $sgIndex, $sgRef := $.SecurityGroupRefs}}


### PR DESCRIPTION
Launch Templates introduced in https://github.com/kubernetes-incubator/kube-aws/pull/1531 did not enable monitoring. This PR adds detailed monitoring, so that worker nodes will behave the same way they did prior to kube-aws 0.13