### PR TITLE
v0.14.x: Allow server certs to also be used for client authentication

### DIFF
--- a/pki/x509.go
+++ b/pki/x509.go
@@ -88,7 +88,7 @@ func NewSignedServerCertificate(cfg ServerCertConfig, key *rsa.PrivateKey, caCer
 		NotBefore:    caCert.NotBefore,
 		NotAfter:     time.Now().Add(cfg.Duration).UTC(),
 		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}
 	certDERBytes, err := x509.CreateCertificate(rand.Reader, &certTmpl, caCert, key.Public(), caKey)
 	if err != nil {


### PR DESCRIPTION
In the recent versions of golang, etcd and kubernetes etc. the cert key usages are more strictly observed, e.g. an ectd server may not connect to another etcd server using a cert with only TLS Server Authentication - it also needs the Client Authentication usage.