### PR TITLE
Allow new nodepools to spin up without A-Z dependencies

### DIFF
--- a/builtin/files/stack-templates/etcd.json.tmpl
+++ b/builtin/files/stack-templates/etcd.json.tmpl
@@ -530,7 +530,7 @@
         }
       },
       "DependsOn": [
-        {{if $.StackExists}}{{if not $.EtcdMigrationEnabled }}{{if $etcdIndex}}"{{$etcdInstance.LogicalNameForIndex (sub $etcdIndex 1)}}",{{end}}{{end}}{{end}}
+        {{if $.Stack.StackExists}}{{if not $.EtcdMigrationEnabled }}{{if $etcdIndex}}"{{$etcdInstance.LogicalNameForIndex (sub $etcdIndex 1)}}",{{end}}{{end}}{{end}}
         {{if $etcdInstance.EIPManaged}}
         "{{$etcdInstance.EIPLogicalName}}",
         {{end}}

--- a/builtin/files/stack-templates/root.json.tmpl
+++ b/builtin/files/stack-templates/root.json.tmpl
@@ -107,16 +107,18 @@
       },
       "DependsOn": [
         "{{$.ControlPlane.Name}}"
-        {{ if eq $p.NodePoolRollingStrategy "Sequential" -}}
-          {{ if $i -}}
-          ,"{{ (index $.NodePools (sub $i 1)).Name}}"
-          {{ end -}}
-        {{ end -}}
-        {{ if eq $p.NodePoolRollingStrategy "AvailabilityZone" -}}
-          {{- if ne ($.NodePoolAvailabilityZoneDependencies $p $.Subnets) "" }}
-          ,{{ $.NodePoolAvailabilityZoneDependencies $p $.Subnets }}
+        {{- if $p.StackExists }}
+          {{- if eq $p.NodePoolRollingStrategy "Sequential" }}
+            {{- if $i }}
+            ,"{{ (index $.NodePools (sub $i 1)).Name}}"
+            {{- end }}
           {{- end }}
-        {{ end -}}
+          {{- if eq $p.NodePoolRollingStrategy "AvailabilityZone" }}
+            {{- if ne ($.NodePoolAvailabilityZoneDependencies $p $.Subnets) "" }}
+            ,{{ $.NodePoolAvailabilityZoneDependencies $p $.Subnets }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
       ]
     }{{end}}
     {{range $n, $r := .ExtraCfnResources}}

--- a/core/root/cluster.go
+++ b/core/root/cluster.go
@@ -228,7 +228,7 @@ func (cl *Cluster) ensureNestedStacksLoaded() error {
 		}
 		npExtras := extras
 		npExtras.Configs = npCfg.Plugins
-		np, err := model.NewWorkerStack(cfg, npCfg, npOpts, npExtras, assetsConfig)
+		np, err := model.NewWorkerStack(cfg, npCfg, npOpts, npExtras, assetsConfig, cl.context())
 		if err != nil {
 			return fmt.Errorf("failed to load node pool #%d: %v", i, err)
 		}

--- a/core/root/template_params.go
+++ b/core/root/template_params.go
@@ -177,6 +177,10 @@ func (p nodePool) NeedToExportIAMroles() bool {
 	return p.nodePool.NodePoolConfig.IAMConfig.InstanceProfile.Arn == ""
 }
 
+func (p nodePool) StackExists() bool {
+	return p.nodePool.StackExists
+}
+
 func (p TemplateParams) ControlPlane() controlPlane {
 	return controlPlane{
 		controlPlane: p.cluster.controlPlaneStack,

--- a/pkg/api/existing_etcd.go
+++ b/pkg/api/existing_etcd.go
@@ -2,7 +2,6 @@ package api
 
 // ExistingState describes the existing state of the etcd cluster
 type EtcdExistingState struct {
-	StackExists                    bool
 	EtcdMigrationEnabled           bool
 	EtcdMigrationExistingEndpoints string
 }

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -19,6 +19,7 @@ type Stack struct {
 	StackName   string
 	S3URI       string
 	ClusterName string
+	StackExists bool
 	Region      api.Region
 
 	Config         *Config


### PR DESCRIPTION
Whilst making the nodePoolRollingStrategy "AvailabilityZone" the default in this release, I noticed that my node pools in a new clusters were being created an AZ at a time.  In a new cluster, or when adding new nodepools we don't want these to roll-out by AZ.  This change makes it so that new nodepools do not *Depend* on other pools when they are created the first time, but they do afterwards when they are updated.

This works by looking up the nodepool stacks in a similar way we lookup the 'etcd' stack and I've chosen to save this state into the Stack object so that knowledge of the existence of a stack can be used with its stack template (this is how we can create dependencies only when the stack exists). 