### PR TITLE
[v0.13.x] CoreDNS prometheus metric annotations exposed at deployment level

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4123,6 +4123,11 @@ write_files:
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"
+          {{- if eq .KubeDns.Provider "coredns" }}
+          annotations:
+            prometheus.io/port: "9153"
+            prometheus.io/scrape: "true"
+          {{- end }}
         spec:
           # replicas: not specified here:
           # 1. In order to make Addon Manager do not reconcile this replicas parameter.
@@ -4141,10 +4146,6 @@ write_files:
                 k8s-app: kube-dns
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
-              {{- if eq .KubeDns.Provider "coredns" }}
-                prometheus.io/port: "9153"
-                prometheus.io/scrape: "true"
-              {{- end }}
             spec:
               priorityClassName: system-cluster-critical
               volumes:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4141,6 +4141,10 @@ write_files:
                 k8s-app: kube-dns
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
+              {{- if eq .KubeDns.Provider "coredns" }}
+                prometheus.io/port: "9153"
+                prometheus.io/scrape: "true"
+              {{- end }}
             spec:
               priorityClassName: system-cluster-critical
               volumes:
@@ -4291,11 +4295,6 @@ write_files:
         metadata:
           name: kube-dns
           namespace: kube-system
-          {{- if eq .KubeDns.Provider "coredns" }}
-          annotations:
-            prometheus.io/port: "9153"
-            prometheus.io/scrape: "true"
-          {{- end }}
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
Just the same as #1718 & #1720 - moving the prometheus annotations to the deployment instead of the service so they can be properly used on pods. As it is currently does not work.