### PR TITLE
Toleration added to prevent node drainer scheduling on cordoned nodes 

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1492,6 +1492,9 @@ experimental:
     iamRole:
       # Empty, inactive by default. Set it to valid ARN "arn: arn:aws:iam::0123456789012:role/roleName" to activate.
       arn: ""
+    # Prevents the nodeDrainer from scheduling on nodes that have been cordoned.
+    # This happens if a nodes take more than the alloted time to drain
+    unschedulableWhenCordoned: true
 
   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
   # For using Dex as a custom OIDC provider, please check "contrib/dex/README.md".

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2772,6 +2772,8 @@ write_files:
                 effect: NoExecute
               - operator: Exists
                 key: CriticalAddonsOnly
+              - key: node.kubernetes.io/unschedulable
+                effect: NoSchedule
               initContainers:
                 - name: hyperkube
                   image: {{.HyperkubeImage.RepoWithTag}}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2772,8 +2772,10 @@ write_files:
                 effect: NoExecute
               - operator: Exists
                 key: CriticalAddonsOnly
+            {{ if .nodeDrainer.unschedulableWhenCordoned }}
               - key: node.kubernetes.io/unschedulable
                 effect: NoSchedule
+            {{ end }}
               initContainers:
                 - name: hyperkube
                   image: {{.HyperkubeImage.RepoWithTag}}


### PR DESCRIPTION
As title says.

Its seems that if a node takes longer to drain than 300s set here the node drainer pod will try reschedule itself onto the node. This causes it to be in a restart loop until the node drains and goes offline, which makes our alerts pretty noisy!

Since a cordoned node is given the label node.kubernetes.io/unschedulable, this gives the user the option to make the daemonset respect this