### PR TITLE
Issue when kube-aws manages/creates subnets

### DIFF
--- a/builtin/files/stack-templates/control-plane.json.tmpl
+++ b/builtin/files/stack-templates/control-plane.json.tmpl
@@ -26,13 +26,13 @@
         "LaunchConfigurationName": {
           "Ref": "{{.Controller.LogicalName}}LC"
         },
-        "MaxSize": "{{.MaxControllerCount}}",
+        "MaxSize": "{{.Controller.MaxControllerCount}}",
         "MetricsCollection": [
           {
             "Granularity": "1Minute"
           }
         ],
-        "MinSize": "{{.MinControllerCount}}",
+        "MinSize": "{{.Controller.MinControllerCount}}",
         "Tags": [
           {{range $k, $v := $.Controller.InstanceTags -}}
           {
@@ -65,7 +65,7 @@
         "VPCZoneIdentifier": [
           {{range $index, $subnet := .Controller.Subnets}}
           {{if gt $index 0}},{{end}}
-          {{$subnet.Ref}}
+          {{$.Subnets.RefByName $subnet.Name }}
           {{end}}
         ],
         "LoadBalancerNames" : [
@@ -84,14 +84,14 @@
       {{if .WaitSignal.Enabled}}
       "CreationPolicy" : {
         "ResourceSignal" : {
-          "Count" : "{{.MinControllerCount}}",
+          "Count" : "{{.Controller.MinControllerCount}}",
           "Timeout" : "{{.Controller.CreateTimeout}}"
         }
       },
       {{end}}
       "UpdatePolicy" : {
         "AutoScalingRollingUpdate" : {
-          "MinInstancesInService" : "{{.ControllerRollingUpdateMinInstancesInService}}",
+          "MinInstancesInService" : "{{.Controller.ControllerRollingUpdateMinInstancesInService}}",
           "MaxBatchSize" : "1",
           {{if .WaitSignal.Enabled}}
           "WaitOnResourceSignals" : "true",
@@ -272,7 +272,7 @@
                   ]
                 },
                 {{ end }}
-                {{ if .UserDataController.Parts.s3 }}
+                {{ if .UserData.Controller.Parts.s3 }}
 		            {
                   "Effect": "Allow",
                   "Action": [
@@ -556,7 +556,7 @@
         "Subnets" : [
           {{range $index, $subnet := .LoadBalancer.Subnets}}
           {{if gt $index 0}},{{end}}
-          {{$subnet.Ref}}
+          {{$.Subnets.RefByName $subnet.Name }}
           {{end}}
         ],
         {{if .LoadBalancer.Private}}
@@ -584,7 +584,7 @@
         "Subnets" : [
           {{range $index, $subnet := .LoadBalancer.Subnets}}
           {{if gt $index 0}},{{end}}
-          {{$subnet.Ref}}
+          {{$.Subnets.RefByName $subnet.Name }}
           {{end}}
         ],
         "Listeners" : [
@@ -681,7 +681,7 @@
           {{end}}
         ],
         "PlacementTenancy": "{{ .Controller.Tenancy }}",
-        "UserData": {{ $.UserDataController.Parts.instance.Template | checkSizeLessThan 16384 }}
+        "UserData": {{ $.UserData.Controller.Parts.instance.Template | checkSizeLessThan 16384 }}
       },
   {{ if .Experimental.AwsEnvironment.Enabled }}
       "Metadata" : {

--- a/builtin/files/stack-templates/etcd.json.tmpl
+++ b/builtin/files/stack-templates/etcd.json.tmpl
@@ -112,13 +112,13 @@
               "Resource": "*"
             },
             {{end -}}
-            {{- if $.UserDataEtcd.Parts.s3 }}
+            {{- if $.UserData.Etcd.Parts.s3 }}
             {
               "Effect": "Allow",
               "Action": [
                 "s3:GetObject"
               ],
-              "Resource": "arn:{{.Region.Partition}}:s3:::{{ $.UserDataEtcd.Parts.s3.Asset.S3Prefix }}*"
+              "Resource": "arn:{{.Region.Partition}}:s3:::{{ $.UserData.Etcd.Parts.s3.Asset.S3Prefix }}*"
             },
             {{- end }}
             {{/* Required for `etcdadm reconfigure` to check existence of an etcd snapshot in S3 */}}
@@ -573,7 +573,7 @@
           {{end}}
         ],
         "PlacementTenancy": "{{$.Etcd.Tenancy}}",
-        "UserData": {{ $.UserDataEtcd.Parts.instance.Template (dict "etcdIndex" $etcdIndex) | checkSizeLessThan 16384 }}
+        "UserData": {{ $.UserData.Etcd.Parts.instance.Template (dict "etcdIndex" $etcdIndex) | checkSizeLessThan 16384 }}
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     }

--- a/builtin/files/stack-templates/node-pool.json.tmpl
+++ b/builtin/files/stack-templates/node-pool.json.tmpl
@@ -100,7 +100,7 @@
               {{end}}
             ],
             "SubnetId": {{$workerSubnet.Ref}},
-            "UserData": {{ $.UserDataWorker.Parts.instance.Template }}
+            "UserData": {{ $.UserData.Worker.Parts.instance.Template }}
           }
           {{end}}
           {{end}}
@@ -332,7 +332,7 @@
           "Placement": {
             "Tenancy": "{{.Tenancy}}"
           },
