### PR TITLE
[0.12.x Only] Fix ExtraCoreDNSConfig typo in stack template

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3429,8 +3429,8 @@ write_files:
                     upstream
                     fallthrough in-addr.arpa ip6.arpa
                 }
-                {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.extraCoreDNSConfig }}
-                {{ .KubeDns.extraCoreDNSConfig }}
+                {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.ExtraCoreDNSConfig }}
+                {{ .KubeDns.ExtraCoreDNSConfig }}
                 {{- end }}
                 prometheus :9153
                 proxy . /etc/resolv.conf


### PR DESCRIPTION
With this fix, in our company we close the 0.12 branch. So next PRs will go to ^0.13