### PR TITLE
master: Plugin enhancement - allow embedding templates within templates

### DIFF
--- a/filereader/texttemplate/texttemplate.go
+++ b/filereader/texttemplate/texttemplate.go
@@ -39,6 +39,9 @@ var funcs2 = template.FuncMap{
 	"execTemplate": func(name string, ctx interface{}) (string, error) {
 		panic("[bug] Stub 'execTemplate' was not replaced")
 	},
+	"insertTemplateFile": func(name string, ctx interface{}) (string, error) {
+		panic("[bug] Stub 'insertTemplateFile' was not replaced")
+	},
 	"fingerprint": func(data string) string {
 		return fingerprint.SHA256(data)
 	},
@@ -86,6 +89,9 @@ func Parse(name string, raw string, funcs template.FuncMap) (*template.Template,
 				b := bytes.Buffer{}
 				err := t.ExecuteTemplate(&b, name, ctx)
 				return b.String(), err
+			},
+			"insertTemplateFile": func(path string, ctx interface{}) (string, error) {
+				return GetString(path, ctx)
 			},
 		})
 	}

--- a/plugin/plugincontents/template.go
+++ b/plugin/plugincontents/template.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"bytes"
+	"text/template"
+
 	"github.com/kubernetes-incubator/kube-aws/filereader/texttemplate"
 	"github.com/kubernetes-incubator/kube-aws/pkg/api"
 	"github.com/kubernetes-incubator/kube-aws/provisioner"
-	"text/template"
 )
 
 type data struct {


### PR DESCRIPTION
add insertTemplateFile template function which allows embedding a template file within any templatable plugin object, e.g. within in stack resource: -

```
        "prometheus-server-cloud-int": {
          "files": {
            "/var/run/coreos/cloud_config": {
              "content": {
                "Fn::Sub": {{ insertTemplateFile "plugins/prometheus/assets/cloud-config.yaml" $ | toJSON }}
              }
            },
            "/var/run/coreos/prometheus.yaml": {
                "content": {
                  "Fn::Sub": {{ insertTemplateFile "plugins/prometheus/assets/prometheus-config.yaml" $ | toJSON }}
              }
            },
            "/var/run/coreos/nginx_config": {
                "content": {
                  "Fn::Sub": {{ insertTemplateFile "plugins/prometheus/assets/nginx-config" $ | toJSON }}
              }
            },
            "/var/run/coreos/script_exporter.yaml": {
              "content": {
                "Fn::Sub": {{ insertTemplateFile "plugins/prometheus/assets/script-exporter-config.yaml" $ | toJSON }}
              }
            }
          }
        }
```
e.g. within an inserted template for userdata: -

```
#!/bin/bash -xe
# Trigger updates any of these files change:-
# cloud-config: {{ insertTemplateFile "plugins/prometheus/assets/cloud-config.yaml" $ | fingerprint }}
# promethus-config: {{ insertTemplateFile "plugins/prometheus/assets/prometheus-config.yaml" $ | fingerprint }}
# nginx-config: {{ insertTemplateFile "plugins/prometheus/assets/nginx-config" $ | fingerprint }}
# script-exporter-config: {{ insertTemplateFile "plugins/prometheus/assets/script-exporter-config.yaml" $ | fingerprint }}
cloud-init() {
  container_name="cloud-init-container"
...
```