### PR TITLE
Cannot depend on resources in another stack

### DIFF
--- a/builtin/files/stack-templates/etcd.json.tmpl
+++ b/builtin/files/stack-templates/etcd.json.tmpl
@@ -515,7 +515,6 @@
         }
       },
       "DependsOn": [
-        {{if $etcdInstance.DependencyExists}}{{$etcdInstance.DependencyRef}},{{end}}
         {{if $.StackExists}}{{if $etcdIndex}}"{{$.Etcd.LogicalName}}{{sub $etcdIndex 1}}",{{end}}{{end}}
         {{if $etcdInstance.EIPManaged}}
         "{{$etcdInstance.EIPLogicalName}}",


### PR DESCRIPTION
The dependency on the other stack gives errors. Starting the etcd node
before the natgateway is deployed is not a big issue as it keeps
restarting its proces to fetch its data. Wait signal should be long
enough for this to be resolved.

Fixes https://github.com/kubernetes-incubator/kube-aws/issues/1332

See also https://github.com/kubernetes-incubator/kube-aws/pull/1667