### PR TITLE
Add proper indentation to extra CoreDNS config

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3849,7 +3849,7 @@ write_files:
                     health_check 5s
                 }
                 {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.ExtraCoreDNSConfig }}
-                {{ .KubeDns.ExtraCoreDNSConfig }}
+{{ .KubeDns.ExtraCoreDNSConfig | indent 16 }}
                 {{- end }}
                 prometheus :9153
                 cache {{ .KubeDns.TTL }}


### PR DESCRIPTION
When using more than one line of extra config, the indentation was not right and generated YAML was not valid

This should fix this issue