### PR TITLE
WIP: v0.13.x: Add handle-kubernetes-version-jump

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -5995,7 +5995,7 @@ write_files:
         namespace: kube-system
       data:
         kubernetesVersion: ${version}
-        disable: "kube-controller-manager kube-scheduler"
+        disable: "kube-controller-manager kube-scheduler kube-apiserver"
       EOT
       )"
 
@@ -6022,7 +6022,7 @@ write_files:
         while [ "$test" -eq "1" ]; do
           test=0
           for cont in $controllers; do
-            for pod in kube-controller-manager kube-scheduler
+            for pod in kube-controller-manager kube-scheduler kube-apiserver
             do
               local found=$(find_pod "${pod}" "${cont}")
               if [[ -n "${found}" ]]; then

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -69,6 +69,27 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
+    - name: handle-kubernetes-version-jump.service
+      enable: true
+      command: start
+      content: |
+        [Unit]
+        Description=Smooth upgrades where the version jumps more than 1 release
+        After=kubelet.service network-online.target
+        Before=install-kube-system.service
+        Wants=kubelet.service
+
+        [Service]
+        Type=simple
+        TimeoutStartSec=60m
+        Restart=on-failure
+        RestartSec=30
+        ExecStartPre=/usr/bin/systemctl is-active kubelet
+        ExecStart=/opt/bin/handle-kubernetes-version-jump
+
+        [Install]
+        WantedBy=multi-user.target
+
     - name: handle-cluster-cidr-changes.service
       enable: true
       command: start
@@ -5799,7 +5820,7 @@ write_files:
         local return_code=0
 
         while [ "$tries" -lt "$retries" ]; do
-          result_text=$(docker run --rm -i --net=host -v /tmp:/tmp:rw -v /etc/kubernetes:/etc/kubernetes:ro  -v /etc/resolv.conf:/etc/resolv.conf:ro $hyperkube_image /kubectl "$@")
+          result_text=$(docker run --rm -i --net=host -v /tmp:/tmp:rw -v /etc/kubernetes:/etc/kubernetes:ro  -v /etc/resolv.conf:/etc/resolv.conf:ro $hyperkube_image /kubectl --kubeconfig=/etc/kubernetes/kubeconfig/kube-controller-manager.yaml "$@")
           return_code=$?
           if [ "$return_code" -eq "0" ]; then
             echo "${result_text}"
@@ -5866,7 +5887,6 @@ write_files:
       }
 
       # MAIN
-
       log "Running watcher for requests to disable core services..."
       while true
       do
@@ -5888,6 +5908,150 @@ write_files:
         fi
 
         sleep 10
