### PR TITLE
master: Fixes for rendering plugin systemd units

### DIFF
--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -227,7 +227,7 @@ type SystemdUnits []SystemdUnit
 type SystemdUnit struct {
 	Name string `yaml:"name,omitempty"`
 	// Contents must be a valid go text template producing a valid systemd unit definition
-	Contents `yaml:"contents,omitempty"`
+	Contents `yaml:",inline"`
 }
 
 // Kubelet represents a set of customizations to kubelets running on the nodes

--- a/pkg/model/stack_new.go
+++ b/pkg/model/stack_new.go
@@ -204,7 +204,7 @@ func NewEtcdStack(conf *Config, opts api.StackTemplateOptions, extras clusterext
 			stack.ExtraCfnResources = extraStack.Resources
 			stack.ExtraCfnOutputs = extraStack.Outputs
 
-			extraEtcd, err := extras.Etcd()
+			extraEtcd, err := extras.Etcd(conf)
 			if err != nil {
 				return fmt.Errorf("failed to load etcd node extras from plugins: %v", err)
 			}

--- a/plugin/plugincontents/loader.go
+++ b/plugin/plugincontents/loader.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 
 	"fmt"
+
+	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/kubernetes-incubator/kube-aws/pkg/api"
 	"github.com/kubernetes-incubator/kube-aws/provisioner"
 )
@@ -25,12 +27,14 @@ func (l *PluginFileLoader) String(f provisioner.RemoteFileSpec) (string, error) 
 		f.Source.Path = filepath.Join("plugins", l.p.Name, f.Source.Path)
 	}
 
+	logger.Debugf("PluginFileLoader.String(): Calling load on FileLoader with RemoteFileSpec: %+v", f)
 	loaded, err := l.FileLoader.Load(f)
 	if err != nil {
 		return "", err
 	}
 
 	res := loaded.Content.String()
+	logger.Debugf("PluginFileLoader.String(): resultant string is: %+v", res)
 
 	if f.Source.Path != "" && len(res) == 0 {
 		return "", fmt.Errorf("[bug] empty file loaded from %s", f.Source.Path)

--- a/plugin/plugincontents/template.go
+++ b/plugin/plugincontents/template.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	"github.com/kubernetes-incubator/kube-aws/filereader/texttemplate"
+	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/kubernetes-incubator/kube-aws/pkg/api"
 	"github.com/kubernetes-incubator/kube-aws/provisioner"
 )
