### PR TITLE
Reserve resources for calico typha

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1196,6 +1196,13 @@ kubernetes:
     selfHosting:
       type: canal      # either "canal" or "flannel"
       typha: false     # enable for type 'canal' for 50+ node clusters
+#      typhaResources:  # control k8s resources assigned to Typha pods 
+#        requests:
+#          cpu: "100m"
+#          memory: "100Mi"
+#        limits:
+#          cpu: "250m"
+#          memory: "200Mi"
 #      calicoNodeImage:
 #        repo: quay.io/calico/node
 #        tag: v3.1.3

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1451,11 +1451,11 @@ write_files:
                 #  value: "9093"
               resources:
                 requests:
-                  cpu: "100m"
-                  memory: "100Mi"
+                  cpu: {{ if .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Cpu }}{{ .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Cpu }}{{ else }}"100m"{{ end }}
+                  memory: {{ if .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Memory }}{{ .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Memory }}{{ else }}"100Mi"{{ end }}
                 limits:
-                  cpu: "250m"
-                  memory: "200Mi"
+                  cpu: {{ if .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Cpu }}{{ .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Cpu }}{{ else }}"250m"{{ end }}
+                  memory: {{ if .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Memory }}{{ .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Memory }}{{ else }}"200Mi"{{ end }}
               livenessProbe:
                 httpGet:
                   path: /liveness

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1449,6 +1449,13 @@ write_files:
                 #  value: "true"
                 #- name: TYPHA_PROMETHEUSMETRICSPORT
                 #  value: "9093"
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "100Mi"
+                limits:
+                  cpu: "250m"
+                  memory: "200Mi"
               livenessProbe:
                 httpGet:
                   path: /liveness

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1451,11 +1451,11 @@ write_files:
                 #  value: "9093"
               resources:
                 requests:
-                  cpu: {{ if .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Cpu }}{{ .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Cpu }}{{ else }}"100m"{{ end }}
-                  memory: {{ if .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Memory }}{{ .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Memory }}{{ else }}"100Mi"{{ end }}
+                  cpu: {{ .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Cpu }}
+                  memory: {{ .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Memory }}
                 limits:
-                  cpu: {{ if .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Cpu }}{{ .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Cpu }}{{ else }}"250m"{{ end }}
-                  memory: {{ if .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Memory }}{{ .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Memory }}{{ else }}"200Mi"{{ end }}
+                  cpu: {{ .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Cpu }}
+                  memory: {{ .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Memory }}
               livenessProbe:
                 httpGet:
                   path: /liveness

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -204,8 +204,18 @@ func NewDefaultCluster() *Cluster {
 						Enabled: false,
 					},
 					SelfHosting: SelfHosting{
-						Type:            "canal",
-						Typha:           false,
+						Type:  "canal",
+						Typha: false,
+						TyphaResources: ComputeResources{
+							Requests: ResourceQuota{
+								Cpu:    "100m",
+								Memory: "100Mi",
+							},
+							Limits: ResourceQuota{
+								Cpu:    "250",
+								Memory: "200Mi",
+							},
+						},
 						CalicoNodeImage: Image{Repo: "quay.io/calico/node", Tag: kubeNetworkingSelfHostingDefaultCalicoNodeImageTag, RktPullDocker: false},
 						CalicoCniImage:  Image{Repo: "quay.io/calico/cni", Tag: kubeNetworkingSelfHostingDefaultCalicoCniImageTag, RktPullDocker: false},
 						FlannelImage:    Image{Repo: "quay.io/coreos/flannel", Tag: kubeNetworkingSelfHostingDefaultFlannelImageTag, RktPullDocker: false},

--- a/pkg/api/networking.go
+++ b/pkg/api/networking.go
@@ -6,11 +6,12 @@ type Networking struct {
 }
 
 type SelfHosting struct {
-	Type            string `yaml:"type"`
-	Typha           bool   `yaml:"typha"`
-	CalicoNodeImage Image  `yaml:"calicoNodeImage"`
-	CalicoCniImage  Image  `yaml:"calicoCniImage"`
-	FlannelImage    Image  `yaml:"flannelImage"`
-	FlannelCniImage Image  `yaml:"flannelCniImage"`
-	TyphaImage      Image  `yaml:"typhaImage"`
+	Type            string           `yaml:"type"`
+	Typha           bool             `yaml:"typha"`
+	TyphaResources  ComputeResources `yaml:"typhaResources,omitempty"`
+	CalicoNodeImage Image            `yaml:"calicoNodeImage"`
+	CalicoCniImage  Image            `yaml:"calicoCniImage"`
+	FlannelImage    Image            `yaml:"flannelImage"`
+	FlannelCniImage Image            `yaml:"flannelCniImage"`
+	TyphaImage      Image            `yaml:"typhaImage"`
 }


### PR DESCRIPTION
Calico-typha does not have any reserved resource so it works in a best effort mode. Since it is a 'system service' it should have some resources reserved. What do you think?