+      done
+
+  - path: /opt/bin/handle-kubernetes-version-jump
+    permissions: 0755
+    content: |
+      #!/bin/bash
+      # Smooth upgrades/roll-backs where the release of kubernetes jumps 2 or more
+      # e.g. from 1.11.0 to 1.13.0
+      # Stops the kube-scheduler and kube-controller manager on master nodes so that an upgraded node
+      # immediately takes over these functions (using the kube-aws-migration-disable-xxx configmap mechanism)
+      #
+      # A request to disable is a configmap matching the hostname and kubernetes version containing a list of core service to stop: -
+      # apiVersion: v1
+      # kind: ConfigMap
+      # metadata:
+      #   name: kube-aws-migration-disable-ip-10-29-26-83.us-west-2.compute.internal
+      #   namespace: kube-system
+      # data:
+      #   kubernetesVersion: v1.9.3
+      #   disable: "kube-apiserver kube-controller-manager kube-scheduler"
+
+      retries=5
+      hyperkube_image="{{.HyperkubeImage.RepoWithTag}}"
+      my_kubernetes_version="{{.HyperkubeImage.Tag}}"
+      myhostname=$(hostname -f)
+
+      kubectl() {
+        local tries=0
+        local result_text=""
+        local return_code=0
+
+        while [ "$tries" -lt "$retries" ]; do
+          result_text=$(docker run --rm -i --net=host -v /tmp:/tmp:rw -v /etc/kubernetes:/etc/kubernetes:ro  -v /etc/resolv.conf:/etc/resolv.conf:ro $hyperkube_image /kubectl --kubeconfig=/etc/kubernetes/kubeconfig/admin.yaml "$@")
+          return_code=$?
+          if [ "$return_code" -eq "0" ]; then
+            echo "${result_text}"
+            break
+          fi
+          sleep 10
+          tries=$((tries+1))
+        done
+        return $return_code
+      }
+
+      log() {
+        echo "$@" >&2
+      }
+
+      get_masters() {
+        kubectl get nodes -l kubernetes.io/role=master --no-headers -o custom-columns=NAME:metadata.name,VERSION:status.nodeInfo.kubeletVersion | awk '{printf "%s:%s\n", $1, $2}'
+      }
+
+      get_major() {
+        local major=$(echo $1 | awk -F. '{print $1}')
+        echo "${major#v}"
+      }
+
+      get_release() {
+        echo $1 | awk -F. '{print $2}'
+      }
+
+      valid_version() {
+        match=$(echo $1 | awk -e '(/^v[0-9]+\.[0-9]+\.[0-9]+/){print "match"}')
+        [[ "$match" == "match" ]]
+      }
+
+      version_jumps() {
+        # A major release change is a version jump
+        if [[ $(get_major $1) != $(get_major $2) ]]; then
+          return 0
+        fi
+
+        # A release change of more than 1 is a version jump
+        local release1=$(get_release $1)
+        local release2=$(get_release $2)
+        if [ "$release1" -gt "$release2" ]; then
+          if [ "$((release1-release2))" -gt "1" ]; then
+            return 0
+          fi
+        elif [ "$release2" -gt "$release1" ]; then
+          if [ "$((release2-release1))" -gt "1" ]; then
+            return 0
+          fi
+        fi
+
+        return 1
+      }
+
+      # stop a controller by writing a special kube-aws disable service configmap
+      disable_controller() {
+        local controller=$1
+        local version=$2
+
+        local request="$(cat <<EOT
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-aws-migration-disable-${controller}
+        namespace: kube-system
+      data:
+        kubernetesVersion: ${version}
+        disable: "kube-controller-manager kube-scheduler"
+      EOT
+      )"
+
+        log "Creating disable service configmap kube-system/kube-aws-migration-disable-${controller}"
+        echo "${request}" | kubectl -n kube-system apply -f - || return 1
+        return 0
+      }
+
+      # MAIN
+      while ! kubectl get ns kube-system; do
+        echo "Waiting until apiserver/kube-system available..."
+        sleep 3
+      done
+
+      if ! $(valid_version ${my_kubernetes_version}); then
+        log "My kubernetes version ${my_kubernetes_version} is invalid - aborting!"
+        exit 1
+      fi
+
+      log "Checking for masters/controllers with kubernetes release jumps (>1) ..."
+      for controller in $(get_masters); do
+        controller_name=$(echo "${controller%%:*}")
+        controller_version=$(echo "${controller##*:}")
+        if [[ "${controller_name}" != "$myhostname" ]]; then
+          log "Checking controller ${controller_name}..."
+          if ! $(valid_version ${controller_version}); then
+            log "Controller ${controller_name} has an invalid version number ${controller_version}!"
+            continue
+          fi
+
+          if $(version_jumps ${my_kubernetes_version} ${controller_version}); then
+            log "Detected a version jump between my version ${my_kubernetes_version} and theirs ${controller_version}"
+            log "Disabling kube-scheduler and kube-controller-manager on ${controller_name}"
+            disable_controller ${controller_name} ${controller_version}
+          else
+            log "No version jump between my version ${my_kubernetes_version} and theirs ${controller_version}"
+          fi
+        fi
+      done
+
+      while true; do
+        sleep 999999
       done
   
   - path: /opt/bin/handle-cluster-cidr-changes
@@ -6225,7 +6389,7 @@ write_files:
       EOT
       )"
           
-        log "Creating disable service configmap kubw-system/kube-aws-migration-disable-${controller}"
+        log "Creating disable service configmap kube-system/kube-aws-migration-disable-${controller}"
         echo "${request}" | kubectl -n kube-system create -f - || return 1
         return 0
       }

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -6011,6 +6011,17 @@ write_files:
         kubectl -n kube-system get pod "${name}-${host}" --no-headers -o wide --ignore-not-found
       }
 