@@ -18,6 +19,7 @@ type data struct {
 }
 
 func RenderStringFromTemplateWithValues(expr string, values interface{}, config interface{}) (string, error) {
+	logger.Debugf("plugincontents.RenderStringFromTemplateWithValues: %s", expr)
 	t, err := texttemplate.Parse("template", expr, template.FuncMap{})
 	data := data{
 		Values: values,
@@ -55,6 +57,7 @@ func (r *TemplateRenderer) File(f provisioner.RemoteFileSpec) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to render template: %v", err)
 	}
+	logger.Debugf("TemplateRenderer.File: string is %s", str)
 	if f.Type == "credential" {
 		return str, nil
 	}

--- a/provisioner/remote_file.go
+++ b/provisioner/remote_file.go
@@ -2,14 +2,16 @@ package provisioner
 
 import (
 	"fmt"
+	"strings"
+	"text/template"
+
 	"github.com/kubernetes-incubator/kube-aws/filereader/texttemplate"
 	"github.com/kubernetes-incubator/kube-aws/gzipcompressor"
 	"github.com/kubernetes-incubator/kube-aws/logger"
-	"strings"
-	"text/template"
 )
 
 func NewRemoteFile(spec RemoteFileSpec) *RemoteFile {
+	logger.Debugf("provisioner.NewRemoteFile() called with: \n%+v\n", spec)
 	var loaded RemoteFile
 	loaded.Path = spec.Path
 	loaded.Permissions = spec.Permissions

--- a/provisioner/remote_file_loader.go
+++ b/provisioner/remote_file_loader.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/kubernetes-incubator/kube-aws/logger"
 )
 
 type RemoteFileLoader struct {
@@ -14,6 +16,7 @@ type RemoteFileLoader struct {
 
 func (loader *RemoteFileLoader) Load(f RemoteFileSpec) (*RemoteFile, error) {
 	loaded := NewRemoteFile(f)
+	logger.Debugf("RemoteFileLoader.Load(): loaded RemoteFile: %+v", loaded)
 
 	path := f.Source.Path
 
@@ -55,9 +58,14 @@ func (loader *RemoteFileLoader) Load(f RemoteFileSpec) (*RemoteFile, error) {
 
 		loaded.Content = NewBinaryContent(data)
 	} else {
-		loaded.Content = f.Content
+		if f.Template != "" {
+			loaded.Content = NewStringContent(f.Template)
+		} else {
+			loaded.Content = f.Content
+		}
 	}
 
+	logger.Debugf("RemoteFileLoader.String(): returning loaded remoteFile: %+v", loaded)
 	return loaded, nil
 }
 

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -48,6 +48,7 @@ kubeAwsPlugins:
     oidc:
       issuer:
         url: "https://login.example.com/"
+    systemdTemplateValue: "elvis123"
 
 worker:
   nodePools:
@@ -237,7 +238,7 @@ spec:
             units:
             - name: save-queue-name.service
               content: |
-                [Unit]
+                [Unit] {{ .Values.systemdTemplateValue }}
           files:
           - path: /var/kube-aws/bar.txt
             permissions: 0644
@@ -259,7 +260,7 @@ spec:
             units:
             - name: save-queue-name.service
               content: |
-                [Unit]
+                [Unit] {{ .Values.systemdTemplateValue }}
           files:
           - path: /var/kube-aws/bar.txt
             permissions: 0644
@@ -286,7 +287,7 @@ spec:
             units:
             - name: save-queue-name.service
               content: |
-                [Unit]
+                [Unit] {{ .Values.systemdTemplateValue }}
           files:
           - path: /var/kube-aws/bar.txt
             permissions: 0644
@@ -295,7 +296,6 @@ spec:
             permissions: 0644
             source:
               path: assets/worker/baz.txt
-
 `,
 				},
 			},
@@ -445,20 +445,29 @@ spec:
 						}
 					}
 
-					// A kube-aws plugin can inject systemd units
+					// A kube-aws plugin can inject systemd units - which are evaluated as templates
 					controllerUserdataS3Part := cp.UserData["Controller"].Parts[api.USERDATA_S3].Asset.Content
 					if !strings.Contains(controllerUserdataS3Part, "save-queue-name.service") {
-						t.Errorf("Invalid controller userdata: %v", controllerUserdataS3Part)
+						t.Errorf("Invalid controller userdata: missing systemd unit save-queue-name.service: %v", controllerUserdataS3Part)
+					}
+					if !strings.Contains(controllerUserdataS3Part, "elvis123") {
+						t.Errorf("Invalid controller userdata: systemd unit not templated: %v", controllerUserdataS3Part)
 					}
 
 					etcdUserdataS3Part := etcd.UserData["Etcd"].Parts[api.USERDATA_S3].Asset.Content
 					if !strings.Contains(etcdUserdataS3Part, "save-queue-name.service") {
-						t.Errorf("Invalid etcd userdata: %v", etcdUserdataS3Part)
+						t.Errorf("Invalid etcd userdata: missing systemd unit save-queue-name.service: %v", etcdUserdataS3Part)
+					}
+					if !strings.Contains(etcdUserdataS3Part, "elvis123") {
+						t.Errorf("Invalid etcd userdata: systemd unit not templated: %v", etcdUserdataS3Part)
 					}
 
 					workerUserdataS3Part := np.UserData["Worker"].Parts[api.USERDATA_S3].Asset.Content
 					if !strings.Contains(workerUserdataS3Part, "save-queue-name.service") {
-						t.Errorf("Invalid worker userdata: %v", workerUserdataS3Part)
+						t.Errorf("Invalid worker userdata: missing systemd unit save-queue-name.service: %v", workerUserdataS3Part)
+					}
+					if !strings.Contains(workerUserdataS3Part, "elvis123") {
+						t.Errorf("Invalid worker userdata: systemd unit not templated: %v", workerUserdataS3Part)
 					}
 
 					// A kube-aws plugin can inject custom cfn stack resources

--- a/test/integration/plugin_test.go
+++ b/test/integration/plugin_test.go
@@ -236,9 +236,8 @@ spec:
           systemd:
             units:
             - name: save-queue-name.service
-              contents:
-                inline: |
-                  [Unit]
+              content: |
+                [Unit]
           files:
           - path: /var/kube-aws/bar.txt
             permissions: 0644
@@ -259,9 +258,8 @@ spec:
           systemd:
             units:
             - name: save-queue-name.service
-              contents:
-                inline: |
-                  [Unit]
+              content: |
+                [Unit]
           files:
           - path: /var/kube-aws/bar.txt
             permissions: 0644
@@ -287,9 +285,8 @@ spec:
           systemd:
             units:
             - name: save-queue-name.service
-              contents:
-                inline: |
-                  [Unit]
+              content: |
+                [Unit]
           files:
           - path: /var/kube-aws/bar.txt
             permissions: 0644


### PR DESCRIPTION
Systemd unit content is no longer: -

```
units:
- name: xyz
  contents:
     content: |
       abc
```
but is now...

```
units:
- name: xyz
  content: |
     abc
```

This is more in-line with how files and manifests are working.

Fixed issue rendering systemd unit templates.
Fixed issue when RemoteFileSpec contains Template and not content.
Refactored extras.go to clean up repetitive code.