### PR TITLE
Allow extra Coredns configuration

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -209,6 +209,7 @@ func NewDefaultCluster() *Cluster {
 					NodesPerReplica: 16,
 					Min:             2,
 				},
+				ExtraCoreDNSConfig: "",
 			},
 			KubeSystemNamespaceLabels: make(map[string]string),
 			KubernetesDashboard: KubernetesDashboard{
@@ -875,6 +876,7 @@ type KubeDns struct {
 	NodeLocalResolverOptions []string          `yaml:"nodeLocalResolverOptions"`
 	DeployToControllers      bool              `yaml:"deployToControllers"`
 	Autoscaler               KubeDnsAutoscaler `yaml:"autoscaler"`
+	ExtraCoreDNSConfig       string            `yaml:"extraCoreDNSConfig"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -1251,6 +1251,24 @@ kubeDns:
 				},
 			},
 		},
+		{
+			conf: `
+kubeDns:
+  provider: coredns
+  extraCoreDNSConfig: rewrite name substring demo.app.org app.default.svc.cluster.local
+`,
+			kubeDns: KubeDns{
+				Provider:            "coredns",
+				NodeLocalResolver:   false,
+				DeployToControllers: false,
+				Autoscaler: KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+				ExtraCoreDNSConfig: "rewrite name substring demo.app.org app.default.svc.cluster.local",
+			},
+		},
 	}
 
 	for _, conf := range validConfigs {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3428,6 +3428,9 @@ write_files:
                     upstream
                     fallthrough in-addr.arpa ip6.arpa
                 }
+                {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.extraCoreDNSConfig }}
+                {{ .KubeDns.extraCoreDNSConfig }}
+                {{- end }}
                 prometheus :9153
                 proxy . /etc/resolv.conf
                 cache 30

--- a/core/root/config/templates/cluster.yaml
+++ b/core/root/config/templates/cluster.yaml
@@ -1327,6 +1327,9 @@ kubeDns:
     coresPerReplica: 256
     nodesPerReplica: 16
     min: 2
+  # Allows to add extra configuration into CoreDNS config map
+  # extraCoreDNSConfig: |
+  #   rewrite name substring demo.app.org app.default.svc.cluster.local
 
 kubeProxy:
   # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.9.0+ to work reliably)


### PR DESCRIPTION
When touching the coredns configmap a cluster upgrade will overwrite the changes. This PR introduces a way to configure the changes inside the cluster config so no need to touch manually the config.

It will be ignored when other provider is specified