### PR TITLE
Fix VPCRef

### DIFF
--- a/builtin/files/stack-templates/network.json.tmpl
+++ b/builtin/files/stack-templates/network.json.tmpl
@@ -35,7 +35,7 @@
             "Value": "{{$.ClusterName}}-sg-api-endpoint-{{$i}}"
           }
         ],
-        "VpcId": {{$.VPCRef}}
+        "VpcId": {{$.VPCRefFromNetworkStack}}
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
@@ -61,7 +61,7 @@
             "Value": "{{$.ClusterName}}-sg-elb-api-server"
           }
         ],
-        "VpcId": {{$.VPCRef}}
+        "VpcId": {{$.VPCRefFromNetworkStack}}
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
@@ -141,7 +141,7 @@
             "Value": "{{$.ClusterName}}-sg-controller"
           }
         ],
-        "VpcId": {{.VPCRef}}
+        "VpcId": {{$.VPCRefFromNetworkStack}}
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
@@ -239,7 +239,7 @@
             "Value": "{{$.ClusterName}}-sg-worker"
           }
         ],
-        "VpcId": {{.VPCRef}}
+        "VpcId": {{$.VPCRefFromNetworkStack}}
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
@@ -612,7 +612,7 @@
             "Value": "{{$.ClusterName}}-sg-etcd"
           }
         ],
-        "VpcId": {{.VPCRef}}
+        "VpcId": {{$.VPCRefFromNetworkStack}}
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
@@ -671,7 +671,7 @@
             "Value": "{{$.ClusterName}}-sg-mount-target"
           }
         ],
-        "VpcId": {{.VPCRef}}
+        "VpcId": {{$.VPCRefFromNetworkStack}}
       },
       "Type": "AWS::EC2::SecurityGroup"
     }
@@ -717,7 +717,7 @@
             "Value": "{{$.ClusterName}}-{{$subnet.LogicalName}}"
           }
         ],
-        "VpcId": {{$.VPCRef}}
+        "VpcId": {{$.VPCRefFromNetworkStack}}
       },
       "Type": "AWS::EC2::Subnet"
     }
@@ -739,7 +739,7 @@
             "Value": "{{$.ClusterName}}-{{$subnet.RouteTableLogicalName}}"
           }
         ],
-        "VpcId": {{$.VPCRef}}
+        "VpcId": {{$.VPCRefFromNetworkStack}}
       },
       "Type": "AWS::EC2::RouteTable"
     }
@@ -850,7 +850,7 @@
     "VPCGatewayAttachment": {
       "Properties": {
         "InternetGatewayId": {{.InternetGatewayRef}},
-        "VpcId": {{.VPCRef}}
+        "VpcId": {{$.VPCRefFromNetworkStack}}
       },
       "Type": "AWS::EC2::VPCGatewayAttachment"
     }

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -97,6 +97,21 @@ func (c Config) VPCRef() (string, error) {
 	return c.VPC.RefOrError(c.VPCLogicalName)
 }
 
+func (c Config) VPCRefFromNetworkStack() (string, error) {
+	i := c.VPC
+	if i.IDFromStackOutput != "" {
+		return fmt.Sprintf(`{ "Fn::ImportValue" : %q }`, i.IDFromStackOutput), nil
+	} else if i.ID != "" {
+		return fmt.Sprintf(`"%s"`, i.ID), nil
+	} else {
+		logicalName, err := c.VPCLogicalName()
+		if err != nil {
+			return "", fmt.Errorf("failed to get id or ref: %v", err)
+		}
+		return fmt.Sprintf(`{ "Ref" : %q }`, logicalName), nil
+	}
+}
+
 func (c Config) InternetGatewayLogicalName() string {
 	return internetGatewayLogicalName
 }

--- a/pkg/model/stack_new.go
+++ b/pkg/model/stack_new.go
@@ -98,6 +98,7 @@ func NewControlPlaneStack(conf *Config, opts api.StackTemplateOptions, extras cl
 			conf.Controller.CustomFiles = append(conf.Controller.CustomFiles, extraController.Files...)
 			conf.Controller.IAMConfig.Policy.Statements = append(conf.Controller.IAMConfig.Policy.Statements, extraController.IAMPolicyStatements...)
 			conf.KubeAWSVersion = VERSION
+			conf.VPC = stack.tmplCtx.(ControllerTmplCtx).VPC
 			for k, v := range extraController.NodeLabels {
 				conf.Controller.NodeLabels[k] = v
 			}


### PR DESCRIPTION
VPCRef isn't set correctly when kube-aws manages your VPC, i.e:

"VpcId": {
  "Ref": "VPC"
}

Instead of:

"VpcId": {
"Fn::ImportValue": {
  "Fn::Sub": "${NetworkStackName}-VPC"
}

By setting Config.VPC this will be fixed.

However, this will break configurations with existing/external VPCs.
Therefore, we added VPCRefFromNetworkStack to set this correctly as
well from the network stack.