### PR TITLE
Allow setting Kiam version <3.0

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1467,14 +1467,14 @@ experimental:
   # This is intended to be used in combination with .controller.iam.role.name. See #297 for more information.
   kiamSupport:
     enabled: false
-    image:
-      repo: quay.io/uswitch/kiam
-      tag: v2.8
-      rktPullDocker: false
-    sessionDuration: 15m
-    serverAddresses:
-      serverAddress: localhost:443
-      agentAddress: kiam-server:443
+    # image:
+    #  repo: quay.io/uswitch/kiam
+    #  tag: v3.2
+    #  rktPullDocker: false
+    # sessionDuration: 30m
+    # serverAddresses:
+    #  serverAddress: localhost:443
+    #  agentAddress: kiam-server:443
     # Optional resource change for kiam servers/agents can be done via using the resources block below and changing the values.
     # Values below are the default if not set.
     # serverResources:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -5548,9 +5548,11 @@ write_files:
               - name: kiam
                 image: {{.Experimental.KIAMSupport.Image.RepoWithTag}}
                 command:
-                  - /kiam
+                  - {{if checkVersion ">= 3.0" .Experimental.KIAMSupport.Image.Tag}}/kiam{{else}}/server{{end}}
                 args:
+                  {{if checkVersion ">= 3.0" .Experimental.KIAMSupport.Image.Tag -}}
                   - server
+                  {{ end -}}
                   - --json-log
                   - --bind=0.0.0.0:443
                   - --cert=/etc/kiam/tls/server.pem
@@ -5569,13 +5571,18 @@ write_files:
                 livenessProbe:
                   exec:
                     command:
+                    {{if checkVersion ">= 3.0" .Experimental.KIAMSupport.Image.Tag -}}
                     - /kiam
                     - health
+                    - --gateway-timeout-creation=1s
+                    {{ else -}}
+                    - /health
+                    - --server-address-refresh=2s
+                    {{ end -}}
                     - --cert=/etc/kiam/tls/server.pem
                     - --key=/etc/kiam/tls/server-key.pem
                     - --ca=/etc/kiam/tls/ca.pem
                     - --server-address={{.Experimental.KIAMSupport.ServerAddresses.ServerAddress}}
-                    - --gateway-timeout-creation=1s
                     - --timeout=5s
                   initialDelaySeconds: 10
                   periodSeconds: 10
@@ -5583,13 +5590,18 @@ write_files:
                 readinessProbe:
                   exec:
                     command:
+                    {{if checkVersion ">= 3.0" .Experimental.KIAMSupport.Image.Tag -}}
                     - /kiam
                     - health
+                    - --gateway-timeout-creation=1s
+                    {{ else -}}
+                    - /health
+                    - --server-address-refresh=2s
+                    {{ end -}}
                     - --cert=/etc/kiam/tls/server.pem
                     - --key=/etc/kiam/tls/server-key.pem
                     - --ca=/etc/kiam/tls/ca.pem
                     - --server-address={{.Experimental.KIAMSupport.ServerAddresses.ServerAddress}}
-                    - --gateway-timeout-creation=1s
                     - --timeout=5s
                   initialDelaySeconds: 3
                   periodSeconds: 10
@@ -5732,9 +5744,13 @@ write_files:
                     add: ["NET_ADMIN"]
                 image: {{.Experimental.KIAMSupport.Image.RepoWithTag}}
                 command:
-                  - /kiam
+                  - {{if checkVersion ">= 3.0" .Experimental.KIAMSupport.Image.Tag}}/kiam{{else}}/agent{{end}}
                 args:
+                  {{if checkVersion ">= 3.0" .Experimental.KIAMSupport.Image.Tag -}}
                   - agent
+                  - --whitelist-route-regexp=.*
+                  - --gateway-timeout-creation=1s
+                  {{ end -}}
                   - --iptables
            {{- if .Kubernetes.Networking.AmazonVPC.Enabled }}
                   - --host-interface=!eni0
