### PR TITLE
[v0.14.x] Allow extra Coredns configuration

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1371,7 +1371,10 @@ kubeDns:
     coresPerReplica: 256
     nodesPerReplica: 16
     min: 2
-    
+  # Allows to add extra configuration into CoreDNS config map
+  # extraCoreDNSConfig: |
+  #   rewrite name substring demo.app.org app.default.svc.cluster.local
+
 kubeProxy:
   # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.9.0+ to work reliably)
   # This is intended to address performance issues of iptables mode for clusters with big number of nodes and services

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3847,6 +3847,9 @@ write_files:
                     except cluster.local
                     health_check 5s
                 }
+                {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.ExtraCoreDNSConfig }}
+                {{ .KubeDns.ExtraCoreDNSConfig }}
+                {{- end }}
                 prometheus :9153
                 cache {{ .KubeDns.TTL }}
                 loop

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -843,7 +843,7 @@ func (cl *Cluster) ValidateStack(opts ...OperationTargets) (string, error) {
 func streamJournaldLogs(c *Cluster, q chan struct{}) error {
 	logger.Infof("Streaming filtered Journald logs for log group '%s'...\nNOTE: Due to high initial entropy, '.service' failures may occur during the early stages of booting.\n", c.controlPlaneStack.ClusterName)
 	cwlSvc := cloudwatchlogs.New(c.session)
-	s := time.Now().Unix() * 1E3
+	s := time.Now().Unix() * 1e3
 	t := s
 	in := cloudwatchlogs.FilterLogEventsInput{
 		LogGroupName:  &c.controlPlaneStack.ClusterName,
@@ -867,7 +867,7 @@ func streamJournaldLogs(c *Cluster, q chan struct{}) error {
 						ms[*event.Message] = *event.Timestamp
 						res := api.SystemdMessageResponse{}
 						json.Unmarshal([]byte(*event.Message), &res)
-						s := int(((*event.Timestamp) - t) / 1E3)
+						s := int(((*event.Timestamp) - t) / 1e3)
 						d := fmt.Sprintf("+%.2d:%.2d:%.2d", s/3600, (s/60)%60, s%60)
 						logger.Infof("%s\t%s: \"%s\"\n", d, res.Hostname, res.Message)
 					}

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -181,6 +181,7 @@ func NewDefaultCluster() *Cluster {
 						Cpu:    "200m",
 					},
 				},
+				ExtraCoreDNSConfig: "",
 			},
 			KubeSystemNamespaceLabels: make(map[string]string),
 			KubernetesDashboard: KubernetesDashboard{

--- a/pkg/api/node_volume_mount_test.go
+++ b/pkg/api/node_volume_mount_test.go
@@ -54,7 +54,7 @@ func TestVolumeMountValidate(t *testing.T) {
 		t.Errorf("validate should return a 'iops' error for using an invalid 'iops' value (%d)", c6.Iops)
 	}
 
-	c7 := NodeVolumeMount{"io1", 1E9, 100, "/dev/xvdf", "xfs", "/ebs", false}
+	c7 := NodeVolumeMount{"io1", 1e9, 100, "/dev/xvdf", "xfs", "/ebs", false}
 	if c7.Validate() == nil {
 		t.Errorf("validate should return a 'size' error for using an invalid 'size' value (%d)", c7.Iops)
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -219,6 +219,7 @@ type KubeDns struct {
 	TTL                          int               `yaml:"ttl"`
 	Autoscaler                   KubeDnsAutoscaler `yaml:"autoscaler"`
 	DnsDeploymentResources       ComputeResources  `yaml:"dnsDeploymentResources,omitempty"`
+	ExtraCoreDNSConfig           string            `yaml:"extraCoreDNSConfig"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1352,6 +1352,36 @@ kubeDns:
 				},
 			},
 		},
+		{
+			conf: `
+kubeDns:
+  provider: coredns
+  extraCoreDNSConfig: rewrite name substring demo.app.org app.default.svc.cluster.local
+`,
+			kubeDns: api.KubeDns{
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
+				Autoscaler: api.KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+				DnsDeploymentResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
+				ExtraCoreDNSConfig: "rewrite name substring demo.app.org app.default.svc.cluster.local",
+			},
+		},
 	}
 
 	for _, conf := range validConfigs {


### PR DESCRIPTION
When touching the coredns configmap a cluster upgrade will overwrite the changes. This PR introduces a way to configure the changes inside the cluster config so no need to touch manually the config

Also realigned with gofmt