### PR TITLE
Fixing broken apiserver feature gate logic for 1.9.3

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -365,8 +365,14 @@ func (c *Cluster) ControllerFeatureGates() model.FeatureGates {
 	if !c.Experimental.Admission.Priority.Enabled {
 		gates["PodPriority"] = "false"
 	}
+	if c.Experimental.Admission.Priority.Enabled {
+		gates["PodPriority"] = "true"
+	}
 	if !c.Experimental.Admission.PersistentVolumeClaimResize.Enabled {
 		gates["ExpandPersistentVolumes"] = "false"
+	}
+	if c.Experimental.Admission.PersistentVolumeClaimResize.Enabled {
+		gates["ExpandPersistentVolumes"] = "true"
 	}
 	return gates
 }

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -303,8 +303,14 @@ func (c ProvidedConfig) FeatureGates() model.FeatureGates {
 	if !c.Experimental.Admission.Priority.Enabled {
 		gates["PodPriority"] = "false"
 	}
+	if c.Experimental.Admission.Priority.Enabled {
+		gates["PodPriority"] = "true"
+	}
 	if !c.Experimental.Admission.PersistentVolumeClaimResize.Enabled {
 		gates["ExpandPersistentVolumes"] = "false"
+	}
+	if c.Experimental.Admission.PersistentVolumeClaimResize.Enabled {
+		gates["ExpandPersistentVolumes"] = "true"
 	}
 	return gates
 }


### PR DESCRIPTION
## What
A small fix in the logic for featuregate flags, if you are running kube < 1.11 these feature gates need to be explicitly set to true. The existing logic was to always set them to false.

## Why
When the flags are set in the cluster.yaml they were not being applied in the cluster.