### PR TITLE
[v0.13.x] Allow CoreDNS resources to be configured

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1328,7 +1328,7 @@ kubeDns:
   provider: coredns
   
   # Defines resources for the CoreDNS Deployment. Ignored if using kubedns.
-  # coreDnsResources:
+  # dnsDeploymentResources:
   #   requests:
   #     cpu: "100m"
   #     memory: "70Mi"

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1326,6 +1326,15 @@ kubernetesDashboard:
 kubeDns:
   # Define which DNS provider to use (kube-dns or coredns), default coredns.
   provider: coredns
+  
+  # Defines resources for the CoreDNS Deployment. Ignored if using kubedns.
+  # coreDnsResources:
+  #   requests:
+  #     cpu: "100m"
+  #     memory: "70Mi"
+  #   limits:
+  #     cpu: "200m"
+  #     memory: "170Mi"
 
   # When enabled, will enable a DNS-masq DaemonSet to make PODs to resolve DNS names via locally running dnsmasq
   # It is disabled by default.
@@ -1350,7 +1359,7 @@ kubeDns:
     coresPerReplica: 256
     nodesPerReplica: 16
     min: 2
-
+    
 kubeProxy:
   # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.9.0+ to work reliably)
   # This is intended to address performance issues of iptables mode for clusters with big number of nodes and services

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4077,10 +4077,11 @@ write_files:
                 imagePullPolicy: IfNotPresent
                 resources:
                   limits:
-                    memory: 170Mi
+                    cpu: {{ .KubeDns.CoreDNSResources.Requests.Cpu }}
+                    memory: {{ .KubeDns.CoreDNSResources.Requests.Memory }}
                   requests:
-                    cpu: 100m
-                    memory: 70Mi
+                    cpu: {{ .KubeDns.CoreDNSResources.Limits.Cpu }}
+                    memory: {{ .KubeDns.CoreDNSResources.Limits.Cpu }}
                 args: [ "-conf", "/etc/coredns/Corefile" ]
                 volumeMounts:
                 - name: config-volume

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4077,11 +4077,11 @@ write_files:
                 imagePullPolicy: IfNotPresent
                 resources:
                   limits:
-                    cpu: {{ .KubeDns.CoreDNSResources.Limits.Cpu }}
-                    memory: {{ .KubeDns.CoreDNSResources.Limits.Memory }}
+                    cpu: {{ .KubeDns.DnsDeploymentResources.Limits.Cpu }}
+                    memory: {{ .KubeDns.DnsDeploymentResources.Limits.Memory }}
                   requests:
-                    cpu: {{ .KubeDns.CoreDNSResources.Requests.Cpu }}
-                    memory: {{ .KubeDns.CoreDNSResources.Requests.Memory }}
+                    cpu: {{ .KubeDns.DnsDeploymentResources.Requests.Cpu }}
+                    memory: {{ .KubeDns.DnsDeploymentResources.Requests.Memory }}
                 args: [ "-conf", "/etc/coredns/Corefile" ]
                 volumeMounts:
                 - name: config-volume
@@ -4181,10 +4181,11 @@ write_files:
                 image: {{ .KubeDnsImage.RepoWithTag }}
                 resources:
                   limits:
-                    memory: 170Mi
+                    cpu: {{ .KubeDns.DnsDeploymentResources.Limits.Cpu }}
+                    memory: {{ .KubeDns.DnsDeploymentResources.Limits.Memory }}
                   requests:
-                    cpu: 100m
-                    memory: 70Mi
+                    cpu: {{ .KubeDns.DnsDeploymentResources.Requests.Cpu }}
+                    memory: {{ .KubeDns.DnsDeploymentResources.Requests.Memory }}
                 livenessProbe:
                   httpGet:
                     path: /healthcheck/kubedns

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4077,11 +4077,11 @@ write_files:
                 imagePullPolicy: IfNotPresent
                 resources:
                   limits:
+                    cpu: {{ .KubeDns.CoreDNSResources.Limits.Cpu }}
+                    memory: {{ .KubeDns.CoreDNSResources.Limits.Memory }}
+                  requests:
                     cpu: {{ .KubeDns.CoreDNSResources.Requests.Cpu }}
                     memory: {{ .KubeDns.CoreDNSResources.Requests.Memory }}
-                  requests:
-                    cpu: {{ .KubeDns.CoreDNSResources.Limits.Cpu }}
-                    memory: {{ .KubeDns.CoreDNSResources.Limits.Cpu }}
                 args: [ "-conf", "/etc/coredns/Corefile" ]
                 volumeMounts:
                 - name: config-volume

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -171,6 +171,16 @@ func NewDefaultCluster() *Cluster {
 					NodesPerReplica: 16,
 					Min:             2,
 				},
