### PR TITLE
[v0.14.x] CoreDNS prometheus metric annotations exposed at deployment level

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4120,6 +4120,11 @@ write_files:
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"
+          {{- if eq .KubeDns.Provider "coredns" }}
+          annotations:
+            prometheus.io/port: "9153"
+            prometheus.io/scrape: "true"
+          {{- end }}
         spec:
           # replicas: not specified here:
           # 1. In order to make Addon Manager do not reconcile this replicas parameter.
@@ -4138,10 +4143,6 @@ write_files:
                 k8s-app: kube-dns
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
-              {{- if eq .KubeDns.Provider "coredns" }}
-                prometheus.io/port: "9153"
-                prometheus.io/scrape: "true"
-              {{- end }}
             spec:
               priorityClassName: system-cluster-critical
               volumes:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4138,6 +4138,10 @@ write_files:
                 k8s-app: kube-dns
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
+              {{- if eq .KubeDns.Provider "coredns" }}
+                prometheus.io/port: "9153"
+                prometheus.io/scrape: "true"
+              {{- end }}
             spec:
               priorityClassName: system-cluster-critical
               volumes:
@@ -4288,11 +4292,6 @@ write_files:
         metadata:
           name: kube-dns
           namespace: kube-system
-          {{- if eq .KubeDns.Provider "coredns" }}
-          annotations:
-            prometheus.io/port: "9153"
-            prometheus.io/scrape: "true"
-          {{- end }}
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
Just the same as #1719 & #1720 - moving the prometheus annotations to the deployment instead of the service so they can be properly used on pods. As it is currently does not work.