### PR TITLE
Custom APIServer SANs

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -51,6 +51,14 @@ disableContainerLinuxAutomaticUpdates: true
 #sshAccessAllowedSourceCIDRs:
 #- 0.0.0.0/0
 
+# Custom API Server settings that allow additional SANs attached to the generated certificate.
+# customApiServerSettings:
+#  additionalDnsSans:
+#  - my.host.com
+#  additionalIPAddressSans:
+#  - 0.0.0.0
+
+
 # The name of one of API endpoints defined in `apiEndpoints` below to be written in kubeconfig and then used by admins
 # to access k8s API from their laptops, CI servers, or etc.
 # Required if there are 2 or more API endpoints defined in `apiEndpoints`

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -519,6 +519,11 @@ type EtcdSettings struct {
 	Etcd `yaml:"etcd,omitempty"`
 }
 
+type CustomApiServerSettings struct {
+	AdditionalDnsSANs     []string `yaml:"additionalDnsSans,omitempty"`
+	AdditionalIPAddresses []string `yaml:"additionalIPAddressSans,omitempty"`
+}
+
 // Cluster is the container of all the configurable parameters of a kube-aws cluster, customizable via cluster.yaml
 type Cluster struct {
 	KubeClusterSettings   `yaml:",inline"`
@@ -534,8 +539,9 @@ type Cluster struct {
 	Worker                `yaml:"worker"`
 	PluginConfigs         PluginConfigs `yaml:"kubeAwsPlugins,omitempty"`
 	// SSHAccessAllowedSourceCIDRs is network ranges of sources you'd like SSH accesses to be allowed from, in CIDR notation
-	SSHAccessAllowedSourceCIDRs CIDRRanges             `yaml:"sshAccessAllowedSourceCIDRs,omitempty"`
-	CustomSettings              map[string]interface{} `yaml:"customSettings,omitempty"`
+	SSHAccessAllowedSourceCIDRs CIDRRanges              `yaml:"sshAccessAllowedSourceCIDRs,omitempty"`
+	CustomApiServerSettings     CustomApiServerSettings `yaml:"customApiServerSettings,omitempty"`
+	CustomSettings              map[string]interface{}  `yaml:"customSettings,omitempty"`
 	KubeResourcesAutosave       `yaml:"kubeResourcesAutosave,omitempty"`
 }
 

--- a/pkg/model/credentials.go
+++ b/pkg/model/credentials.go
@@ -32,14 +32,16 @@ func (s *Context) LoadCredentials(cfg *Config, opts api.StackTemplateOptions) (*
 
 func NewCredentialGenerator(c *Config) *credential.Generator {
 	r := &credential.Generator{
-		TLSCADurationDays:         c.TLSCADurationDays,
-		TLSCertDurationDays:       c.TLSCertDurationDays,
-		TLSBootstrapEnabled:       c.Experimental.TLSBootstrap.Enabled,
-		ManageCertificates:        c.ManageCertificates,
-		Region:                    c.Region.String(),
-		APIServerExternalDNSNames: c.ExternalDNSNames(),
-		EtcdNodeDNSNames:          c.EtcdCluster().DNSNames(),
-		ServiceCIDR:               c.ServiceCIDR,
+		TLSCADurationDays:                c.TLSCADurationDays,
+		TLSCertDurationDays:              c.TLSCertDurationDays,
+		TLSBootstrapEnabled:              c.Experimental.TLSBootstrap.Enabled,
+		ManageCertificates:               c.ManageCertificates,
+		Region:                           c.Region.String(),
+		APIServerExternalDNSNames:        c.ExternalDNSNames(),
+		APIServerAdditionalDNSSans:       c.CustomApiServerSettings.AdditionalDnsSANs,
+		APIServerAdditionalIPAddressSans: c.CustomApiServerSettings.AdditionalIPAddresses,
+		EtcdNodeDNSNames:                 c.EtcdCluster().DNSNames(),
+		ServiceCIDR:                      c.ServiceCIDR,
 	}
 
 	return r

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -650,6 +650,34 @@ kubeProxy:
 			configYaml: kubeAwsSettings.withClusterName("my-cluster").minimumValidClusterYaml(),
 		},
 		{
+			context: "WithcustomApiServerSettings",
+			configYaml: minimalValidConfigYaml + `
+customApiServerSettings:
+  additionalDnsSans:
+  - my.host.com
+  additionalIPAddressSans:
+  - 0.0.0.0
+`,
+			assertConfig: []ConfigTester{
+				func(c *config.Config, t *testing.T) {
+					expectedDnsSans := []string{"my.host.com"}
+					actualDnsSans := c.CustomApiServerSettings.AdditionalDnsSANs
+					if !reflect.DeepEqual(expectedDnsSans, actualDnsSans) {
+						t.Errorf("additionalDnsSans didn't match : expected=%v actual=%v", expectedDnsSans, actualDnsSans)
+					}
+
+					expectedIPSans := []string{"0.0.0.0"}
+					actualIPSans := c.CustomApiServerSettings.AdditionalIPAddresses
+					if !reflect.DeepEqual(expectedIPSans, actualIPSans) {
+						t.Errorf("additionalIPAddressSans didn't match : expected=%v actual=%v", expectedIPSans, actualIPSans)
+					}
+				},
+			},
+			assertCluster: []ClusterTester{
+				hasDefaultCluster,
+			},
+		},
+		{
 			context: "WithCustomSettings",
 			configYaml: minimalValidConfigYaml + `
 customSettings:


### PR DESCRIPTION
## Changes

- Adds the ability to define custom SANs to the APIServer. Internally we found this incredibly useful when trying to roll changes to CIDRs inside of the cluster.