### PR TITLE
kube2iam resources improvement

### DIFF
--- a/builtin/files/plugins/kube2iam/manifests/daemonset.yaml
+++ b/builtin/files/plugins/kube2iam/manifests/daemonset.yaml
@@ -54,10 +54,9 @@ spec:
               name: http
           resources:
             limits:
-              cpu: 10m
-              memory: 32Mi
+              memory: 128Mi
             requests:
-              cpu: 10m
-              memory: 32Mi
+              cpu: 100m
+              memory: 64Mi
           securityContext:
             privileged: true


### PR DESCRIPTION
After 2y running this we faced some issues with the default kube2iam resources values.

CPU limits cause applications to run up to 100% slower, in this case can end in race conditions while touching the ip tables and also in timeouts.
Default CPU requests and memory are not enough for +50 nodes.  
You can run the next query in prometheus to see if your kube2iam instances are throttling:
```
 100
  * sum by(container, pod, namespace) (increase(container_cpu_cfs_throttled_periods_total{container!=""}[5m]))
  / sum by(container, pod, namespace) (increase(container_cpu_cfs_periods_total[5m]))
  > 25
```