### PR TITLE
[v0.14.x] Fix trailing slash in Taint templating.

### DIFF
--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -353,7 +353,7 @@ coreos:
         --node-labels=node.kubernetes.io/role="node",node.kubernetes.io/role="{{ toLabel .NodePoolName }}",kubernetes.io/role=node,node-role.kubernetes.io/node=\"\",node-role.kubernetes.io/{{ toLabel .NodePoolName }}=\"\"{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-node=true \
         --config=/etc/kubernetes/config/kubelet.yaml \
-        {{if .Taints -}}
+        {{- if .Taints }}
         --register-with-taints={{.Taints.String}} \
         {{- end }}
         --cloud-provider=aws \


### PR DESCRIPTION
## Changes

- Moving the `-` to the left curl braces ensures we get the formatting we want from the formatting by removing a linebreak.

Resolves #1647