### PR TITLE
Add flag to cmds to use AWS profile

### DIFF
--- a/awsconn/awsconn.go
+++ b/awsconn/awsconn.go
@@ -2,20 +2,26 @@ package awsconn
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/kubernetes-incubator/kube-aws/model"
 )
 
 // NewSessionFromRegion creaes an AWS session from AWS region and a debug flag
-func NewSessionFromRegion(region model.Region, debug bool) (*session.Session, error) {
+func NewSessionFromRegion(region model.Region, debug bool, awsProfile string) (*session.Session, error) {
 	awsConfig := aws.NewConfig().
 		WithRegion(region.String()).
 		WithCredentialsChainVerboseErrors(true)
 
 	if debug {
 		awsConfig = awsConfig.WithLogLevel(aws.LogDebug)
+	}
+
+	if awsProfile != "" {
+		awsConfig = awsConfig.WithCredentials(credentials.NewSharedCredentials("", awsProfile))
 	}
 
 	session, err := newSession(awsConfig)

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -24,6 +24,7 @@ var (
 	applyOpts = struct {
 		awsDebug, prettyPrint, skipWait, export bool
 		force                                   bool
+		profile                                 string
 		targets                                 []string
 	}{}
 )
@@ -35,6 +36,7 @@ func init() {
 	cmdApply.Flags().BoolVar(&applyOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
 	cmdApply.Flags().BoolVar(&applyOpts.skipWait, "skip-wait", false, "Don't wait the resources finish")
 	cmdApply.Flags().BoolVar(&applyOpts.force, "force", false, "Don't ask for confirmation")
+	cmdApply.Flags().StringVar(&applyOpts.profile, "profile", "", "The AWS profile to use from credentials file")
 	cmdApply.Flags().StringSliceVar(&applyOpts.targets, "targets", root.AllOperationTargetsAsStringSlice(), "Update nothing but specified sub-stacks.  Specify `all` or any combination of `etcd`, `control-plane`, and node pool names. Defaults to `all`")
 }
 
@@ -44,7 +46,7 @@ func runCmdApply(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	opts := root.NewOptions(applyOpts.prettyPrint, applyOpts.skipWait)
+	opts := root.NewOptions(applyOpts.prettyPrint, applyOpts.skipWait, applyOpts.profile)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, applyOpts.awsDebug)
 	if err != nil {

--- a/cmd/calculator.go
+++ b/cmd/calculator.go
@@ -22,18 +22,20 @@ var (
 	}
 
 	calculatorOpts = struct {
+		profile  string
 		awsDebug bool
 	}{}
 )
 
 func init() {
 	RootCmd.AddCommand(cmdCalculator)
+	cmdCalculator.Flags().StringVar(&calculatorOpts.profile, "profile", "", "The AWS profile to use from credentials file")
 	cmdCalculator.Flags().BoolVar(&calculatorOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
 }
 
 func runCmdCalculator(_ *cobra.Command, _ []string) error {
 
-	opts := root.NewOptions(false, false)
+	opts := root.NewOptions(false, false, calculatorOpts.profile)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, calculatorOpts.awsDebug)
 	if err != nil {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -25,6 +25,7 @@ var (
 
 func init() {
 	RootCmd.AddCommand(cmdDestroy)
+	cmdDestroy.Flags().StringVar(&destroyOpts.Profile, "profile", "", "The AWS profile to use from credentials file")
 	cmdDestroy.Flags().BoolVar(&destroyOpts.AwsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
 	cmdDestroy.Flags().BoolVar(&destroyOpts.Force, "force", false, "Don't ask for confirmation")
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/kubernetes-incubator/kube-aws/core/root"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var (
@@ -21,6 +22,7 @@ var (
 	diffOpts = struct {
 		awsDebug, prettyPrint, skipWait, export bool
 		context                                 int
+		profile                                 string
 		targets                                 []string
 	}{}
 )
@@ -37,12 +39,13 @@ func (e *ExitError) Error() string {
 func init() {
 	RootCmd.AddCommand(cmdDiff)
 	cmdDiff.Flags().BoolVar(&diffOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdDiff.Flags().StringVar(&diffOpts.profile, "profile", "", "The AWS profile to use from credentials file")
 	cmdDiff.Flags().StringSliceVar(&diffOpts.targets, "targets", root.AllOperationTargetsAsStringSlice(), "Diff nothing but specified sub-stacks.  Specify `all` or any combination of `etcd`, `control-plane`, and node pool names. Defaults to `all`")
 	cmdDiff.Flags().IntVarP(&diffOpts.context, "context", "C", -1, "output NUM lines of context around changes")
 }
 
 func runCmdDiff(c *cobra.Command, _ []string) error {
-	opts := root.NewOptions(diffOpts.prettyPrint, diffOpts.skipWait)
+	opts := root.NewOptions(diffOpts.prettyPrint, diffOpts.skipWait, diffOpts.profile)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, diffOpts.awsDebug)
 	if err != nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -16,14 +16,20 @@ var (
 		RunE:         runCmdStatus,
 		SilenceUsage: true,
 	}
+
+	statusOpts = struct {
+		profile string
+	}{}
 )
 
 func init() {
 	RootCmd.AddCommand(cmdStatus)
+	cmdStatus.Flags().StringVar(&statusOpts.profile, "profile", "", "The AWS profile to use from credentials file")
 }
 
 func runCmdStatus(_ *cobra.Command, _ []string) error {
-	describer, err := root.ClusterDescriberFromFile(configPath)
+	opts := root.NewOptions(false, false, statusOpts.profile)
+	describer, err := root.ClusterDescriberFromFile(configPath, opts)
 	if err != nil {
 		return fmt.Errorf("failed to read cluster config: %v", err)
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -19,6 +19,7 @@ var (
 
 	upOpts = struct {
 		awsDebug, export, prettyPrint, skipWait bool
+		profile            string
 	}{}
 )
 
@@ -28,13 +29,14 @@ func init() {
 	cmdUp.Flags().BoolVar(&upOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
 	cmdUp.Flags().BoolVar(&upOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
 	cmdUp.Flags().BoolVar(&upOpts.skipWait, "skip-wait", false, "Don't wait for the cluster components be ready")
+	cmdUp.Flags().StringVar(&upOpts.profile, "profile", "", "The AWS profile to use from credentials file")
 }
 
 func runCmdUp(_ *cobra.Command, _ []string) error {
 	logger.Warnf("WARNING! kube-aws 'up' command is deprecated and will be removed in future versions")
 	logger.Warnf("Please use 'apply' to create your cluster")
 
-	opts := root.NewOptions(upOpts.prettyPrint, upOpts.skipWait)
+	opts := root.NewOptions(upOpts.prettyPrint, upOpts.skipWait, upOpts.profile)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, upOpts.awsDebug)
 	if err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -24,6 +24,7 @@ var (
 	updateOpts = struct {
 		awsDebug, prettyPrint, skipWait bool
 		force                           bool
+		profile							string
 		targets                         []string
 	}{}
 )
@@ -34,6 +35,7 @@ func init() {
 	cmdUpdate.Flags().BoolVar(&updateOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
 	cmdUpdate.Flags().BoolVar(&updateOpts.skipWait, "skip-wait", false, "Don't wait the resources finish")
 	cmdUpdate.Flags().BoolVar(&updateOpts.force, "force", false, "Don't ask for confirmation")
+	cmdUpdate.Flags().StringVar(&updateOpts.profile, "profile", "", "The AWS profile to use from credentials file")
 	cmdUpdate.Flags().StringSliceVar(&updateOpts.targets, "targets", root.AllOperationTargetsAsStringSlice(), "Update nothing but specified sub-stacks.  Specify `all` or any combination of `etcd`, `control-plane`, and node pool names. Defaults to `all`")
 }
 
@@ -46,7 +48,7 @@ func runCmdUpdate(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	opts := root.NewOptions(updateOpts.prettyPrint, updateOpts.skipWait)
+	opts := root.NewOptions(updateOpts.prettyPrint, updateOpts.skipWait, updateOpts.profile)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, updateOpts.awsDebug)
 	if err != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/kubernetes-incubator/kube-aws/core/root"
 	"github.com/kubernetes-incubator/kube-aws/logger"
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ var (
 
 	validateOpts = struct {
 		awsDebug, skipWait bool
+		profile            string
 		targets            []string
 	}{}
 )
@@ -30,6 +32,7 @@ func init() {
 		false,
 		"Log debug information from aws-sdk-go library",
 	)
+	cmdValidate.Flags().StringVar(&validateOpts.profile, "profile", "", "The AWS profile to use from credentials file")
 	cmdValidate.Flags().StringSliceVar(
 		&validateOpts.targets,
 		"targets",
@@ -38,7 +41,7 @@ func init() {
 }
 
 func runCmdValidate(_ *cobra.Command, _ []string) error {
-	opts := root.NewOptions(validateOpts.awsDebug, validateOpts.skipWait)
+	opts := root.NewOptions(validateOpts.awsDebug, validateOpts.skipWait, validateOpts.profile)
 
 	cluster, err := root.ClusterFromFile(configPath, opts, validateOpts.awsDebug)
 	if err != nil {

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -142,7 +142,7 @@ func ClusterFromFile(configPath string, opts options, awsDebug bool) (*clusterIm
 }
 
 func ClusterFromConfig(cfg *config.Config, opts options, awsDebug bool) (*clusterImpl, error) {
-	session, err := awsconn.NewSessionFromRegion(cfg.Region, awsDebug)
+	session, err := awsconn.NewSessionFromRegion(cfg.Region, awsDebug, opts.AWSProfile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to establish aws session: %v", err)
 	}

--- a/core/root/describer.go
+++ b/core/root/describer.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -31,13 +32,13 @@ type clusterDescriberImpl struct {
 	stackName   string
 }
 
-func ClusterDescriberFromFile(configPath string) (ClusterDescriber, error) {
+func ClusterDescriberFromFile(configPath string, opts options) (ClusterDescriber, error) {
 	config, err := config.ConfigFromFile(configPath)
 	if err != nil {
 		return nil, err
 	}
 
-	session, err := awsconn.NewSessionFromRegion(config.Region, false)
+	session, err := awsconn.NewSessionFromRegion(config.Region, false, opts.AWSProfile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to establish aws session: %v", err)
 	}

--- a/core/root/destroyer.go
+++ b/core/root/destroyer.go
@@ -9,6 +9,7 @@ import (
 )
 
 type DestroyOptions struct {
+	Profile  string
 	AwsDebug bool
 	Force    bool
 }
@@ -27,7 +28,7 @@ func ClusterDestroyerFromFile(configPath string, opts DestroyOptions) (ClusterDe
 		return nil, err
 	}
 
-	session, err := awsconn.NewSessionFromRegion(cfg.Region, opts.AwsDebug)
+	session, err := awsconn.NewSessionFromRegion(cfg.Region, opts.AwsDebug, opts.Profile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to establish aws session: %v", err)
 	}

--- a/core/root/options.go
+++ b/core/root/options.go
@@ -12,11 +12,17 @@ type options struct {
 	NetworkStackTemplateTmplFile      string
 	EtcdStackTemplateTmplFile         string
 	NodePoolStackTemplateTmplFile     string
+	AWSProfile                        string
 	SkipWait                          bool
 	PrettyPrint                       bool
 }
 
-func NewOptions(prettyPrint bool, skipWait bool) options {
+func NewOptions(prettyPrint bool, skipWait bool, awsProfile ...string) options {
+	var profile string
+	if len(awsProfile) > 0 {
+		profile = awsProfile[0]
+	}
+
 	return options{
 		AssetsDir:                         defaults.AssetsDir,
 		ControllerTmplFile:                defaults.ControllerTmplFile,
@@ -27,6 +33,7 @@ func NewOptions(prettyPrint bool, skipWait bool) options {
 		EtcdStackTemplateTmplFile:         defaults.EtcdStackTemplateTmplFile,
 		NodePoolStackTemplateTmplFile:     defaults.NodePoolStackTemplateTmplFile,
 		RootStackTemplateTmplFile:         defaults.RootStackTemplateTmplFile,
+		AWSProfile:                        profile,
 		SkipWait:                          skipWait,
 		PrettyPrint:                       prettyPrint,
 	}


### PR DESCRIPTION
Add a new flag to command line utilities to allow to choose a AWS profile from the aws credentials file