### PR TITLE
[v0.14.x] Fix formatting with cluster-autoscaler

### DIFF
--- a/builtin/files/plugins/cluster-autoscaler/manifests/deployment.yaml
+++ b/builtin/files/plugins/cluster-autoscaler/manifests/deployment.yaml
@@ -30,9 +30,9 @@ spec:
             - --skip-nodes-with-system-pods=false
             - --expander=least-waste
             {{- if index .Values "options" }}
-              {{- range $flag, $value := .Values.options }}
-              - --{{ $flag }}={{ $value }}
-              {{- end }}
+            {{- range $flag, $value := .Values.options }}
+            - --{{ $flag }}={{ $value }}
+            {{- end }}
             {{- end }}
           env:
             - name: AWS_REGION


### PR DESCRIPTION
## Changes

- Fixes the formatting used by the Go Templates when creating the option set for cluster-autoscaler, with the current setup the formatting will index the text too far as shown below.

```
- --expander=least-waste
              - --a=b
              - --c=d
```

Bumping them a little to the right fixes the formatting.

Resolves #1653