### PR TITLE
Remove duplicated kiam agent flags

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -5756,10 +5756,8 @@ write_files:
                   - --key=/etc/kiam/tls/agent-key.pem
                   - --ca=/etc/kiam/tls/ca.pem
                   - --server-address={{.Experimental.KIAMSupport.ServerAddresses.AgentAddress}}
-                  - --whitelist-route-regexp=.*
                   - --prometheus-listen-addr=0.0.0.0:9620
                   - --prometheus-sync-interval=5s
-                  - --gateway-timeout-creation=1s
                 env:
                   - name: HOST_IP
                     valueFrom:


### PR DESCRIPTION
The kiam agent flags `--whitelist-route-regexp=.*` and `--gateway-timeout-creation=1s` are not supported on kiam < 3.0. So removing them from the "base" set of flags, as they are added if kiam version > 3.0 is specified in cluster.yaml.