### PR TITLE
Coredns prometheus metrics

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4288,9 +4288,8 @@ write_files:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
               {{- if eq .KubeDns.Provider "coredns" }}
-                annotations:
-                  prometheus.io/port: "9153"
-                  prometheus.io/scrape: "true"
+                prometheus.io/port: "9153"
+                prometheus.io/scrape: "true"
               {{- end }}
             spec:
               priorityClassName: system-cluster-critical

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4287,6 +4287,11 @@ write_files:
                 k8s-app: kube-dns
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
+              {{- if eq .KubeDns.Provider "coredns" }}
+                annotations:
+                  prometheus.io/port: "9153"
+                  prometheus.io/scrape: "true"
+              {{- end }}
             spec:
               priorityClassName: system-cluster-critical
               volumes:
@@ -4437,11 +4442,6 @@ write_files:
         metadata:
           name: kube-dns
           namespace: kube-system
-          {{- if eq .KubeDns.Provider "coredns" }}
-          annotations:
-            prometheus.io/port: "9153"
-            prometheus.io/scrape: "true"
-          {{- end }}
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
The coredns annotation for prometheus metrics is tied to the wrong resource. This should re-point it to the actual deployment and hence pods, allowing metrics to be scraped. 