### PR TITLE
[v0.14.x] Allow resource configuration for APIServer

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1179,13 +1179,25 @@ kubernetes:
     enabled: false
 
 #  controllerManager:
+#   resources:
+#     requests:
+#       cpu: 100m
+#       memory: 100Mi
+#     limits:
+#       cpu: 250m
+#       memory: 512Mi
+
+#  apiServer:
+#    # Memory limit for apiserver in MB (used to configure sizes of etcd caches, etc.)
+#    targetRamMb: 320Mi
+#    # Resource limits for the apiserver.
 #    resources:
 #      requests:
-#        cpu: 100m
-#        memory: 100M
+#        cpu: 256m
+#        memory: 256Mi
 #      limits:
-#        cpu: 250m
-#        memory: 512M
+#        cpu: 1024m
+#        memory: 2048Mi
 
 # Kubernetes Self-hosted networking daemonsets
 # Choose either 'canal' (calico+flannel) or 'flannel'

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1189,7 +1189,7 @@ kubernetes:
 
 #  apiServer:
 #    # Memory limit for apiserver in MB (used to configure sizes of etcd caches, etc.)
-#    targetRamMb: 4096Mi
+#    targetRamMb: 4096
 #    # Resource limits for the apiserver.
 #    resources:
 #      requests:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3397,9 +3397,9 @@ write_files:
           - --enable-bootstrap-token-auth=true
           - --token-auth-file=/etc/kubernetes/auth/tokens.csv
           - --storage-backend=etcd3
-          {{- if .Kubernetes.KubeApiServer.TargetRamMb -}}
+          {{ if .Kubernetes.KubeApiServer.TargetRamMb -}}
           - --target-ram-mb={{.Kubernetes.KubeApiServer.TargetRamMb}}
-          {{- end}}
+          {{ end -}}
           - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
           {{if .Experimental.AuditLog.Enabled}}
           - --audit-log-maxage={{.Experimental.AuditLog.MaxAge}}
@@ -3451,27 +3451,27 @@ write_files:
           {{range $f := .APIServerFlags}}
           - --{{$f.Name}}={{$f.Value}}
           {{ end -}}
-          {{- if .Kubernetes.KubeApiServer.ComputeResources -}}
+          {{ if .Kubernetes.KubeApiServer.ComputeResources -}}
           resources:
-            {{- if .Kubernetes.KubeApiServer.ComputeResources.Requests -}}
+            {{ if .Kubernetes.KubeApiServer.ComputeResources.Requests -}}
             requests:
-              {{- if .Kubernetes.KubeApiServer.ComputeResources.Requests.Cpu -}}
+              {{ if .Kubernetes.KubeApiServer.ComputeResources.Requests.Cpu -}}
               cpu: {{.Kubernetes.KubeApiServer.ComputeResources.Requests.Cpu }}
-              {{- end }}
-              {{- if .Kubernetes.KubeApiServer.ComputeResources.Requests.Memory -}}
+              {{ end -}}
+              {{ if .Kubernetes.KubeApiServer.ComputeResources.Requests.Memory -}}
               memory: {{.Kubernetes.KubeApiServer.ComputeResources.Requests.Memory }}
-              {{- end }}
-            {{- end }}
-            {{- if .Kubernetes.KubeApiServer.ComputeResources.Limits -}}
+              {{ end -}}
+            {{ end -}}
+            {{ if .Kubernetes.KubeApiServer.ComputeResources.Limits -}}
             limits:
-              {{- if .Kubernetes.KubeApiServer.ComputeResources.Limits.Cpu -}}
+              {{ if .Kubernetes.KubeApiServer.ComputeResources.Limits.Cpu -}}
               cpu: {{.Kubernetes.KubeApiServer.ComputeResources.Limits.Cpu }}
-              {{- end }}
+              {{ end -}}
               {{- if .Kubernetes.KubeApiServer.ComputeResources.Limits.Memory -}}
               memory: {{.Kubernetes.KubeApiServer.ComputeResources.Limits.Memory }}
-              {{- end }}
-            {{- end }}
-          {{- end }}
+              {{ end -}}
+            {{ end -}}
+          {{ end -}}
           livenessProbe:
             tcpSocket:
               port: 443

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3461,7 +3461,7 @@ write_files:
               {{ if .Kubernetes.KubeApiServer.ComputeResources.Requests.Memory -}}
               memory: {{.Kubernetes.KubeApiServer.ComputeResources.Requests.Memory }}
               {{ end -}}
