### PR TITLE
master: Remove the control-plane stacks dependence on cross stack references

### DIFF
--- a/builtin/files/stack-templates/control-plane.json.tmpl
+++ b/builtin/files/stack-templates/control-plane.json.tmpl
@@ -10,12 +10,18 @@
       "Type": "String",
       "Description": "The name of an etcd stack used to import values into this stack"
     }
-    {{if .CloudWatchLogging.Enabled}},
+    {{range $index, $etcdInstance := $.EtcdNodes }},
+    "{{$etcdInstance.LogicalName}}FQDN": {
+      "Type": "String",
+      "Description": "The FQDN for etcd node {{$index}}"
+    }
+    {{- end}}
+    {{if .CloudWatchLogging.Enabled }},
     "CloudWatchLogGroupARN": {
       "Type": "String",
       "Description": "CloudWatch LogGroup to send journald logs to"
     }
-    {{end}}
+    {{- end}}
   },
   "Resources": {
     "{{.Controller.LogicalName}}": {
@@ -156,7 +162,7 @@
                   "ETCD_ENDPOINTS='",
                   {{range $index, $etcdInstance := $.EtcdNodes}}
                   {{if $index}}",", {{end}} "https://",
-                  {{$etcdInstance.ImportedAdvertisedFQDNRef}}, ":2379",
+                  { "Ref" : "{{$etcdInstance.LogicalName}}FQDN" }, ":2379",
                   {{end}}
                   "'\n"
                 ]]}

--- a/builtin/files/stack-templates/etcd.json.tmpl
+++ b/builtin/files/stack-templates/etcd.json.tmpl
@@ -586,7 +586,6 @@
     ,
     {{quote $n}}: {{toJSON $r}}
     {{end}}
-    
   },
   "Outputs": {
     {{range $index, $etcdInstance := $.EtcdNodes}}
@@ -609,9 +608,15 @@
       "Description": "The name of this stack which is used by node pool stacks to import outputs from this stack",
       "Value": { "Ref": "AWS::StackName" }
     }
-    {{range $n, $r := .ExtraCfnOutputs}}
+    {{range $index, $etcdInstance := $.EtcdNodes }},
+    "{{$etcdInstance.LogicalName}}FQDN": {
+      "Description": "The FQDN for etcd node {{$index}}",
+      "Value": {{$etcdInstance.AdvertisedFQDN}}
+    }
+    {{- end}}
+    {{range $n, $r := .ExtraCfnOutputs -}}
     ,
     {{quote $n}}: {{toJSON $r}}
-    {{end}}
+    {{- end}}
   }
 }

--- a/builtin/files/stack-templates/root.json.tmpl
+++ b/builtin/files/stack-templates/root.json.tmpl
@@ -37,10 +37,13 @@
         "Parameters": {
           "EtcdStackName": {"Fn::GetAtt" : [ "{{$.Etcd.Name}}" , "Outputs.StackName" ]},
           "NetworkStackName": {"Fn::GetAtt" : [ "{{$.Network.Name}}" , "Outputs.StackName" ]}
-          {{if .CloudWatchLogging.Enabled}}
+          {{range $index, $etcdInstance := $.EtcdNodes -}}
           ,
+          "{{$etcdInstance.LogicalName}}FQDN": {"Fn::GetAtt" : [ "{{$.Etcd.Name}}" , "Outputs.{{$etcdInstance.LogicalName}}FQDN" ]}
+          {{- end}}
+          {{if .CloudWatchLogging.Enabled}},
           "CloudWatchLogGroupARN": { "Fn::GetAtt": [ "CloudWatchLogGroup", "Arn" ] }
-          {{ end }}
+          {{- end }}
         },
         "Tags" : [
           {

--- a/core/root/template_params.go
+++ b/core/root/template_params.go
@@ -40,6 +40,10 @@ func (p TemplateParams) KubeDnsMasq() api.KubeDns {
 	return p.cluster.controlPlaneStack.Config.KubeDns
 }
 
+func (p TemplateParams) EtcdNodes() []model.EtcdNode {
+	return p.cluster.Cfg.EtcdNodes
+}
+
 func newTemplateParams(c *Cluster) TemplateParams {
 	return TemplateParams{
 		cluster: *c,


### PR DESCRIPTION
… this prevents us from ever removing or changing these values.  The best practice way is to pass variables as parameters between nested stacks (via the root stack).   We have to remove the dependencies before we can remove the exports, so they are still exported from the etcd stack alongside our new parameters which are used in the updated control-plane stack.