### PR TITLE
[v0.14.x] Toleration to prevent node drainer scheduling on cordoned nodes

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1495,7 +1495,7 @@ experimental:
     
     # Prevents the nodeDrainer from scheduling on nodes that have been cordoned.
     # This happens if a nodes take more than the alloted time to drain
-    unschedulableWhenCordoned: true
+    # unschedulableWhenCordoned: true
 
   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
   # For using Dex as a custom OIDC provider, please check "contrib/dex/README.md".

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1492,6 +1492,10 @@ experimental:
     iamRole:
       # Empty, inactive by default. Set it to valid ARN "arn: arn:aws:iam::0123456789012:role/roleName" to activate.
       arn: ""
+    
+    # Prevents the nodeDrainer from scheduling on nodes that have been cordoned.
+    # This happens if a nodes take more than the alloted time to drain
+    unschedulableWhenCordoned: true
 
   # Configure OpenID Connect token authenticator plugin in Kubernetes API server.
   # For using Dex as a custom OIDC provider, please check "contrib/dex/README.md".

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2770,7 +2770,7 @@ write_files:
                 effect: NoExecute
               - operator: Exists
                 key: CriticalAddonsOnly
-            {{ if .nodeDrainer.unschedulableWhenCordoned }}
+            {{ if .Experimental.NodeDrainer.UnschedulableWhenCordoned }}
               - key: node.kubernetes.io/unschedulable
                 effect: NoSchedule
             {{ end }}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2770,6 +2770,10 @@ write_files:
                 effect: NoExecute
               - operator: Exists
                 key: CriticalAddonsOnly
+            {{ if .nodeDrainer.unschedulableWhenCordoned }}
+              - key: node.kubernetes.io/unschedulable
+                effect: NoSchedule
+            {{ end }}
               initContainers:
                 - name: hyperkube
                   image: {{.HyperkubeImage.RepoWithTag}}

--- a/pkg/api/node_drainer.go
+++ b/pkg/api/node_drainer.go
@@ -6,9 +6,10 @@ import (
 )
 
 type NodeDrainer struct {
-	Enabled      bool    `yaml:"enabled"`
-	DrainTimeout int     `yaml:"drainTimeout"`
-	IAMRole      IAMRole `yaml:"iamRole,omitempty"`
+	Enabled                   bool    `yaml:"enabled"`
+	DrainTimeout              int     `yaml:"drainTimeout"`
+	UnschedulableWhenCordoned bool    `yaml:"unschedulableWhenCordoned,omitempty"`
+	IAMRole                   IAMRole `yaml:"iamRole,omitempty"`
 }
 
 func (nd *NodeDrainer) DrainTimeoutInSeconds() int {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -940,9 +940,10 @@ func TestNodeDrainerConfig(t *testing.T) {
 			conf: `
 `,
 			nodeDrainer: api.NodeDrainer{
-				Enabled:      false,
-				DrainTimeout: 5,
-				IAMRole:      api.IAMRole{},
+				Enabled:                   false,
+				DrainTimeout:              5,
+				UnschedulableWhenCordoned: false,
+				IAMRole:                   api.IAMRole{},
 			},
 		},
 		{
@@ -950,13 +951,16 @@ func TestNodeDrainerConfig(t *testing.T) {
 experimental:
   nodeDrainer:
     enabled: true
+    unschedulableWhenCordoned: true
     iamRole:
       arn: arn:aws:iam::0123456789012:role/asg-list-role
 `,
 			nodeDrainer: api.NodeDrainer{
-				Enabled:      true,
-				DrainTimeout: 5,
-				IAMRole:      api.IAMRole{ARN: api.ARN{Arn: "arn:aws:iam::0123456789012:role/asg-list-role"}},
+				Enabled:                   true,
+				DrainTimeout:              5,
+				UnschedulableWhenCordoned: true,
+				IAMRole:                   api.IAMRole{ARN: api.ARN{Arn: "arn:aws:iam::0123456789012:role/asg-list-role"}},
+
 			},
 		},
 		{
@@ -964,11 +968,13 @@ experimental:
 experimental:
   nodeDrainer:
     enabled: true
+    unschedulableWhenCordoned: true
     drainTimeout: 3
 `,
 			nodeDrainer: api.NodeDrainer{
-				Enabled:      true,
-				DrainTimeout: 3,
+				Enabled:                   true,
+				DrainTimeout:              3,
+				UnschedulableWhenCordoned: true,
 			},
 		},
 	}

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -960,7 +960,6 @@ experimental:
 				DrainTimeout:              5,
 				UnschedulableWhenCordoned: true,
 				IAMRole:                   api.IAMRole{ARN: api.ARN{Arn: "arn:aws:iam::0123456789012:role/asg-list-role"}},
-
 			},
 		},
 		{

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -146,8 +146,9 @@ func TestMainClusterConfig(t *testing.T) {
 				GroupsClaim:   "groups",
 			},
 			NodeDrainer: api.NodeDrainer{
-				Enabled:      false,
-				DrainTimeout: 5,
+				Enabled:                   false,
+				UnschedulableWhenCordoned: false,
+				DrainTimeout:              5,
 			},
 		}
 
@@ -1437,6 +1438,7 @@ worker:
     nodeDrainer:
       enabled: true
       drainTimeout: 5
+      unschedulableWhenCordoned: true
     nodeLabels:
       kube-aws.coreos.com/role: worker
     taints:
@@ -1477,8 +1479,9 @@ worker:
 							SecurityGroupIds: []string{"sg-12345678"},
 						},
 						NodeDrainer: api.NodeDrainer{
-							Enabled:      false,
-							DrainTimeout: 0,
+							Enabled:                   false,
+							DrainTimeout:              0,
+							UnschedulableWhenCordoned: false,
 						},
 					}
 					p := c.NodePools[0]


### PR DESCRIPTION
As title says.

Its seems that if a node takes longer to drain than 300s set here the node drainer pod will try reschedule itself onto the node. This causes it to be in a restart loop until the node drains and goes offline, which makes our alerts pretty noisy!

Since a cordoned node is given the label node.kubernetes.io/unschedulable, this gives the user the option to make the daemonset respect this