+      node_running() {
+        local node=$1
+
+        ready=$(kubectl -n kube-system get node "${node}" --no-headers --ignore-not-found | awk '{print $2}')
+        if [[ "${ready}" == "Ready" ]]; then
+          return 0
+        fi
+
+        return 1
+      }
+
       wait_stopped() {
         local controllers=$1
         log ""
@@ -6021,21 +6032,15 @@ write_files:
         local test=1
         while [ "$test" -eq "1" ]; do
           test=0
+
           for cont in $controllers; do
-            for pod in kube-controller-manager kube-scheduler kube-apiserver
-            do
-              local found=$(find_pod "${pod}" "${cont}")
-              if [[ -n "${found}" ]]; then
-                log "found pod: ${found}"
-                test=1
-              else
-                log "no pod ${pod}-${cont} found - good"
-              fi
-            done
+            if node_running $cont; then
+              test=1
+            fi
           done
 
           if [ "$test" -eq "1" ]; then
-            log "Pods found retrying in 5 seconds..."
+            log "Controllers still active, waiting 5 seconds..."
             sleep 5
           fi
         done

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -69,27 +69,6 @@ coreos:
         [Install]
         WantedBy=multi-user.target
 
-    - name: handle-kubernetes-version-jump.service
-      enable: true
-      command: start
-      content: |
-        [Unit]
-        Description=Smooth upgrades where the version jumps more than 1 release
-        After=kubelet.service network-online.target
-        Before=install-kube-system.service
-        Wants=kubelet.service
-
-        [Service]
-        Type=simple
-        TimeoutStartSec=60m
-        Restart=on-failure
-        RestartSec=30
-        ExecStartPre=/usr/bin/systemctl is-active kubelet
-        ExecStart=/opt/bin/handle-kubernetes-version-jump
-
-        [Install]
-        WantedBy=multi-user.target
-
     - name: handle-cluster-cidr-changes.service
       enable: true
       command: start
@@ -1018,6 +997,9 @@ write_files:
         echo Waiting until kube-system created.
         sleep 3
       done
+
+      # Handle kubernetes version jumps by shutting down legacy controllers
+      /opt/bin/handle-kubernetes-version-jump
 
       # KUBE_SYSTEM NAMESPACE
       deploy "/srv/kubernetes/manifests/kube-system-ns.yaml"
@@ -6018,41 +6000,76 @@ write_files:
         return 0
       }
 
-      # MAIN
-      while ! kubectl get ns kube-system; do
-        echo "Waiting until apiserver/kube-system available..."
-        sleep 3
-      done
+      find_pod() {
+        local name=$1
+        local host=$2
+
+        kubectl -n kube-system get pod "${name}-${host}" --no-headers -o wide
+      }
+
+      wait_stopped() {
+        local controllers=$1
+        log ""
+        log "WAITING FOR ALL MATCHED CONTROLLERS TO STOP:-"
+        log "${controllers}"
+        log ""
+
+        local test=1
+        while [ "$test" -eq "1" ]; do
+          test=0
+          for cont in $controllers; do
+            for pod in kube-controller-manager kube-scheduler
+            do
+              if find_pod "${pod}" "${cont}"; then
+                log "found pod ${pod}-${cont}"
+                test=1
+              else
+                log "no pod ${pod}-${cont}"
+              fi
+            done
+          done
+
+          if [ "$test" -eq "1" ]; then
+            log "Pods found retrying in 5 seconds..."
+            sleep 5
+          fi
+        done
+      }
 
       if ! $(valid_version ${my_kubernetes_version}); then
         log "My kubernetes version ${my_kubernetes_version} is invalid - aborting!"
         exit 1
       fi
 
-      log "Checking for masters/controllers with kubernetes release jumps (>1) ..."
+      log ""
+      log "CHECKING CONTROLLER VERSIONS"
+      log ""
+      found=""
       for controller in $(get_masters); do
         controller_name=$(echo "${controller%%:*}")
         controller_version=$(echo "${controller##*:}")
         if [[ "${controller_name}" != "$myhostname" ]]; then
-          log "Checking controller ${controller_name}..."
           if ! $(valid_version ${controller_version}); then
             log "Controller ${controller_name} has an invalid version number ${controller_version}!"
             continue
           fi
 
           if $(version_jumps ${my_kubernetes_version} ${controller_version}); then
