### PR TITLE
Add autoscaling:DescribeAutoScalingGroups policy for node drainer.

### DIFF
--- a/builtin/files/stack-templates/node-pool.json.tmpl
+++ b/builtin/files/stack-templates/node-pool.json.tmpl
@@ -464,6 +464,7 @@
                 {
                   "Action": [
                     "autoscaling:DescribeAutoScalingInstances",
+                    "autoscaling:DescribeAutoScalingGroups",
                     "autoscaling:DescribeLifecycleHooks"
                   ],
                   "Effect": "Allow",


### PR DESCRIPTION
cherry-picking Pull Request: https://github.com/kubernetes-incubator/kube-aws/pull/1799

***

The Pod of `kube-node-drainer-asg-status-updater` outputs the following error.

```
$ kubectl logs kube-node-drainer-asg-status-updater-b88545d8f-79c8h -n kube-system
+ updated_instances_to_drain=
+ [  ==  ]
+ continue
+ sleep 10
+ asg describe-auto-scaling-groups
+ aws --region=ap-northeast-1 autoscaling describe-auto-scaling-groups
+ jq -r [.AutoScalingGroups[] | select((.Tags[].Key | contains("kube-aws:")) and (.Tags[].Key | contains("kubernetes.io/cluster/cluster-name"))) | .Instances[] | select(.LifecycleState == "Terminating:Wait") | .InstanceId] | sort | join(",")

An error occurred (AccessDenied) when calling the DescribeAutoScalingGroups operation: User: arn:aws:sts::123456789:assumed-role/foo is not authorized to perform: autoscaling:DescribeAutoScalingGroups
```

Used kube-aws version:

* v0.13.2