-          "UserData": {{ .UserDataWorker.Parts.instance.Template }}
+          "UserData": {{ .UserData.Worker.Parts.instance.Template }}
         }
       },
       "Type": "AWS::EC2::LaunchTemplate"
@@ -384,7 +384,7 @@
                   "Effect": "Allow",
                   "Resource": "*"
                 },
-                {{- if $.UserDataWorker.Parts.s3 }}
+                {{- if $.UserData.Worker.Parts.s3 }}
                 {
                   "Effect": "Allow",
                   "Action": [

--- a/filereader/texttemplate/texttemplate.go
+++ b/filereader/texttemplate/texttemplate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/Masterminds/sprig"
 	"github.com/kubernetes-incubator/kube-aws/fingerprint"
+	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/kubernetes-incubator/kube-aws/tmpl"
 )
 
@@ -92,6 +93,7 @@ func Parse(name string, raw string, funcs template.FuncMap) (*template.Template,
 }
 
 func GetBytesBuffer(filename string, data interface{}) (*bytes.Buffer, error) {
+	logger.Debugf("Rendering filename %s with following data: \n%+v", filename, data)
 	tmpl, err := ParseFile(filename, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/api/subnet.go
+++ b/pkg/api/subnet.go
@@ -3,6 +3,8 @@ package api
 import (
 	"fmt"
 	"strings"
+
+	"github.com/kubernetes-incubator/kube-aws/logger"
 )
 
 type Subnet struct {
@@ -237,7 +239,10 @@ func (s *Subnet) ManageSubnet() bool {
 
 // Ref returns ID or ref to newly created resource
 func (s *Subnet) Ref() string {
-	return s.Identifier.Ref(s.LogicalName)
+	logger.Debugf("Ref called on subnet %s: %+v", s.Name, s)
+	out := s.Identifier.Ref(s.LogicalName)
+	logger.Debugf("Ref returned: %s", out)
+	return out
 }
 
 // RouteTableLogicalName represents the name of the route table to which this subnet is associated.

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -7,6 +7,9 @@ import (
 
 	"errors"
 
+	"net/url"
+	"time"
+
 	"github.com/kubernetes-incubator/kube-aws/cfnstack"
 	"github.com/kubernetes-incubator/kube-aws/filereader/jsontemplate"
 	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
@@ -16,8 +19,6 @@ import (
 	"github.com/kubernetes-incubator/kube-aws/pkg/api"
 	"github.com/kubernetes-incubator/kube-aws/pki"
 	"github.com/kubernetes-incubator/kube-aws/provisioner"
-	"net/url"
-	"time"
 )
 
 // VERSION set by build script
@@ -74,8 +75,7 @@ func (c *Stack) Assets() cfnstack.Assets {
 }
 
 func (c *Stack) buildAssets() (cfnstack.Assets, error) {
-	logger.Debugf("Building assets for %s", c.StackName)
-	logger.Debugf("Context is: %+v", c)
+	logger.Debugf("buildAssets: Building assets for %s", c.StackName)
 
 	var err error
 
@@ -92,7 +92,7 @@ func (c *Stack) buildAssets() (cfnstack.Assets, error) {
 		userdataS3PartAssetName := "userdata-" + strings.ToLower(id)
 
 		if err = assetsBuilder.AddUserDataPart(c.UserData[id], api.USERDATA_S3, userdataS3PartAssetName); err != nil {
-			return nil, fmt.Errorf("failed to addd %s: %v", userdataS3PartAssetName, err)
+			return nil, fmt.Errorf("failed to add %s: %v", userdataS3PartAssetName, err)
 		}
 	}
 

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -66,12 +66,6 @@ type EtcdTmplCtx struct {
 	EtcdNodes []EtcdNode
 }
 
-// UserDataEtcd is here for backward-compatibility.
-// You should use `Userdata.Etcd` instead in your templates.
-func (c EtcdTmplCtx) UserDataEtcd() *api.UserData {
-	return c.GetUserData("Etcd")
-}
-
 // ControllerTmplCtx is used for rendering controller stack and userdata
 type ControllerTmplCtx struct {
 	*Stack
@@ -80,34 +74,10 @@ type ControllerTmplCtx struct {
 	Subnets api.Subnets
 }
 
-// UserDataController is here for backward-compatibility.
-// You should use `Userdata.Controller` instead in your templates.
-func (c ControllerTmplCtx) UserDataController() *api.UserData {
-	return c.GetUserData("Controller")
-}
-
-func (c ControllerTmplCtx) MinControllerCount() int {
-	return c.Controller.MinControllerCount()
-}
-
-func (c ControllerTmplCtx) MaxControllerCount() int {
-	return c.Controller.MaxControllerCount()
-}
-
-func (c ControllerTmplCtx) ControllerRollingUpdateMinInstancesInService() int {
-	return c.Controller.ControllerRollingUpdateMinInstancesInService()
-}
-
 // WorkerTmplCtx is used for rendering worker stacks and userdata
 type WorkerTmplCtx struct {
 	*Stack
 	*NodePoolConfig
-}
-
-// UserDataWorker is here for backward-compatibility.
-// You should use `Userdata.Worker` instead in your templates.
-func (c WorkerTmplCtx) UserDataWorker() *api.UserData {
-	return c.GetUserData("Worker")
 }
 
 type NetworkTmplCtx struct {


### PR DESCRIPTION
Subnets in the controller stack not being referenced against the network stack when being managed by kube-aws.  Map subnets back to the looked up set by name.  Various additional log messages to debug level.  Remove some helper functions on tempCtx types by calling the correct path in the stack templates.