### PR TITLE
Toleration added to prevent node drainer scheduling on cordoned nodes

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1495,7 +1495,7 @@ experimental:
 
     # Prevents the nodeDrainer from scheduling on nodes that have been cordoned.
     # This happens if a nodes take more than the alloted time to drain
-    unschedulableWhenCordoned: true
+    # unschedulableWhenCordoned: true
     
   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
   # For using Dex as a custom OIDC provider, please check "contrib/dex/README.md".

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1493,6 +1493,10 @@ experimental:
       # Empty, inactive by default. Set it to valid ARN "arn: arn:aws:iam::0123456789012:role/roleName" to activate.
       arn: ""
 
+    # Prevents the nodeDrainer from scheduling on nodes that have been cordoned.
+    # This happens if a nodes take more than the alloted time to drain
+    unschedulableWhenCordoned: true
+    
   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
   # For using Dex as a custom OIDC provider, please check "contrib/dex/README.md".
   # WARNING: always use "https" for "issuerUrl", otherwise the Kubernetes API server will not start correctly.

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2772,7 +2772,7 @@ write_files:
                 effect: NoExecute
               - operator: Exists
                 key: CriticalAddonsOnly
-            {{ if .nodeDrainer.unschedulableWhenCordoned }}
+            {{ if .Experimental.NodeDrainer.UnschedulableWhenCordoned }}
               - key: node.kubernetes.io/unschedulable
                 effect: NoSchedule
             {{ end }}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2772,6 +2772,10 @@ write_files:
                 effect: NoExecute
               - operator: Exists
                 key: CriticalAddonsOnly
+            {{ if .nodeDrainer.unschedulableWhenCordoned }}
+              - key: node.kubernetes.io/unschedulable
+                effect: NoSchedule
+            {{ end }}
               initContainers:
                 - name: hyperkube
                   image: {{.HyperkubeImage.RepoWithTag}}

