### PR TITLE
master: CoreDNS prometheus metric annotations exposed at pod level

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4106,6 +4106,8 @@ write_files:
               labels:
                 k8s-app: kube-dns
               annotations:
+                prometheus.io/port: "9153"
+                prometheus.io/scrape: "true"
                 seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
             spec:
               priorityClassName: system-node-critical
@@ -4200,11 +4202,6 @@ write_files:
           labels:
             k8s-app: kube-dns
             kubernetes.io/cluster-service: "true"
-          {{- if eq .KubeDns.Provider "coredns" }}
-          annotations:
-            prometheus.io/port: "9153"
-            prometheus.io/scrape: "true"
-          {{- end }}
         spec:
           # replicas: not specified here:
           # 1. In order to make Addon Manager do not reconcile this replicas parameter.


### PR DESCRIPTION
These annotations would previously never be rendered because they
were added under the kube-dns section (rather than CoreDNS's).
Additionally, the annotations are now added to the Pods themselves
rather than the Deployment.

Fixes #1768