### PR TITLE
WIP: [Small] Enhance NLB support for api-endpoint

### DIFF
--- a/cfnstack/provisioner.go
+++ b/cfnstack/provisioner.go
@@ -188,7 +188,7 @@ func (c *Provisioner) updateStackWithTemplateURL(cfSvc UpdateService, templateUR
 func (c *Provisioner) UpdateStackAtURLAndWait(cfSvc CRUDService, templateURL string) (string, error) {
 	updateOutput, err := c.updateStackWithTemplateURL(cfSvc, templateURL)
 	if err != nil {
-		return "", fmt.Errorf("error updating cloudformation stack: %v", err)
+		return "", fmt.Errorf("error updating cloudformation stack: %s, %v", templateURL, err)
 	}
 	return c.waitUntilStackGetsUpdated(cfSvc, updateOutput)
 }

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -141,6 +141,8 @@ apiEndpoints:
   loadBalancer:
     type: network
     recordSetManaged: false
+    apiAccessAllowedSourceCIDRs:
+      - 10.0.0.0/8
 `, `
 apiEndpoints:
 - name: public
@@ -149,15 +151,25 @@ apiEndpoints:
     type: network
     recordSetManaged: false
     securityGroupIds: []
+    apiAccessAllowedSourceCIDRs:
+      - 10.0.0.0/8
 `, `
 apiEndpoints:
-- name: public
+- name: existing-nlb
   dnsName: test.staging.core-os.net
   loadBalancer:
     type: network
-    recordSetManaged: false
-    securityGroupIds: []
-    apiAccessAllowedSourceCIDRs: []
+    id: apiserver-nlb/0000
+`, `
+apiEndpoints:
+- name: to-be-created-nlb
+  dnsName: test.staging.core-os.net
+  loadBalancer:
+    type: network
+    hostedZone:
+      id: hostedzone-xxxxxx
+    apiAccessAllowedSourceCIDRs:
+      - 10.0.0.0/8
 `,
 }
 
@@ -231,6 +243,13 @@ apiEndpoints:
     type: classic
     recordSetManaged: false
     securityGroupIds: []
+    apiAccessAllowedSourceCIDRs: []
+`, `
+# No apiAccessAllowedSourceCIDRs set for managed NLB
+apiEndpoints:
+- name: public
+  loadBalancer:
+    type: network
     apiAccessAllowedSourceCIDRs: []
 `,
 }
@@ -325,22 +344,10 @@ apiEndpoints:
   loadBalancer:
     type: network
     recordSetManaged: false
-    apiAccessAllowedSourceCIDRs: []
-`,
-			cidrs: []string{},
-		},
-		{
-			conf: `
-apiEndpoints:
-- name: endpoint-1
-  dnsName: test-1.staging.core-os.net
-  loadBalancer:
-    type: network
-    recordSetManaged: false
     apiAccessAllowedSourceCIDRs:
-      - 0.0.0.0/0
+      - 10.0.0.0/8
 `,
-			cidrs: []string{"0.0.0.0/0"},
+			cidrs: []string{"10.0.0.0/8"},
 		},
 		{
 			conf: `

--- a/core/controlplane/config/templates/stack-template.json
+++ b/core/controlplane/config/templates/stack-template.json
@@ -499,50 +499,7 @@
       }
     },
     {{ end -}}
-    {{ if .LoadBalancer.NetworkLoadBalancer }}
-    "{{.LoadBalancer.LogicalName}}TargetGroup": {
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "Properties": {
-        "HealthCheckIntervalSeconds": "10",
-        "HealthyThresholdCount": "3",
-        "UnhealthyThresholdCount": "3",
-        "Port": "443",
-        "VpcId": {{$.VPCRef}},
-        "Protocol": "TCP"
-      }
-    },
-    "{{.LoadBalancer.LogicalName}}Listener": {
-      "Type": "AWS::ElasticLoadBalancingV2::Listener",
-      "Properties": {
-        "DefaultActions": [
-          {
-            "TargetGroupArn": {"Ref": "{{.LoadBalancer.LogicalName}}TargetGroup"},
-            "Type": "forward"
-          }
-        ],
-        "LoadBalancerArn": {"Ref": "{{.LoadBalancer.LogicalName}}"},
-        "Port": "443",
-        "Protocol": "TCP"
-      }
-    },
-    "{{.LoadBalancer.LogicalName}}" : {
-      "Type" : "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "Properties" : {
-        "Type": "network",
-        "Subnets" : [
-          {{range $index, $subnet := .LoadBalancer.Subnets}}
-          {{if gt $index 0}},{{end}}
-          {{$subnet.Ref}}
-          {{end}}
-        ],
-        {{if .LoadBalancer.Private}}
-        "Scheme": "internal"
-        {{else}}
-        "Scheme": "internet-facing"
-        {{end}}
-      }
-    },
-    {{ else }}
+    {{ if not .LoadBalancer.NetworkLoadBalancer -}}
     "{{.LoadBalancer.LogicalName}}" : {
       "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties" : {
@@ -584,8 +541,8 @@
         ]
       }
     },