-            {{ end -}}
+            {{ end }}
             {{ if .Kubernetes.KubeApiServer.ComputeResources.Limits -}}
             limits:
               {{ if .Kubernetes.KubeApiServer.ComputeResources.Limits.Cpu -}}
@@ -3470,8 +3470,8 @@ write_files:
               {{- if .Kubernetes.KubeApiServer.ComputeResources.Limits.Memory -}}
               memory: {{.Kubernetes.KubeApiServer.ComputeResources.Limits.Memory }}
               {{ end -}}
-            {{ end -}}
-          {{ end -}}
+            {{ end }}
+          {{ end }}
           livenessProbe:
             tcpSocket:
               port: 443

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3397,6 +3397,9 @@ write_files:
           - --enable-bootstrap-token-auth=true
           - --token-auth-file=/etc/kubernetes/auth/tokens.csv
           - --storage-backend=etcd3
+          {{- if .Kubernetes.KubeApiServer.TargetRamMb -}}
+          - --target-ram-mb={{.Kubernetes.KubeApiServer.TargetRamMb}}
+          {{- end}}
           - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
           {{if .Experimental.AuditLog.Enabled}}
           - --audit-log-maxage={{.Experimental.AuditLog.MaxAge}}
@@ -3448,6 +3451,27 @@ write_files:
           {{range $f := .APIServerFlags}}
           - --{{$f.Name}}={{$f.Value}}
           {{ end -}}
+          {{- if .Kubernetes.KubeApiServer.ComputeResources -}}
+          resources:
+            {{- if .Kubernetes.KubeApiServer.ComputeResources.Requests -}}
+            requests:
+              {{- if .Kubernetes.KubeApiServer.ComputeResources.Requests.Cpu -}}
+              cpu: {{.Kubernetes.KubeApiServer.ComputeResources.Requests.Cpu }}
+              {{- end }}
+              {{- if .Kubernetes.KubeApiServer.ComputeResources.Requests.Memory -}}
+              memory: {{.Kubernetes.KubeApiServer.ComputeResources.Requests.Memory }}
+              {{- end }}
+            {{- end }}
+            {{- if .Kubernetes.KubeApiServer.ComputeResources.Limits -}}
+            limits:
+              {{- if .Kubernetes.KubeApiServer.ComputeResources.Limits.Cpu -}}
+              cpu: {{.Kubernetes.KubeApiServer.ComputeResources.Limits.Cpu }}
+              {{- end }}
+              {{- if .Kubernetes.KubeApiServer.ComputeResources.Limits.Memory -}}
+              memory: {{.Kubernetes.KubeApiServer.ComputeResources.Limits.Memory }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
           livenessProbe:
             tcpSocket:
               port: 443

--- a/pkg/api/kubernetes.go
+++ b/pkg/api/kubernetes.go
@@ -7,12 +7,18 @@ type Kubernetes struct {
 	ControllerManager ControllerManager        `yaml:"controllerManager,omitempty"`
 	KubeScheduler     KubeScheduler            `yaml:"kubeScheduler,omitempty"`
 	KubeProxy         KubeProxy                `yaml:"kubeProxy,omitempty"`
+	KubeApiServer     KubeApiServer            `yaml:"apiServer,omitempty"`
 	Kubelet           Kubelet                  `yaml:"kubelet,omitempty"`
 	APIServer         KubernetesAPIServer      `yaml:"apiserver,omitempty"`
 
 	// Manifests is a list of manifests to be installed to the cluster.
 	// Note that the list is sorted by their names by kube-aws so that it won't result in unnecessarily node replacements.
 	Manifests KubernetesManifests `yaml:"manifests,omitempty"`
+}
+
+type KubeApiServer struct {
+	ComputeResources ComputeResources `yaml:"resources,omitempty"`
+	TargetRamMb      string           `yaml:"targetRamMb,omitempty"`
 }
 
 type ControllerManager struct {

--- a/pkg/api/kubernetes.go
+++ b/pkg/api/kubernetes.go
@@ -18,7 +18,7 @@ type Kubernetes struct {
 
 type KubeApiServer struct {
 	ComputeResources ComputeResources `yaml:"resources,omitempty"`
-	TargetRamMb      string           `yaml:"targetRamMb,omitempty"`
+	TargetRamMb      int              `yaml:"targetRamMb,omitempty"`
 }
 
 type ControllerManager struct {


### PR DESCRIPTION
## Changes

- Allows resource configuration for pod deployment.
- Allows configuration for `targetRamMb` to limit size of watch cache.