@@ -5749,10 +5765,8 @@ write_files:
                   - --key=/etc/kiam/tls/agent-key.pem
                   - --ca=/etc/kiam/tls/ca.pem
                   - --server-address={{.Experimental.KIAMSupport.ServerAddresses.AgentAddress}}
-                  - --whitelist-route-regexp=.*
                   - --prometheus-listen-addr=0.0.0.0:9620
                   - --prometheus-sync-interval=5s
-                  - --gateway-timeout-creation=1s
                 env:
                   - name: HOST_IP
                     valueFrom:

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -76,7 +76,7 @@ func NewDefaultCluster() *Cluster {
 		KIAMSupport: KIAMSupport{
 			Enabled:         false,
 			Image:           Image{Repo: "quay.io/uswitch/kiam", Tag: "v3.2", RktPullDocker: false},
-			SessionDuration: "15m",
+			SessionDuration: "30m",
 			ServerAddresses: KIAMServerAddresses{ServerAddress: "localhost:443", AgentAddress: "kiam-server:443"},
 		},
 		Kube2IamSupport: Kube2IamSupport{

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -118,7 +118,7 @@ func TestMainClusterConfig(t *testing.T) {
 			KIAMSupport: api.KIAMSupport{
 				Enabled:         false,
 				Image:           api.Image{Repo: "quay.io/uswitch/kiam", Tag: "v3.2", RktPullDocker: false},
-				SessionDuration: "15m",
+				SessionDuration: "30m",
 				ServerAddresses: api.KIAMServerAddresses{ServerAddress: "localhost:443", AgentAddress: "kiam-server:443"},
 			},
 			Kube2IamSupport: api.Kube2IamSupport{
@@ -1383,7 +1383,7 @@ worker:
 						KIAMSupport: api.KIAMSupport{
 							Enabled:         false,
 							Image:           api.Image{Repo: "quay.io/uswitch/kiam", Tag: "v3.2", RktPullDocker: false},
-							SessionDuration: "15m",
+							SessionDuration: "30m",
 							ServerAddresses: api.KIAMServerAddresses{ServerAddress: "localhost:443", AgentAddress: "kiam-server:443"},
 						},
 						Kube2IamSupport: api.Kube2IamSupport{
@@ -1556,8 +1556,8 @@ experimental:
       tag: v2.6
     sessionDuration: 30m	
     serverAddresses:
-      serverAddress: localhost
-      agentAddress: kiam-server
+      serverAddress: localhost:443
+      agentAddress: kiam-server:443
 worker:
   nodePools:
   - name: pool1
@@ -1568,7 +1568,7 @@ worker:
 						Enabled:         true,
 						Image:           api.Image{Repo: "quay.io/uswitch/kiam", Tag: "v2.6", RktPullDocker: false},
 						SessionDuration: "30m",
-						ServerAddresses: api.KIAMServerAddresses{ServerAddress: "localhost", AgentAddress: "kiam-server"},
+						ServerAddresses: api.KIAMServerAddresses{ServerAddress: "localhost:443", AgentAddress: "kiam-server:443"},
 					}
 
 					actual := c.Experimental
@@ -1599,7 +1599,7 @@ worker:
 						KIAMSupport: api.KIAMSupport{
 							Enabled:         true,
 							Image:           api.Image{Repo: "quay.io/uswitch/kiam", Tag: "v3.2", RktPullDocker: false},
-							SessionDuration: "15m",
+							SessionDuration: "30m",
 							ServerAddresses: api.KIAMServerAddresses{ServerAddress: "localhost:443", AgentAddress: "kiam-server:443"},
 						},
 					}


### PR DESCRIPTION
The Kiam server and agent command line flags changed in v3.0.
Although we install Kiam v3.2 by default - allow users to deploy older versions with the different command line options.

Tested deploying v2.7 and then upgrading to v3.2