-    {{ end }}
-    {{if .LoadBalancer.ManageSecurityGroup -}}
+    {{ end -}}
+    {{ if .LoadBalancer.ManageSecurityGroup -}}
     "{{.LoadBalancer.SecurityGroupLogicalName}}" : {
       "Properties": {
         "GroupDescription": {
@@ -612,9 +569,65 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
-    {{end -}}
-    {{end -}}
-    {{end -}}
+    {{ end -}}
+    {{ end -}}
+    {{ if .LoadBalancer.NetworkLoadBalancer -}}
+    "{{.LoadBalancer.TargetGroupLogicalName}}": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "HealthCheckIntervalSeconds": "10",
+        "HealthyThresholdCount": "3",
+        "UnhealthyThresholdCount": "3",
+        "Port": "443",
+        "VpcId": {{$.VPCRef}},
+        "Protocol": "TCP"
+      }
+    },
+    "{{.LoadBalancer.LogicalName}}Listener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {"Ref": "{{.LoadBalancer.TargetGroupLogicalName}}"},
+            "Type": "forward"
+          }
+        ],
+        {{ if .LoadBalancer.ManageELB }}
+        "LoadBalancerArn": {"Ref": "{{.LoadBalancer.LogicalName}}"},
+        {{ else }}
+        "LoadBalancerArn": {{.LoadBalancer.Ref}},
+        {{ end }}
+        "Port": "443",
+        "Protocol": "TCP"
+      }
+    },
+    {{ if .LoadBalancer.ManageELB }}
+    "{{.LoadBalancer.LogicalName}}": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "Type": "network",
+        "LoadBalancerAttributes": [
+          {
+            "Key": "load_balancing.cross_zone.enabled",
+            "Value": "true"
+          }
+        ],
+        "Subnets": [
+          {{range $index, $subnet := .LoadBalancer.Subnets}}
+          {{if gt $index 0}},{{end}}
+          {{$subnet.Ref}}
+          {{end}}
+        ],
+        {{if .LoadBalancer.Private}}
+        "Scheme": "internal"
+        {{else}}
+        "Scheme": "internet-facing"
+        {{end}}
+      }
+    },
+    {{ end }}
+    {{ end -}}
+    {{ end -}}
     "{{.Controller.LogicalName}}LC": {
       "Properties": {
         "BlockDeviceMappings": [

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -68,9 +68,12 @@ apiEndpoints:
   # Omit all the settings when you want kube-aws not to provision a load balancer for you
   loadBalancer:
     # Specifies an existing load-balancer used for load-balancing controller nodes and serving this endpoint
-    # Setting id requires all the other settings excluding `name` to be omitted because reusing an ELB implies that configuring other resources
+    # Setting id requires the fields subnets, HostZoneId & private be omitted because reusing an existing ELB implies that configuring other resources
     # like a Route 53 record set for the endpoint is now your responsibility!
-    # Also, don't forget to add controller.securityGroupIds to include a glue SG to allow your existing ELB to access controller nodes created by kube-aws
+    # Classic: If you're using a classic LB then don't forget to add controller.securityGroupIds to include a glue SG to allow your existing ELB to access controller nodes created by kube-aws
+    # Network: If you're using a network LB then a Listener will be created & the specified NLB attached to it. A TargetGroup will also be created and attached to the Controllers ASG.
+    #          Also, if using a type: network LB, then you'll need to specify the full ARN of the existing LB like so:
+    #          id: arn:aws:elasticloadbalancing:<region>:<account_id>:loadbalancer/net/cluster-apiserver-nlb/<lb_id>
     #id: existing-elb
 
     # All the subnets assigned to this load-balancer. Specified only when this load balancer is not reused but managed one

--- a/model/derived/api_endpoint_lb.go
+++ b/model/derived/api_endpoint_lb.go
@@ -2,8 +2,9 @@ package derived
 
 import (
 	"fmt"
-	"github.com/kubernetes-incubator/kube-aws/model"
 	"strings"
+
+	"github.com/kubernetes-incubator/kube-aws/model"
 )
 
 // APIEndpointLB is the load balancer serving the API endpoint
@@ -53,13 +54,8 @@ func (b APIEndpointLB) Ref() string {
 // TargetGroupRef returns a CloudFormation ref for the Target Group backing the API endpoint
 func (b APIEndpointLB) TargetGroupRef() string {
 	return b.Identifier.Ref(func() string {
-		return fmt.Sprintf("%sTargetGroup", b.LogicalName())
+		return fmt.Sprintf(b.TargetGroupLogicalName())
 	})
-}
-
-// SecurityGroupLogicalName returns a CloudFormation ref for the Security Group backing the API endpoint
-func (b APIEndpointLB) SecurityGroupLogicalName() string {
-	return fmt.Sprintf("APIEndpoint%sSG", strings.Title(b.Name))
 }
 
 // SecurityGroupRefs contains CloudFormation resource references for additional SGs associated to this LB
@@ -81,4 +77,14 @@ func (b APIEndpointLB) SecurityGroupRefs() []string {
 	)
 
 	return refs
+}
+
+// TargetGroupLogicalName returns a CloudFormation ref for the Target Group backing the API endpoint
+func (b APIEndpointLB) TargetGroupLogicalName() string {
+	return fmt.Sprintf("APIEndpoint%sTG", strings.Title(b.Name))
+}
+
+// SecurityGroupLogicalName returns a CloudFormation ref for the Security Group backing the API endpoint
+func (b APIEndpointLB) SecurityGroupLogicalName() string {
+	return fmt.Sprintf("APIEndpoint%sSG", strings.Title(b.Name))
 }

--- a/model/derived/api_endpoints.go
+++ b/model/derived/api_endpoints.go
@@ -2,9 +2,10 @@ package derived
 
 import (
 	"fmt"
-	"github.com/kubernetes-incubator/kube-aws/model"
 	"sort"
 	"strings"
+
+	"github.com/kubernetes-incubator/kube-aws/model"
 )
 
 // APIEndpoints is a set of API endpoints associated to a Kubernetes cluster
@@ -99,7 +100,7 @@ func (e APIEndpoints) ELBClassicRefs() []string {
 	return refs
 }
 
-// ELBV2TargetGroupRefs returns the names of all the Load Balancers v2 to which controller nodes should be associated
+// ELBV2TargetGroupRefs returns the names of all the TargetGroups which should be attached to NLBs managed by kube-aws
 func (e APIEndpoints) ELBV2TargetGroupRefs() []string {
 	refs := []string{}
 	for _, endpoint := range e {
@@ -110,7 +111,7 @@ func (e APIEndpoints) ELBV2TargetGroupRefs() []string {
 	return refs
 }
 
-// ManageELBLogicalNames returns all the logical names of the cfn resources corresponding to ELBs managed by kube-aws for API endpoints
+// ManagedELBLogicalNames returns all the logical names of the cfn resources corresponding to ELBs managed by kube-aws for API endpoints
 func (e APIEndpoints) ManagedELBLogicalNames() []string {
 	logicalNames := []string{}
 	for _, endpoint := range e {

--- a/plugin/clusterextension/extras.go
+++ b/plugin/clusterextension/extras.go
@@ -111,7 +111,7 @@ func (e ClusterExtension) NodePoolStack() (*stack, error) {
 
 			m, err := render.MapFromContents(p.Spec.CloudFormation.Stacks.NodePool.Resources.Append.Contents)
 			if err != nil {
-				return nil, fmt.Errorf("failed to load additioanl resources for worker node-pool stack: %v", err)
+				return nil, fmt.Errorf("failed to load additional resources for worker node-pool stack: %v", err)
 			}
 			for k, v := range m {
 				resources[k] = v

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -2144,7 +2144,7 @@ apiEndpoints:
 					elbOnly := c.APIEndpoints["elbOnly"]
 
 					if len(unversionedPublic.LoadBalancer.Subnets) != 0 {
-						t.Errorf("unversionedPublic: subnets shuold be empty but was not: actual=%+v", unversionedPublic.LoadBalancer.Subnets)
+						t.Errorf("unversionedPublic: subnets should be empty but was not: actual=%+v", unversionedPublic.LoadBalancer.Subnets)
 					}
 					if !unversionedPublic.LoadBalancer.Enabled() {
 						t.Errorf("unversionedPublic: it should be enabled as the lb to which controller nodes are added, but it was not: loadBalancer=%+v", unversionedPublic.LoadBalancer)
@@ -3974,7 +3974,7 @@ apiEndpoints:
     hostedZone:
       id: hostedzone-public
 `,
-			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: type, private, subnets, hostedZone must be omitted when id is specified to reuse an existing ELB",
+			expectedErrorMessage: "invalid apiEndpoint \"unversionedPublic\" at index 0: invalid loadBalancer: private, subnets, hostedZone must be omitted when id is specified to reuse an existing ELB",
 		},
 		{
 			context: "WithMultiAPIEndpointsInvalidWorkerAPIEndpointName",


### PR DESCRIPTION
**What**
Enhance NLB support for api-endpoint:
- add ability to use an existing NLB
- improve error handling around NLB configuration
- add cross-zone-balancing to created NLBs to mirror behavior of kube-aws-managed ELBs.

**Why**
We (Hotels.com) wish to front our clusters with an NLB managed outside of the kube-aws lifecycle, one which has already been configured with a VPC Endpoint to be shared across multiple AWS accounts.

**How**
I've amended the control-plane stack.json template to accommodate some extra logic if an NLB ID is provided.
The logic in the stack.json around endpoints is a bit ugly, but I favoured verbose checks in the hope it reads clearer. Shout if you're not happy and I'll try present and alternative.

I'll this feature is accepted then I'll make a corresponding PR for 0.12.x, 0.13.x & master.
Thanks! 