-            log "Detected a version jump between my version ${my_kubernetes_version} and theirs ${controller_version}"
-            log "Disabling kube-scheduler and kube-controller-manager on ${controller_name}"
+            log "Detected a version jump on ${controller_name}: my version is ${my_kubernetes_version} and theirs is ${controller_version}"
+            log "Disabling kube-scheduler and kube-controller-manager..."
+            if [[ -z "${found}" ]]; then
+              found="${controller_name}"
+            else
+              found="${found} ${controller_name}"
+            fi
             disable_controller ${controller_name} ${controller_version}
           else
-            log "No version jump between my version ${my_kubernetes_version} and theirs ${controller_version}"
+            log "No version jump on ${controller_name}: my version is ${my_kubernetes_version} and theirs is ${controller_version}"
           fi
         fi
       done
 
-      while true; do
-        sleep 999999
-      done
+      wait_stopped "${found}"
   
   - path: /opt/bin/handle-cluster-cidr-changes
     permissions: 0755

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -6016,6 +6016,7 @@ write_files:
 
         ready=$(kubectl -n kube-system get node "${node}" --no-headers --ignore-not-found | awk '{print $2}')
         if [[ "${ready}" == "Ready" ]]; then
+          echo "${node} is active"
           return 0
         fi
 

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -5917,12 +5917,16 @@ write_files:
       myhostname=$(hostname -f)
 
       kubectl() {
+          /usr/bin/docker run -i --rm -v /etc/kubernetes:/etc/kubernetes:ro --net=host ${hyperkube_image} /hyperkube kubectl --kubeconfig=/etc/kubernetes/kubeconfig/admin.yaml "$@"
+      }
+
+      kubectl_with_retries() {
         local tries=0
         local result_text=""
         local return_code=0
 
         while [ "$tries" -lt "$retries" ]; do
-          result_text=$(docker run --rm -i --net=host -v /tmp:/tmp:rw -v /etc/kubernetes:/etc/kubernetes:ro  -v /etc/resolv.conf:/etc/resolv.conf:ro $hyperkube_image /kubectl --kubeconfig=/etc/kubernetes/kubeconfig/admin.yaml "$@")
+          result_text=$(kubectl "$@")
           return_code=$?
           if [ "$return_code" -eq "0" ]; then
             echo "${result_text}"
@@ -5996,7 +6000,7 @@ write_files:
       )"
 
         log "Creating disable service configmap kube-system/kube-aws-migration-disable-${controller}"
-        echo "${request}" | kubectl -n kube-system apply -f - || return 1
+        echo "${request}" | kubectl_with_retries -n kube-system apply -f - || return 1
         return 0
       }
 
@@ -6004,7 +6008,7 @@ write_files:
         local name=$1
         local host=$2
 
-        kubectl -n kube-system get pod "${name}-${host}" --no-headers -o wide
+        kubectl -n kube-system get pod "${name}-${host}" --no-headers -o wide --ignore-not-found
       }
 
       wait_stopped() {
@@ -6020,11 +6024,12 @@ write_files:
           for cont in $controllers; do
             for pod in kube-controller-manager kube-scheduler
             do
-              if find_pod "${pod}" "${cont}"; then
-                log "found pod ${pod}-${cont}"
+              local found=$(find_pod "${pod}" "${cont}")
+              if [[ -n "${found}" ]]; then
+                log "found pod: ${found}"
                 test=1
               else
-                log "no pod ${pod}-${cont}"
+                log "no pod ${pod}-${cont} found - good"
               fi
             done
           done


### PR DESCRIPTION
When upgrading (or rolling back) you can run into issues when the two versions of kubernetes are far apart from each other (I tried upgrading a cluster from v1.9.3 to v1.13.7).  The difficulty appears to be from having a new apiserver and object schema installed from `install-kube-system` whilst the *kube-controller-manager* and *kube-scheduler* are most likely active on one of the older nodes.

This change makes a controller look for others when starting up for any that it finds which are either a major release or more than 1 release away from its version it will send a special *kube-aws-migration-disable-xyz* configmap to ask the other controller to shutdown it's scheduler and controller-manager so that this node's versions can guarantee to be the active versions of these.

It works both ways - so if a new controller is significantly older than the existing nodes it will also ask them to shutdown.