### PR TITLE
CoreDNS prometheus metric annotations exposed at deployment level 

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4269,6 +4269,11 @@ write_files:
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"
+          {{- if eq .KubeDns.Provider "coredns" }}
+          annotations:
+            prometheus.io/port: "9153"
+            prometheus.io/scrape: "true"
+          {{- end }}
         spec:
           # replicas: not specified here:
           # 1. In order to make Addon Manager do not reconcile this replicas parameter.
@@ -4437,11 +4442,6 @@ write_files:
         metadata:
           name: kube-dns
           namespace: kube-system
-          {{- if eq .KubeDns.Provider "coredns" }}
-          annotations:
-            prometheus.io/port: "9153"
-            prometheus.io/scrape: "true"
-          {{- end }}
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"


### PR DESCRIPTION
Moving the prometheus annotations from svc level to deployment level 