+				CoreDNSResources: ComputeResources{
+					Requests: ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
 			},
 			KubeSystemNamespaceLabels: make(map[string]string),
 			KubernetesDashboard: KubernetesDashboard{

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -171,7 +171,7 @@ func NewDefaultCluster() *Cluster {
 					NodesPerReplica: 16,
 					Min:             2,
 				},
-				CoreDNSResources: ComputeResources{
+				DnsDeploymentResources: ComputeResources{
 					Requests: ResourceQuota{
 						Memory: "70Mi",
 						Cpu:    "100m",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -218,6 +218,7 @@ type KubeDns struct {
 	AntiAffinityAvailabilityZone bool              `yaml:"antiAffinityAvailabilityZone"`
 	TTL                          int               `yaml:"ttl"`
 	Autoscaler                   KubeDnsAutoscaler `yaml:"autoscaler"`
+	CoreDNSResources             ComputeResources  `yaml:"coreDnsResources,omitempty"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -218,7 +218,7 @@ type KubeDns struct {
 	AntiAffinityAvailabilityZone bool              `yaml:"antiAffinityAvailabilityZone"`
 	TTL                          int               `yaml:"ttl"`
 	Autoscaler                   KubeDnsAutoscaler `yaml:"autoscaler"`
-	CoreDNSResources             ComputeResources  `yaml:"coreDnsResources,omitempty"`
+	DnsDeploymentResources       ComputeResources  `yaml:"dnsDeploymentResources,omitempty"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1158,6 +1158,16 @@ kubeDns:
 					NodesPerReplica: 16,
 					Min:             2,
 				},
+				CoreDNSResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
 			},
 		},
 		{
@@ -1176,6 +1186,16 @@ kubeDns:
 					CoresPerReplica: 256,
 					NodesPerReplica: 16,
 					Min:             2,
+				},
+				CoreDNSResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
 				},
 			},
 		},

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1129,7 +1129,7 @@ func TestKubeDns(t *testing.T) {
 					NodesPerReplica: 16,
 					Min:             2,
 				},
-				CoreDNSResources: api.ComputeResources{
+				DnsDeploymentResources: api.ComputeResources{
 					Requests: api.ResourceQuota{
 						Memory: "70Mi",
 						Cpu:    "100m",
@@ -1158,7 +1158,7 @@ kubeDns:
 					NodesPerReplica: 16,
 					Min:             2,
 				},
-				CoreDNSResources: api.ComputeResources{
+				DnsDeploymentResources: api.ComputeResources{
 					Requests: api.ResourceQuota{
 						Memory: "70Mi",
 						Cpu:    "100m",
@@ -1187,7 +1187,7 @@ kubeDns:
 					NodesPerReplica: 16,
 					Min:             2,
 				},
-				CoreDNSResources: api.ComputeResources{
+				DnsDeploymentResources: api.ComputeResources{
 					Requests: api.ResourceQuota{
 						Memory: "70Mi",
 						Cpu:    "100m",
@@ -1216,7 +1216,7 @@ kubeDns:
 					NodesPerReplica: 16,
 					Min:             2,
 				},
-				CoreDNSResources: api.ComputeResources{
+				DnsDeploymentResources: api.ComputeResources{
 					Requests: api.ResourceQuota{
 						Memory: "70Mi",
 						Cpu:    "100m",
@@ -1249,7 +1249,7 @@ kubeDns:
 					NodesPerReplica: 10,
 					Min:             15,
 				},
-				CoreDNSResources: api.ComputeResources{
+				DnsDeploymentResources: api.ComputeResources{
 					Requests: api.ResourceQuota{
 						Memory: "70Mi",
 						Cpu:    "100m",
@@ -1277,7 +1277,7 @@ kubeDns:
 					NodesPerReplica: 16,
 					Min:             2,
 				},
-				CoreDNSResources: api.ComputeResources{
+				DnsDeploymentResources: api.ComputeResources{
 					Requests: api.ResourceQuota{
 						Memory: "70Mi",
 						Cpu:    "100m",
@@ -1293,7 +1293,7 @@ kubeDns:
 			conf: `
 kubeDns:
   provider: coredns
-  coreDnsResources:
+  dnsDeploymentResources:
     requests:
       cpu: "250m"
       memory: "250Mi"
@@ -1311,7 +1311,7 @@ kubeDns:
 					NodesPerReplica: 16,
 					Min:             2,
 				},
-				CoreDNSResources: api.ComputeResources{
+				DnsDeploymentResources: api.ComputeResources{
 					Requests: api.ResourceQuota{
 						Memory: "250Mi",
 						Cpu:    "250m",
@@ -1340,7 +1340,7 @@ kubeDns:
 					NodesPerReplica: 16,
 					Min:             2,
 				},
-				CoreDNSResources: api.ComputeResources{
+				DnsDeploymentResources: api.ComputeResources{
 					Requests: api.ResourceQuota{
 						Memory: "70Mi",
 						Cpu:    "100m",

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1129,6 +1129,16 @@ func TestKubeDns(t *testing.T) {
 					NodesPerReplica: 16,
 					Min:             2,
 				},
+				CoreDNSResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
 			},
 		},
 		{
@@ -1186,6 +1196,16 @@ kubeDns:
 					NodesPerReplica: 16,
 					Min:             2,
 				},
+				CoreDNSResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
 			},
 		},
 		{
@@ -1209,6 +1229,16 @@ kubeDns:
 					NodesPerReplica: 10,
 					Min:             15,
 				},
+				CoreDNSResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
 			},
 		},
 		{
@@ -1226,6 +1256,50 @@ kubeDns:
 					CoresPerReplica: 256,
 					NodesPerReplica: 16,
 					Min:             2,
+				},
+				CoreDNSResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
+			},
+		},
+		{
+			conf: `
+kubeDns:
+  provider: coredns
+  coreDnsResources:
+    requests:
+      cpu: "250m"
+      memory: "250Mi"
+    limits:
+      cpu: "500m"
+      memory: "250Mi"
+`,
+			kubeDns: api.KubeDns{
+				Provider:            "coredns",
+				NodeLocalResolver:   false,
+				DeployToControllers: false,
+				TTL:                 30,
+				Autoscaler: api.KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+				CoreDNSResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "250Mi",
+						Cpu:    "250m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "250Mi",
+						Cpu:    "500m",
+					},
 				},
 			},
 		},
@@ -1245,6 +1319,16 @@ kubeDns:
 					CoresPerReplica: 256,
 					NodesPerReplica: 16,
 					Min:             2,
+				},
+				CoreDNSResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Changes

- Allows CoreDNS resources to be configured through `cluster.yaml`.