### PR TITLE
Expose CoreDNS to Prometheus

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3970,6 +3970,9 @@ write_files:
         metadata:
           name: coredns
           namespace: kube-system
+          annotations:
+            prometheus.io/port: "9153"
+            prometheus.io/scrape: "true"          
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4242,7 +4242,7 @@ write_files:
           annotations:
             prometheus.io/port: "9153"
             prometheus.io/scrape: "true"
-          {{- else }}            
+          {{- end }}            
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3969,10 +3969,7 @@ write_files:
         kind: Deployment
         metadata:
           name: coredns
-          namespace: kube-system
-          annotations:
-            prometheus.io/port: "9153"
-            prometheus.io/scrape: "true"          
+          namespace: kube-system         
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"
@@ -4241,6 +4238,11 @@ write_files:
         metadata:
           name: kube-dns
           namespace: kube-system
+          {{- if eq .KubeDns.Provider "coredns" }}
+          annotations:
+            prometheus.io/port: "9153"
+            prometheus.io/scrape: "true"
+          {{- else }}            
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
## Changes

- Updates the CoreDNS service deployment to allow scraping by Prometheus.
- This matches the Kubernetes upstream CoreDNS addon deployment, shown [here](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/coredns/coredns.yaml.in)