--- a/pkg/api/node_drainer.go
+++ b/pkg/api/node_drainer.go
@@ -6,9 +6,10 @@ import (
 )
 
 type NodeDrainer struct {
-	Enabled      bool    `yaml:"enabled"`
-	DrainTimeout int     `yaml:"drainTimeout"`
-	IAMRole      IAMRole `yaml:"iamRole,omitempty"`
+	Enabled                   bool    `yaml:"enabled"`
+	DrainTimeout              int     `yaml:"drainTimeout"`
+	UnschedulableWhenCordoned bool    `yaml:"unschedulableWhenCordoned"`
+	IAMRole                   IAMRole `yaml:"iamRole,omitempty"`
 }
 
 func (nd *NodeDrainer) DrainTimeoutInSeconds() int {

--- a/pkg/api/node_drainer.go
+++ b/pkg/api/node_drainer.go
@@ -8,7 +8,7 @@ import (
 type NodeDrainer struct {
 	Enabled                   bool    `yaml:"enabled"`
 	DrainTimeout              int     `yaml:"drainTimeout"`
-	UnschedulableWhenCordoned bool    `yaml:"unschedulableWhenCordoned"`
+	UnschedulableWhenCordoned bool    `yaml:"unschedulableWhenCordoned,omitempty"`
 	IAMRole                   IAMRole `yaml:"iamRole,omitempty"`
 }
 

--- a/pkg/api/node_drainer_test.go
+++ b/pkg/api/node_drainer_test.go
@@ -36,50 +36,57 @@ func TestDrainTimeoutInSeconds(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := []struct {
-		enabled      bool
-		drainTimeout int
-		isValid      bool
+		enabled                   bool
+		drainTimeout              int
+		isValid                   bool
+		unschedulableWhenCordoned bool
 	}{
 		// Invalid, drainTimeout is < 1
 		{
-			enabled:      true,
-			drainTimeout: 0,
-			isValid:      false,
+			enabled:                   true,
+			drainTimeout:              0,
+			unschedulableWhenCordoned: true,
+			isValid:                   false,
 		},
 
 		// Invalid, drainTimeout > 60
 		{
-			enabled:      true,
-			drainTimeout: 61,
-			isValid:      false,
+			enabled:                   true,
+			drainTimeout:              61,
+			unschedulableWhenCordoned: true,
+			isValid:                   false,
 		},
 
 		// Valid, disabled
 		{
-			enabled:      false,
-			drainTimeout: 0,
-			isValid:      true,
+			enabled:                   false,
+			drainTimeout:              0,
+			unschedulableWhenCordoned: true,
+			isValid:                   true,
 		},
 
 		// Valid, timeout within boundaries
 		{
-			enabled:      true,
-			drainTimeout: 1,
-			isValid:      true,
+			enabled:                   true,
+			drainTimeout:              1,
+			unschedulableWhenCordoned: true,
+			isValid:                   true,
 		},
 
 		// Valid, timeout within boundaries
 		{
-			enabled:      true,
-			drainTimeout: 60,
-			isValid:      true,
+			enabled:                   true,
+			drainTimeout:              60,
+			unschedulableWhenCordoned: true,
+			isValid:                   true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		drainer := NodeDrainer{
-			Enabled:      testCase.enabled,
-			DrainTimeout: testCase.drainTimeout,
+			Enabled:                   testCase.enabled,
+			DrainTimeout:              testCase.drainTimeout,
+			UnschedulableWhenCordoned: testCase.unschedulableWhenCordoned,
 		}
 
 		err := drainer.Validate()

--- a/pkg/api/node_drainer_test.go
+++ b/pkg/api/node_drainer_test.go
@@ -36,57 +36,50 @@ func TestDrainTimeoutInSeconds(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	testCases := []struct {
-		enabled                   bool
-		drainTimeout              int
-		isValid                   bool
-		unschedulableWhenCordoned bool
+		enabled      bool
+		drainTimeout int
+		isValid      bool
 	}{
 		// Invalid, drainTimeout is < 1
 		{
-			enabled:                   true,
-			drainTimeout:              0,
-			unschedulableWhenCordoned: true,
-			isValid:                   false,
+			enabled:      true,
+			drainTimeout: 0,
+			isValid:      false,
 		},
 
 		// Invalid, drainTimeout > 60
 		{
-			enabled:                   true,
-			drainTimeout:              61,
-			unschedulableWhenCordoned: true,
-			isValid:                   false,
+			enabled:      true,
+			drainTimeout: 61,
+			isValid:      false,
 		},
 
 		// Valid, disabled
 		{
-			enabled:                   false,
-			drainTimeout:              0,
-			unschedulableWhenCordoned: true,
-			isValid:                   true,
+			enabled:      false,
+			drainTimeout: 0,
+			isValid:      true,
 		},
 
 		// Valid, timeout within boundaries
 		{
-			enabled:                   true,
-			drainTimeout:              1,
-			unschedulableWhenCordoned: true,
-			isValid:                   true,
+			enabled:      true,
+			drainTimeout: 1,
+			isValid:      true,
 		},
 
 		// Valid, timeout within boundaries
 		{
-			enabled:                   true,
-			drainTimeout:              60,
-			unschedulableWhenCordoned: true,
-			isValid:                   true,
+			enabled:      true,
+			drainTimeout: 60,
+			isValid:      true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		drainer := NodeDrainer{
-			Enabled:                   testCase.enabled,
-			DrainTimeout:              testCase.drainTimeout,
-			UnschedulableWhenCordoned: testCase.unschedulableWhenCordoned,
+			Enabled:      testCase.enabled,
+			DrainTimeout: testCase.drainTimeout,
 		}
 
 		err := drainer.Validate()

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -942,7 +942,7 @@ func TestNodeDrainerConfig(t *testing.T) {
 			nodeDrainer: api.NodeDrainer{
 				Enabled:                   false,
 				DrainTimeout:              5,
-				UnschedulableWhenCordoned: true,
+				UnschedulableWhenCordoned: false,
 				IAMRole:                   api.IAMRole{},
 			},
 		},

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -940,9 +940,10 @@ func TestNodeDrainerConfig(t *testing.T) {
 			conf: `
 `,
 			nodeDrainer: api.NodeDrainer{
-				Enabled:      false,
-				DrainTimeout: 5,
-				IAMRole:      api.IAMRole{},
+				Enabled:                   false,
+				DrainTimeout               5,
+				UnschedulableWhenCordoned: true,
+				IAMRole:                   api.IAMRole{},
 			},
 		},
 		{
@@ -954,9 +955,10 @@ experimental:
       arn: arn:aws:iam::0123456789012:role/asg-list-role
 `,
 			nodeDrainer: api.NodeDrainer{
-				Enabled:      true,
-				DrainTimeout: 5,
-				IAMRole:      api.IAMRole{ARN: api.ARN{Arn: "arn:aws:iam::0123456789012:role/asg-list-role"}},
+				Enabled:                   true,
+				DrainTimeout:              5,
+				UnschedulableWhenCordoned: true,
+				IAMRole:                   api.IAMRole{ARN: api.ARN{Arn: "arn:aws:iam::0123456789012:role/asg-list-role"}},
 			},
 		},
 		{
@@ -965,10 +967,12 @@ experimental:
   nodeDrainer:
     enabled: true
     drainTimeout: 3
+    unschedulableWhenCordoned: true
 `,
 			nodeDrainer: api.NodeDrainer{
-				Enabled:      true,
-				DrainTimeout: 3,
+				Enabled:                   true,
+				DrainTimeout:              3,
+				UnschedulableWhenCordoned: true,
 			},
 		},
 	}

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -941,7 +941,7 @@ func TestNodeDrainerConfig(t *testing.T) {
 `,
 			nodeDrainer: api.NodeDrainer{
 				Enabled:                   false,
-				DrainTimeout               5,
+				DrainTimeout:               5,
 				UnschedulableWhenCordoned: true,
 				IAMRole:                   api.IAMRole{},
 			},

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -951,6 +951,7 @@ func TestNodeDrainerConfig(t *testing.T) {
 experimental:
   nodeDrainer:
     enabled: true
+    unschedulableWhenCordoned: true
     iamRole:
       arn: arn:aws:iam::0123456789012:role/asg-list-role
 `,

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -941,7 +941,7 @@ func TestNodeDrainerConfig(t *testing.T) {
 `,
 			nodeDrainer: api.NodeDrainer{
 				Enabled:                   false,
-				DrainTimeout:               5,
+				DrainTimeout:              5,
 				UnschedulableWhenCordoned: true,
 				IAMRole:                   api.IAMRole{},
 			},

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1437,8 +1437,8 @@ worker:
     # Ignored, uses global setting
     nodeDrainer:
       enabled: true
-	  drainTimeout: 5
-	  unschedulableWhenCordoned: true
+      drainTimeout: 5
+      unschedulableWhenCordoned: true
     nodeLabels:
       kube-aws.coreos.com/role: worker
     taints:

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -147,7 +147,7 @@ func TestMainClusterConfig(t *testing.T) {
 			},
 			NodeDrainer: api.NodeDrainer{
 				Enabled:                   false,
-				UnschedulableWhenCordoned: true,
+				UnschedulableWhenCordoned: false,
 				DrainTimeout:              5,
 			},
 		}
@@ -1294,7 +1294,6 @@ experimental:
   nodeDrainer:
     enabled: true
     drainTimeout: 3
-    unschedulableWhenCordoned: true
 cloudWatchLogging:
   enabled: true
 amazonSsmAgent:
@@ -1384,9 +1383,8 @@ worker:
 							GroupsClaim:   "groups",
 						},
 						NodeDrainer: api.NodeDrainer{
-							Enabled:                   true,
-							DrainTimeout:              3,
-							UnschedulableWhenCordoned: true,
+							Enabled:      true,
+							DrainTimeout: 3,
 						},
 					}
 
@@ -1483,7 +1481,7 @@ worker:
 						NodeDrainer: api.NodeDrainer{
 							Enabled:                   false,
 							DrainTimeout:              0,
-							UnschedulableWhenCordoned: true,
+							UnschedulableWhenCordoned: false,
 						},
 					}
 					p := c.NodePools[0]
@@ -3698,7 +3696,6 @@ experimental:
   nodeDrainer:
     enabled: true
     drainTimeout: 100
-    unschedulableWhenCordoned: true
 `,
 			expectedErrorMessage: "Drain timeout must be an integer between 1 and 60, but was 100",
 		},

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -146,8 +146,9 @@ func TestMainClusterConfig(t *testing.T) {
 				GroupsClaim:   "groups",
 			},
 			NodeDrainer: api.NodeDrainer{
-				Enabled:      false,
-				DrainTimeout: 5,
+				Enabled:                   false,
+				unschedulableWhenCordoned: true,
+				DrainTimeout:              5,
 			},
 		}
 
@@ -1436,7 +1437,8 @@ worker:
     # Ignored, uses global setting
     nodeDrainer:
       enabled: true
-      drainTimeout: 5
+	  drainTimeout: 5
+	  unschedulableWhenCordoned: true
     nodeLabels:
       kube-aws.coreos.com/role: worker
     taints:

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -147,7 +147,7 @@ func TestMainClusterConfig(t *testing.T) {
 			},
 			NodeDrainer: api.NodeDrainer{
 				Enabled:                   false,
-				unschedulableWhenCordoned: true,
+				UnschedulableWhenCordoned: true,
 				DrainTimeout:              5,
 			},
 		}

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1294,6 +1294,7 @@ experimental:
   nodeDrainer:
     enabled: true
     drainTimeout: 3
+    unschedulableWhenCordoned: true
 cloudWatchLogging:
   enabled: true
 amazonSsmAgent:
@@ -1383,8 +1384,9 @@ worker:
 							GroupsClaim:   "groups",
 						},
 						NodeDrainer: api.NodeDrainer{
-							Enabled:      true,
-							DrainTimeout: 3,
+							Enabled:                   true,
+							DrainTimeout:              3,
+							UnschedulableWhenCordoned: true,
 						},
 					}
 
@@ -1479,8 +1481,9 @@ worker:
 							SecurityGroupIds: []string{"sg-12345678"},
 						},
 						NodeDrainer: api.NodeDrainer{
-							Enabled:      false,
-							DrainTimeout: 0,
+							Enabled:                   false,
+							DrainTimeout:              0,
+							UnschedulableWhenCordoned: true,
 						},
 					}
 					p := c.NodePools[0]
@@ -3695,6 +3698,7 @@ experimental:
   nodeDrainer:
     enabled: true
     drainTimeout: 100
+    unschedulableWhenCordoned: true
 `,
 			expectedErrorMessage: "Drain timeout must be an integer between 1 and 60, but was 100",
 		},


### PR DESCRIPTION
As title says.

Its seems that if a node takes longer to drain than 300s set here the node drainer pod will try reschedule itself onto the node. This causes it to be in a restart loop until the node drains and goes offline, which makes our alerts pretty noisy!

Since a cordoned node is given the label node.kubernetes.io/unschedulable, this gives the user the option to make the daemonset respect this