### PR TITLE
v0.13.x-Reserve resources for calico typha (#1607)

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1196,6 +1196,13 @@ kubernetes:
     selfHosting:
       type: canal      # either "canal" or "flannel"
       typha: false     # enable for type 'canal' for 50+ node clusters
+#      typhaResources:  # control k8s resources assigned to Typha pods 
+#        requests:
+#          cpu: "100m"
+#          memory: "100Mi"
+#        limits:
+#          cpu: "250m"
+#          memory: "200Mi"
 #      calicoNodeImage:
 #        repo: quay.io/calico/node
 #        tag: v3.1.3

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1449,6 +1449,13 @@ write_files:
                 #  value: "true"
                 #- name: TYPHA_PROMETHEUSMETRICSPORT
                 #  value: "9093"
+              resources:
+                requests:
+                  cpu: {{ .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Cpu }}
+                  memory: {{ .Kubernetes.Networking.SelfHosting.TyphaResources.Requests.Memory }}
+                limits:
+                  cpu: {{ .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Cpu }}
+                  memory: {{ .Kubernetes.Networking.SelfHosting.TyphaResources.Limits.Memory }}
               livenessProbe:
                 httpGet:
                   path: /liveness

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -204,8 +204,18 @@ func NewDefaultCluster() *Cluster {
 						Enabled: false,
 					},
 					SelfHosting: SelfHosting{
-						Type:            "canal",
-						Typha:           false,
+						Type:  "canal",
+						Typha: false,
+						TyphaResources: ComputeResources{
+							Requests: ResourceQuota{
+								Cpu:    "100m",
+								Memory: "100Mi",
+							},
+							Limits: ResourceQuota{
+								Cpu:    "250",
+								Memory: "200Mi",
+							},
+						},
 						CalicoNodeImage: Image{Repo: "quay.io/calico/node", Tag: kubeNetworkingSelfHostingDefaultCalicoNodeImageTag, RktPullDocker: false},
 						CalicoCniImage:  Image{Repo: "quay.io/calico/cni", Tag: kubeNetworkingSelfHostingDefaultCalicoCniImageTag, RktPullDocker: false},
 						FlannelImage:    Image{Repo: "quay.io/coreos/flannel", Tag: kubeNetworkingSelfHostingDefaultFlannelImageTag, RktPullDocker: false},

--- a/pkg/api/networking.go
+++ b/pkg/api/networking.go
@@ -6,11 +6,12 @@ type Networking struct {
 }
 
 type SelfHosting struct {
-	Type            string `yaml:"type"`
-	Typha           bool   `yaml:"typha"`
-	CalicoNodeImage Image  `yaml:"calicoNodeImage"`
-	CalicoCniImage  Image  `yaml:"calicoCniImage"`
-	FlannelImage    Image  `yaml:"flannelImage"`
-	FlannelCniImage Image  `yaml:"flannelCniImage"`
-	TyphaImage      Image  `yaml:"typhaImage"`
+	Type            string           `yaml:"type"`
+	Typha           bool             `yaml:"typha"`
+	TyphaResources  ComputeResources `yaml:"typhaResources,omitempty"`
+	CalicoNodeImage Image            `yaml:"calicoNodeImage"`
+	CalicoCniImage  Image            `yaml:"calicoCniImage"`
+	FlannelImage    Image            `yaml:"flannelImage"`
+	FlannelCniImage Image            `yaml:"flannelCniImage"`
+	TyphaImage      Image            `yaml:"typhaImage"`
 }


### PR DESCRIPTION
* Reserve resources for calico typha

* Parametrize typha computing resources

* Defaults typha resources in new cluster fuction

('backport' of https://github.com/kubernetes-incubator/kube-aws/pull/1607)