### PR TITLE
Referencing the drainTimeout value in the NodeDrainer daemonset 

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2831,8 +2831,8 @@ write_files:
                         asg complete-lifecycle-action --lifecycle-action-result CONTINUE --instance-id "${INSTANCE_ID}" --lifecycle-hook-name "${HOOK_NAME}" --auto-scaling-group-name "${ASG_NAME}"
                       fi
 
-                      # Expect instance will be shut down in 5 minutes
-                      sleep 300
+                      # Expect instance will be shut down in defined drain timeout
+                      sleep {{.Experimental.NodeDrainer.DrainTimeoutInSeconds}}
                     done
                   volumeMounts:
                   - mountPath: /opt/bin


### PR DESCRIPTION
In a previous PR (#1722) I had attempted to stop node drainer scheduling on cordoned nodes once the timeout had elapsed (300s/5m). This is beneficial to me as otherwise nodeDrainer tries to redeploy itself onto the node after the 5 minutes have elapsed, and goes into a restart loop as kubelet is preventing things from being scheduled. When this happens our alerts go off.

This proved more difficult than planned, and I can not think of any other way to do so than placing a taint on all nodes that the daemonset does not have a toleration for. This is IMO not feasible and way too heavyweight. 

We already have drainTimeout specified [here in cluster.yml](https://github.com/kubernetes-incubator/kube-aws/blob/9fe0077b7fd08e2df7462512caf1ce4024dd4bcc/builtin/files/cluster.yaml.tmpl#L1467) so it makes sense to use this value in the drain command also. This way I can increase the timeout allowing the node to drain and terminate within the allotted time. 