### PR TITLE
Add proper indentation to extra CoreDNS config

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3430,7 +3430,7 @@ write_files:
                     fallthrough in-addr.arpa ip6.arpa
                 }
                 {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.ExtraCoreDNSConfig }}
-                {{ .KubeDns.ExtraCoreDNSConfig }}
+{{ .KubeDns.ExtraCoreDNSConfig | indent 16 }}
                 {{- end }}
                 prometheus :9153
                 proxy . /etc/resolv.conf


### PR DESCRIPTION
When using more than one line of extra config, the indentation was not right and generated YAML was not valid

This should fix this issue also for 0.12.x (we're currently migrating away from it, but it feels right to leave a working version in the repo)