### PR TITLE
Add missing calico networkset crd and rbac permission

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1520,7 +1520,7 @@ write_files:
                     value: "kubernetes"
                   # Enable felix logging.
                   - name: FELIX_LOGSEVERITYSYS
-                    value: "info"
+                    value: "Warning"
                   # Don't enable BGP.
                   - name: CALICO_NETWORKING_BACKEND
                     value: "none"
@@ -1742,7 +1742,7 @@ write_files:
                     value: "kubernetes"
                   # Enable felix logging.
                   - name: FELIX_LOGSEVERITYSYS
-                    value: "info"
+                    value: "Warning"
                   # Don't enable BGP.
                   - name: CALICO_NETWORKING_BACKEND
                     value: "none"

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2084,6 +2084,19 @@ write_files:
           kind: NetworkPolicy
           plural: networkpolicies
           singular: networkpolicy
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: networksets.crd.projectcalico.org
+      spec:
+        scope: Namespaced
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: NetworkSet
+          plural: networksets
+          singular: networkset
 
   - path: /srv/kubernetes/rbac/network-daemonsets.yaml
     content: |
@@ -2173,6 +2186,7 @@ write_files:
             - globalnetworkpolicies
             - globalnetworksets
             - networkpolicies
+            - networksets
             - clusterinformations
             - hostendpoints
           verbs:


### PR DESCRIPTION
Calico experiencing issues post version upgrade due to missing new crd object and RBAC permission