### PR TITLE
kube2iam metrics

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1574,6 +1574,7 @@ kubeAwsPlugins:
   kube2iam:
     enabled: false
     # image: jtblin/kube2iam:0.10.8
+    # metrics: false
 
   # kiam - allows mapping of pods to AWS STS roles via kiam server and agent components
   # kiam provides individual pod access policies and tokens for restricting pod access to AWS resources

--- a/builtin/files/plugins/kube2iam/manifests/daemonset.yaml
+++ b/builtin/files/plugins/kube2iam/manifests/daemonset.yaml
@@ -32,6 +32,7 @@ spec:
           name: kube2iam
           args:
             - "--app-port=8282"
+            - "--metrics-port=8181"
             - "--auto-discover-base-arn"
             - "--auto-discover-default-role"
             - "--iptables=true"
@@ -52,6 +53,9 @@ spec:
             - containerPort: 8282
               hostPort: 8282
               name: http
+            - containerPort: 8181
+              hostPort: 8181
+              name: metrics
           resources:
             limits:
               memory: 128Mi

--- a/builtin/files/plugins/kube2iam/manifests/podmonitor.yaml
+++ b/builtin/files/plugins/kube2iam/manifests/podmonitor.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.prometheusOperatorPodMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: kube2iam 
+    {{- range $key, $value := .Values.prometheusMetrics.labels }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  name: kube2iam-metrics
+  namespace: {{ .Values.prometheusMetrics.namespace }}
+spec:
+  podMetricsEndpoints:
+  - interval: {{ .Values.prometheusMetrics.interval }}
+    path: /metrics
+    targetPort: 8181
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      name: kube2iam
+{{- end }}

--- a/builtin/files/plugins/kube2iam/plugin.yaml
+++ b/builtin/files/plugins/kube2iam/plugin.yaml
@@ -1,11 +1,16 @@
 metadata:
   name: kube2iam
-  version: 0.1.0
+  version: 0.1.1
 spec:
   cluster:
     values:
       image: jtblin/kube2iam:0.10.8
-
+      prometheusMetrics:
+        enabled: false
+        interval: "15s"
+        namespace: kube-system
+        labels:
+          prometheus: monitoring
     kubernetes:
       manifests:
       - source:

--- a/builtin/files/stack-templates/network.json.tmpl
+++ b/builtin/files/stack-templates/network.json.tmpl
@@ -471,6 +471,36 @@
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
     {{ end }}
+    {{if ((index .PluginConfigs "kube2iam").Enabled) }}
+    "SecurityGroupWorkerIngressFromWorkerToWorkerKube2iam": {
+      "Properties": {
+        "FromPort": 8181,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 8181
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToControllerKube2iam": {
+      "Properties": {
+        "FromPort": 8181,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 8181
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    {{ end }}
     {{if .Addons.Prometheus.SecurityGroupsEnabled}}
     "SecurityGroupWorkerIngressFromWorkerToWorkerCadvisor": {
       "Properties": {


### PR DESCRIPTION
Expose kube2iam metrics by default and allow, as feature flag, PodMonitor for Prometheus Operator.

### Motivation 

Expose kube2iam metrics for proper monitoring

### To discuss

- Enable metrics by default. When plugin is enabled will add an entry in worker and masters networking security group. The reason is that metrics, imo, should be exposed by default and this ones are the only ones available. 

- I set the prometheus pod monitor object base on the cluster autoscaler one but there's an inconsistent behaviour in `prometheusMetrics.selector` in cluster autoscaler, set as `.prometheusMetrics.labels` in this plugin. May need to be fixed in another PR to align plugins consistency.

## WIP

- [ ] Testing