### PR TITLE
[0.13.x] Networking Version Updates

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1205,10 +1205,10 @@ kubernetes:
 #          memory: "200Mi"
 #      calicoNodeImage:
 #        repo: quay.io/calico/node
-#        tag: v3.1.3
+#        tag: v3.6.3
 #      calicoCniImage:
 #        repo: quay.io/calico/cni
-#        tag: v3.1.3
+#        tag: v3.6.3
 #      flannelImage:
 #        repo: quay.io/coreos/flannel
 #        tag: v0.9.1
@@ -1217,7 +1217,7 @@ kubernetes:
 #        tag: v0.3.0
 #      typhaImage:
 #        repo: quay.io/calico/typha
-#        tag: v0.7.4
+#        tag: v3.6.3
 
 # Create MountTargets to subnets managed by kube-aws for a pre-existing Elastic File System (Amazon EFS),
 # and then mount to every node.

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -20,11 +20,11 @@ var KUBERNETES_VERSION = "v99.99"
 
 const (
 	// Experimental SelfHosting feature default images.
-	kubeNetworkingSelfHostingDefaultCalicoNodeImageTag = "v3.6.1"
-	kubeNetworkingSelfHostingDefaultCalicoCniImageTag  = "v3.6.1"
+	kubeNetworkingSelfHostingDefaultCalicoNodeImageTag = "v3.6.3"
+	kubeNetworkingSelfHostingDefaultCalicoCniImageTag  = "v3.6.3"
 	kubeNetworkingSelfHostingDefaultFlannelImageTag    = "v0.11.0"
 	kubeNetworkingSelfHostingDefaultFlannelCniImageTag = "v0.3.0"
-	kubeNetworkingSelfHostingDefaultTyphaImageTag      = "v3.6.1"
+	kubeNetworkingSelfHostingDefaultTyphaImageTag      = "v3.6.3"
 )
 
 func NewDefaultCluster() *Cluster {


### PR DESCRIPTION
## Reasoning

This updates the versions of the networking components to their latest. There is actually a bug in Typha version `3.6.1` and Callico Node `3.6.1` which can end up causing service disruption if there is a problem with the Kubernetes apiserver.

If Typha is under stress it attempts to write a glog message to a mounted `tmp` dir, or at least that’s the expected behaviour of release 3.6.1.

However, if that `tmp` dir does not exist (it does not in kube-aws) then Typha bombs out ( https://github.com/projectcalico/typha/issues/196) and causes network connectivity to drop.

## Changes

- Bumps patch version of networking components from `.1` to `.3` so fix for `tmp` dir issue is resolved.