### PR TITLE
[v0.13.x] - Expose CoreDNS to Prometheus

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4246,7 +4246,7 @@ write_files:
           annotations:
             prometheus.io/port: "9153"
             prometheus.io/scrape: "true"
-          {{- else }}         
+          {{- end }}         
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4242,6 +4242,11 @@ write_files:
         metadata:
           name: kube-dns
           namespace: kube-system
+          {{- if eq .KubeDns.Provider "coredns" }}
+          annotations:
+            prometheus.io/port: "9153"
+            prometheus.io/scrape: "true"
+          {{- else }}         
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
## Changes

- Updates the CoreDNS service deployment to allow scraping by Prometheus.
- This matches the Kubernetes upstream CoreDNS addon deployment, shown [here](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/coredns/coredns.yaml.in)