### PR TITLE
Kubernetes 1.16 Support

### DIFF
--- a/build
+++ b/build
@@ -6,8 +6,8 @@ TAG=$(git describe --exact-match --abbrev=0 --tags "${COMMIT}" 2> /dev/null || t
 BRANCH=$(git branch | grep \* | cut -d ' ' -f2 | sed -e 's/[^a-zA-Z0-9+=._:/-]*//g' || true)
 OUTPUT_PATH=${OUTPUT_PATH:-"bin/kube-aws"}
 VERSION=""
-ETCD_VERSION="v3.3.17"
-KUBERNETES_VERSION="v1.15.6"
+ETCD_VERSION="v3.4.3"
+KUBERNETES_VERSION="v1.16.4"
 
 if [ -z "$TAG" ]; then
         [[ -n "$BRANCH" ]] && VERSION="${BRANCH}/"

--- a/builtin/files/plugins/aws-iam-authenticator/manifests/daemonset.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/manifests/daemonset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: kube-system
@@ -9,6 +9,9 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: aws-iam-authenticator
   template:
     metadata:
       annotations:
@@ -18,55 +21,50 @@ spec:
     spec:
       # run on the host network (don't depend on CNI)
       hostNetwork: true
-
       # run on each master node
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-      - effect: NoSchedule
-        key: node.alpha.kubernetes.io/role
-        value: master
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - key: CriticalAddonsOnly
-        operator: Exists
-
+        - effect: NoSchedule
+          key: node.alpha.kubernetes.io/role
+          value: master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - key: CriticalAddonsOnly
+          operator: Exists
       # run `aws-iam-authenticator server` with three volumes
       # - config (mounted from the ConfigMap at /etc/aws-iam-authenticator/config.yaml)
       # - state (persisted TLS certificate and keys, mounted from the host)
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
-      - name: aws-iam-authenticator
-        image: gcr.io/heptio-images/authenticator:v0.3.0
-        args:
-        - server
-        - --config=/etc/aws-iam-authenticator/config.yaml
-        - --state-dir=/var/aws-iam-authenticator
-        - --kubeconfig-pregenerated=true
-
-        resources:
-          requests:
-            memory: 20Mi
-            cpu: 10m
-          limits:
-            memory: 20Mi
-            cpu: 100m
-
-        volumeMounts:
-        - name: config
-          mountPath: /etc/aws-iam-authenticator/
-        - name: state
-          mountPath: /var/aws-iam-authenticator/
-        - name: output
-          mountPath: /etc/kubernetes/aws-iam-authenticator/
-
+        - name: aws-iam-authenticator
+          image: gcr.io/heptio-images/authenticator:v0.3.0
+          args:
+            - server
+            - --config=/etc/aws-iam-authenticator/config.yaml
+            - --state-dir=/var/aws-iam-authenticator
+            - --kubeconfig-pregenerated=true
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+            limits:
+              memory: 20Mi
+              cpu: 100m
+          volumeMounts:
+            - name: config
+              mountPath: /etc/aws-iam-authenticator/
+            - name: state
+              mountPath: /var/aws-iam-authenticator/
+            - name: output
+              mountPath: /etc/kubernetes/aws-iam-authenticator/
       volumes:
-      - name: config
-        configMap:
-          name: aws-iam-authenticator
-      - name: output
-        hostPath:
-          path: /srv/kubernetes/aws-iam-authenticator/
-      - name: state
-        hostPath:
-          path: /srv/kubernetes/aws-iam-authenticator/
+        - name: config
+          configMap:
+            name: aws-iam-authenticator
+        - name: output
+          hostPath:
+            path: /srv/kubernetes/aws-iam-authenticator/
+        - name: state
+          hostPath:
+            path: /srv/kubernetes/aws-iam-authenticator/

--- a/builtin/files/plugins/cluster-autoscaler/manifests/deployment.yaml
+++ b/builtin/files/plugins/cluster-autoscaler/manifests/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/builtin/files/plugins/cluster-autoscaler/manifests/deployment.yaml
+++ b/builtin/files/plugins/cluster-autoscaler/manifests/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
   namespace: kube-system
 spec:
   replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
   template:
     metadata:
       labels:

--- a/builtin/files/plugins/dashboard/manifests/deployment.yaml
+++ b/builtin/files/plugins/dashboard/manifests/deployment.yaml
@@ -110,7 +110,7 @@ spec:
 
 {{ if .Values.ingress.enabled -}}
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: kubernetes-dashboard

--- a/builtin/files/plugins/dashboard/manifests/deployment.yaml
+++ b/builtin/files/plugins/dashboard/manifests/deployment.yaml
@@ -110,7 +110,7 @@ spec:
 
 {{ if .Values.ingress.enabled -}}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: kubernetes-dashboard

--- a/builtin/files/plugins/kiam/manifests/agent-daemonset.yaml
+++ b/builtin/files/plugins/kiam/manifests/agent-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: kube-system

--- a/builtin/files/plugins/kiam/manifests/agent-daemonset.yaml
+++ b/builtin/files/plugins/kiam/manifests/agent-daemonset.yaml
@@ -8,6 +8,10 @@ spec:
     rollingUpdate:
       maxUnavailable: 100%
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: kiam
+      role: agent
   template:
     metadata:
       annotations:

--- a/builtin/files/plugins/kiam/manifests/server-daemonset.yaml
+++ b/builtin/files/plugins/kiam/manifests/server-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: kube-system

--- a/builtin/files/plugins/kiam/manifests/server-daemonset.yaml
+++ b/builtin/files/plugins/kiam/manifests/server-daemonset.yaml
@@ -8,6 +8,10 @@ spec:
     rollingUpdate:
       maxUnavailable: 100%
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: kiam
+      role: server
   template:
     metadata:
       annotations:

--- a/builtin/files/plugins/kube2iam/manifests/daemonset.yaml
+++ b/builtin/files/plugins/kube2iam/manifests/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube2iam

--- a/builtin/files/plugins/kube2iam/manifests/daemonset.yaml
+++ b/builtin/files/plugins/kube2iam/manifests/daemonset.yaml
@@ -12,6 +12,9 @@ spec:
     rollingUpdate:
       maxUnavailable: 100%
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: kube2iam
   template:
     metadata:
       labels:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -333,30 +333,6 @@ coreos:
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/etcd-environment
         EnvironmentFile=-/etc/default/kubelet
-        Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
-        Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
-        Environment="RKT_RUN_ARGS={{.HyperkubeImage.Options}}\
-        --volume dns,kind=host,source=/etc/resolv.conf \
-        --mount volume=dns,target=/etc/resolv.conf \
-        --volume var-lib-cni,kind=host,source=/var/lib/cni \
-        --mount volume=var-lib-cni,target=/var/lib/cni \
-        --volume var-run-calico,kind=host,source=/var/run/calico \
-        --mount volume=var-run-calico,target=/var/run/calico \
-        --volume var-lib-calico,kind=host,source=/var/lib/calico \
-        --mount volume=var-lib-calico,target=/var/lib/calico \
-        --volume var-log,kind=host,source=/var/log \
-        {{ if gt (len .Kubelet.Mounts) 0 -}}
-        {{ range $i, $m := .Kubelet.Mounts -}}
-        {{ range $j, $a := $m.ToRktRunArgs -}}
-        {{ $a }} \
-        {{ end -}}
-        {{ end -}}
-        {{ end -}}
-        --mount volume=var-log,target=/var/log \
-        --volume cni-bin,kind=host,source=/opt/cni/bin \
-        --mount volume=cni-bin,target=/opt/cni/bin \
-        --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-        --mount volume=etc-kubernetes,target=/etc/kubernetes"
         ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
@@ -365,9 +341,27 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
+        ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
+        ExecStartPre=/bin/bash -c "if ! grep -q "/var/lib/kubelet" /proc/mounts; then mount --bind /var/lib/kubelet /var/lib/kubelet && mount --make-shared /var/lib/kubelet; fi"
         ExecStartPre=/bin/sed -e "s/COREOS_PRIVATE_IPV4/${COREOS_PRIVATE_IPV4}/g" -i /etc/kubernetes/config/kubelet.yaml
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /srv/kubernetes/manifests  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
-        ExecStart=/bin/sh -c "exec /usr/lib/coreos/kubelet-wrapper \
+        ExecStartPre=-/bin/docker rm -f kubelet
+        ExecStart=/bin/sh -c "docker run --name kubelet --privileged --net=host --pid=host \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /etc/resolv.conf:/etc/resolv.conf:ro \
+        -v /var/lib/cni:/var/lib/cni:rw \
+        -v /var/run/calico:/var/run/calico:rw \
+        -v /var/lib/calico:/var/lib/calico:rw \
+        -v /var/log:/var/log:rw \
+        -v /opt/cni/bin:/opt/cni/bin:rw \
+        -v /etc/kubernetes:/etc/kubernetes:rw \
+        -v /var/lib/kubelet:/var/lib/kubelet:shared \
+        {{- if gt (len .Kubelet.Mounts) 0 }}
+          {{- range .Kubelet.Mounts }}
+        {{ .MountDockerRW }} \
+          {{- end }}
+        {{- end }}
+        {{ .HyperkubeImage.RepoWithTag }} /kubelet \
         {{ if checkVersion ">= 1.14" .K8sVer -}}
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- end }}
@@ -380,12 +374,11 @@ coreos:
         --require-kubeconfig \
         {{end -}}
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
-        {{/* Work-around until https://github.com/kubernetes/kubernetes/issues/43967 is fixed via https://github.com/kubernetes/kubernetes/pull/43995 */ -}}
         --cni-bin-dir=/opt/cni/bin \
         --network-plugin={{.K8sNetworkPlugin}} \
         --container-runtime={{.ContainerRuntime}} \
         --register-node=true \
-        --node-labels=node.kubernetes.io/role="master",node-role.kubernetes.io/master=\"\",kubernetes.io/role=master,service-cidr={{ .ServiceCIDR | toLabel }}{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
+        --node-labels=node.kubernetes.io/role="master",service-cidr={{ .ServiceCIDR | toLabel }}{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-with-taints=node.kubernetes.io/role=master:NoSchedule \
         --config=/etc/kubernetes/config/kubelet.yaml \
         {{- if .Kubernetes.Networking.AmazonVPC.Enabled }}
@@ -395,8 +388,8 @@ coreos:
         {{- range $f := .Kubelet.Flags}}
         --{{$f.Name}}={{$f.Value}} \
         {{- end }}
-        $KUBELET_OPTS \
-        "
+        $KUBELET_OPTS"
+        ExecStop=/usr/bin/docker rm -f kubelet
         Restart=always
         RestartSec=10
 
@@ -1451,7 +1444,7 @@ write_files:
       # as the Calico CNI plugins and network config on
       # each master and worker node in a Kubernetes cluster.
       kind: DaemonSet
-      apiVersion: extensions/v1beta1
+      apiVersion: apps/v1
       metadata:
         name: canal-master
         namespace: kube-system
@@ -1673,7 +1666,7 @@ write_files:
       # as the Calico CNI plugins and network config on
       # each master and worker node in a Kubernetes cluster.
       kind: DaemonSet
-      apiVersion: extensions/v1beta1
+      apiVersion: apps/v1
       metadata:
         name: canal-node
         namespace: kube-system
@@ -2336,7 +2329,7 @@ write_files:
             }
           }
       ---
-      apiVersion: extensions/v1beta1
+      apiVersion: apps/v1
       kind: DaemonSet
       metadata:
         name: flannel
@@ -2449,7 +2442,7 @@ write_files:
   - path: /srv/kubernetes/manifests/kube-resources-autosave-de.yaml
     content: |
       ---
-      apiVersion: extensions/v1beta1
+      apiVersion: apps/v1
       kind: Deployment
       metadata:
         name: kube-resources-autosave
@@ -2642,7 +2635,7 @@ write_files:
   - path: /srv/kubernetes/manifests/kube-node-drainer-asg-status-updater-de.yaml
     content: |
         kind: Deployment
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         metadata:
           name: kube-node-drainer-asg-status-updater
           namespace: kube-system
@@ -2727,7 +2720,7 @@ write_files:
   - path: /srv/kubernetes/manifests/kube-node-drainer-ds.yaml
     content: |
         kind: DaemonSet
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         metadata:
           name: kube-node-drainer-ds
           namespace: kube-system
@@ -3215,7 +3208,7 @@ write_files:
 
   - path: /srv/kubernetes/manifests/kube-proxy-ds.yaml
     content: |
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         kind: DaemonSet
         metadata:
           name: kube-proxy
@@ -3353,7 +3346,7 @@ write_files:
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicy=true{{if .Experimental.Admission.Initializers.Enabled}},admissionregistration.k8s.io/v1alpha1{{end}}
+          - --runtime-config=networking.k8s.io/v1/networkpolicies=true,policy/v1beta1/podsecuritypolicy=true{{if .Experimental.Admission.Initializers.Enabled}},admissionregistration.k8s.io/v1alpha1{{end}}
           {{- if .ControllerFeatureGates.Enabled }}
           - --feature-gates={{.ControllerFeatureGates.String}}
           {{- end }}
@@ -3627,7 +3620,7 @@ write_files:
   {{- if .Addons.Rescheduler.Enabled }}
   - path: /srv/kubernetes/manifests/kube-rescheduler-de.yaml
     content: |
-      apiVersion: extensions/v1beta1
+      apiVersion: apps/v1
       kind: Deployment
       metadata:
         name: kube-rescheduler
@@ -3943,7 +3936,7 @@ write_files:
 
   - path: /srv/kubernetes/manifests/kube-dns-autoscaler-de.yaml
     content: |
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           name: kube-dns-autoscaler
@@ -3986,7 +3979,7 @@ write_files:
 {{ if .KubeDns.NodeLocalResolver }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-ds.yaml
     content: |
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         kind: DaemonSet
         metadata:
           name: dnsmasq-node
@@ -4094,7 +4087,7 @@ write_files:
 {{- if eq .KubeDns.Provider "coredns" }}
   - path: /srv/kubernetes/manifests/coredns-de.yaml
     content: |
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           name: coredns
@@ -4209,7 +4202,7 @@ write_files:
 {{- else }}
   - path: /srv/kubernetes/manifests/kube-dns-de.yaml
     content: |
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           name: kube-dns
@@ -4431,7 +4424,7 @@ write_files:
 
   - path: /srv/kubernetes/manifests/metrics-server-de.yaml
     content: |
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           name: metrics-server
@@ -4515,7 +4508,7 @@ write_files:
 
   - path: /srv/kubernetes/manifests/tiller.yaml
     content: |
-        apiVersion: extensions/v1beta1
+        apiVersion: apps/v1
         kind: Deployment
         metadata:
           creationTimestamp: null
@@ -5095,7 +5088,7 @@ write_files:
         namespace: kube-system
       ---
       kind: DaemonSet
-      apiVersion: extensions/v1beta1
+      apiVersion: apps/v1
       metadata:
         name: aws-node
         namespace: kube-system
@@ -5196,7 +5189,7 @@ write_files:
 {{if .Experimental.GpuSupport.Enabled }}
   - path: /srv/kubernetes/manifests/nvidia-driver-installer.yaml
     content: |
-      apiVersion: extensions/v1beta1
+      apiVersion: apps/v1
       kind: DaemonSet
       metadata:
         name: nvidia-driver-installer
@@ -5261,7 +5254,7 @@ write_files:
               name: pause
       ---
 
-      apiVersion: extensions/v1beta1
+      apiVersion: apps/v1
       kind: DaemonSet
       metadata:
         name: nvidia-gpu-device-plugin

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1362,6 +1362,9 @@ write_files:
         # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
         # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
         replicas: 3
+        selector:
+          matchLabels:
+            k8s-app: calico-typha
         revisionHistoryLimit: 2
         template:
           metadata:
@@ -2338,6 +2341,10 @@ write_files:
           tier: node
           app: flannel
       spec:
+        selector:
+          matchLabels:
+            tier: node
+            app: flannel
         updateStrategy:
           rollingUpdate:
             maxUnavailable: 100%
@@ -2451,6 +2458,9 @@ write_files:
           k8s-app: kube-resources-autosave-policy
       spec:
         replicas: 1
+        selector:
+          matchLabels:
+            k8s-app: kube-resources-autosave-policy
         template:
           metadata:
             {{if (index .PluginConfigs "kiam").Enabled -}}
@@ -2634,211 +2644,217 @@ write_files:
 {{if .Experimental.NodeDrainer.Enabled}}
   - path: /srv/kubernetes/manifests/kube-node-drainer-asg-status-updater-de.yaml
     content: |
-        kind: Deployment
-        apiVersion: apps/v1
-        metadata:
-          name: kube-node-drainer-asg-status-updater
-          namespace: kube-system
-          labels:
+      kind: Deployment
+      apiVersion: apps/v1
+      metadata:
+        name: kube-node-drainer-asg-status-updater
+        namespace: kube-system
+        labels:
+          k8s-app: kube-node-drainer-asg-status-updater
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
             k8s-app: kube-node-drainer-asg-status-updater
-        spec:
-          replicas: 1
-          template:
-            metadata:
-              labels:
-                k8s-app: kube-node-drainer-asg-status-updater
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ''
-                {{if ne .Experimental.NodeDrainer.IAMRole.ARN.Arn "" -}}
-                iam.amazonaws.com/role: {{ .Experimental.NodeDrainer.IAMRole.ARN.Arn }}
-                {{ end }}
-            spec:
-              priorityClassName: system-node-critical
-              initContainers:
-                - name: hyperkube
-                  image: {{.HyperkubeImage.RepoWithTag}}
-                  command:
-                  - /bin/cp
-                  - -f
-                  - /hyperkube
-                  - /workdir/kubectl
-                  volumeMounts:
-                  - mountPath: /workdir
-                    name: workdir
-              containers:
-                - name: kube-node-drainer-asg-status-updater
-                  image: {{.AWSCliImage.RepoWithTag}}
-                  env:
-                  - name: NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                  command:
-                  - /bin/sh
-                  - -xec
-                  - |
-                    metadata() { curl -s -S -f http://169.254.169.254/2016-09-02/"$1"; }
-                    asg()      { aws --region="${REGION}" autoscaling "$@"; }
+        template:
+          metadata:
+            labels:
+              k8s-app: kube-node-drainer-asg-status-updater
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+              {{if ne .Experimental.NodeDrainer.IAMRole.ARN.Arn "" -}}
+              iam.amazonaws.com/role: {{ .Experimental.NodeDrainer.IAMRole.ARN.Arn }}
+              {{ end }}
+          spec:
+            priorityClassName: system-node-critical
+            initContainers:
+              - name: hyperkube
+                image: {{.HyperkubeImage.RepoWithTag}}
+                command:
+                - /bin/cp
+                - -f
+                - /hyperkube
+                - /workdir/kubectl
+                volumeMounts:
+                - mountPath: /workdir
+                  name: workdir
+            containers:
+              - name: kube-node-drainer-asg-status-updater
+                image: {{.AWSCliImage.RepoWithTag}}
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                command:
+                - /bin/sh
+                - -xec
+                - |
+                  metadata() { curl -s -S -f http://169.254.169.254/2016-09-02/"$1"; }
+                  asg()      { aws --region="${REGION}" autoscaling "$@"; }
 
-                    # Hyperkube binary is not statically linked, so we need to use
-                    # the musl interpreter to be able to run it in this image
-                    # See: https://github.com/kubernetes-incubator/kube-aws/pull/674#discussion_r118889687
-                    kubectl() { /lib/ld-musl-x86_64.so.1 /opt/bin/kubectl "$@"; }
+                  # Hyperkube binary is not statically linked, so we need to use
+                  # the musl interpreter to be able to run it in this image
+                  # See: https://github.com/kubernetes-incubator/kube-aws/pull/674#discussion_r118889687
+                  kubectl() { /lib/ld-musl-x86_64.so.1 /opt/bin/kubectl "$@"; }
 
-                    REGION=$(metadata dynamic/instance-identity/document | jq -r .region)
-                    [ -n "${REGION}" ]
+                  REGION=$(metadata dynamic/instance-identity/document | jq -r .region)
+                  [ -n "${REGION}" ]
 
-                    # Not customizable, for now
-                    POLL_INTERVAL=10
+                  # Not customizable, for now
+                  POLL_INTERVAL=10
 
-                    # Keeps a comma-separated list of instances that need to be drained. Sets '-'
-                    # to force the ConfigMap to be updated in the first iteration.
-                    instances_to_drain='-'
+                  # Keeps a comma-separated list of instances that need to be drained. Sets '-'
+                  # to force the ConfigMap to be updated in the first iteration.
+                  instances_to_drain='-'
 
-                    # Instance termination detection loop
-                    while sleep ${POLL_INTERVAL}; do
+                  # Instance termination detection loop
+                  while sleep ${POLL_INTERVAL}; do
 
-                      # Fetch the list of instances being terminated by their respective ASGs
-                      updated_instances_to_drain=$(asg describe-auto-scaling-groups | jq -r '[.AutoScalingGroups[] | select((.Tags[].Key | contains("kube-aws:")) and (.Tags[].Key | contains("kubernetes.io/cluster/{{.ClusterName}}"))) | .Instances[] | select(.LifecycleState == "Terminating:Wait") | .InstanceId] | sort | join(",")')
+                    # Fetch the list of instances being terminated by their respective ASGs
+                    updated_instances_to_drain=$(asg describe-auto-scaling-groups | jq -r '[.AutoScalingGroups[] | select((.Tags[].Key | contains("kube-aws:")) and (.Tags[].Key | contains("kubernetes.io/cluster/{{.ClusterName}}"))) | .Instances[] | select(.LifecycleState == "Terminating:Wait") | .InstanceId] | sort | join(",")')
 
-                      # Have things changed since last iteration?
-                      if [ "${updated_instances_to_drain}" == "${instances_to_drain}" ]; then
-                        continue
-                      fi
-                      instances_to_drain="${updated_instances_to_drain}"
+                    # Have things changed since last iteration?
+                    if [ "${updated_instances_to_drain}" == "${instances_to_drain}" ]; then
+                      continue
+                    fi
+                    instances_to_drain="${updated_instances_to_drain}"
 
-                      # Update ConfigMap to reflect current ASG state
-                      echo "{\"apiVersion\": \"v1\", \"kind\": \"ConfigMap\", \"metadata\": {\"name\": \"kube-node-drainer-status\"}, \"data\": {\"asg\": \"${instances_to_drain}\"}}" | kubectl -n kube-system apply -f -
-                    done
-                  volumeMounts:
-                  - mountPath: /opt/bin
-                    name: workdir
-              volumes:
-                - name: workdir
-                  emptyDir: {}
+                    # Update ConfigMap to reflect current ASG state
+                    echo "{\"apiVersion\": \"v1\", \"kind\": \"ConfigMap\", \"metadata\": {\"name\": \"kube-node-drainer-status\"}, \"data\": {\"asg\": \"${instances_to_drain}\"}}" | kubectl -n kube-system apply -f -
+                  done
+                volumeMounts:
+                - mountPath: /opt/bin
+                  name: workdir
+            volumes:
+              - name: workdir
+                emptyDir: {}
 
   - path: /srv/kubernetes/manifests/kube-node-drainer-ds.yaml
     content: |
-        kind: DaemonSet
-        apiVersion: apps/v1
-        metadata:
-          name: kube-node-drainer-ds
-          namespace: kube-system
-          labels:
+      kind: DaemonSet
+      apiVersion: apps/v1
+      metadata:
+        name: kube-node-drainer-ds
+        namespace: kube-system
+        labels:
+          k8s-app: kube-node-drainer-ds
+      spec:
+        updateStrategy:
+          rollingUpdate:
+            maxUnavailable: 100%
+          type: RollingUpdate
+        selector:
+          matchLabels:
             k8s-app: kube-node-drainer-ds
-        spec:
-          updateStrategy:
-            rollingUpdate:
-              maxUnavailable: 100%
-            type: RollingUpdate
-          template:
-            metadata:
-              labels:
-                k8s-app: kube-node-drainer-ds
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ''
-            spec:
-              priorityClassName: system-node-critical
-              tolerations:
-              - operator: Exists
-                effect: NoSchedule
-              - operator: Exists
-                effect: NoExecute
-              - operator: Exists
-                key: CriticalAddonsOnly
-              initContainers:
-                - name: hyperkube
-                  image: {{.HyperkubeImage.RepoWithTag}}
-                  command:
-                  - /bin/cp
-                  - -f
-                  - /hyperkube
-                  - /workdir/kubectl
-                  volumeMounts:
-                  - mountPath: /workdir
-                    name: workdir
-              containers:
-                - name: kube-node-drainer
-                  image: {{.AWSCliImage.RepoWithTag}}
-                  env:
-                  - name: NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                  command:
-                  - /bin/sh
-                  - -xec
-                  - |
-                    metadata() { curl -s -S -f http://169.254.169.254/2016-09-02/"$1"; }
-                    asg()      { aws --region="${REGION}" autoscaling "$@"; }
+        template:
+          metadata:
+            labels:
+              k8s-app: kube-node-drainer-ds
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            priorityClassName: system-node-critical
+            tolerations:
+            - operator: Exists
+              effect: NoSchedule
+            - operator: Exists
+              effect: NoExecute
+            - operator: Exists
+              key: CriticalAddonsOnly
+            initContainers:
+              - name: hyperkube
+                image: {{.HyperkubeImage.RepoWithTag}}
+                command:
+                - /bin/cp
+                - -f
+                - /hyperkube
+                - /workdir/kubectl
+                volumeMounts:
+                - mountPath: /workdir
+                  name: workdir
+            containers:
+              - name: kube-node-drainer
+                image: {{.AWSCliImage.RepoWithTag}}
+                env:
+                - name: NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                command:
+                - /bin/sh
+                - -xec
+                - |
+                  metadata() { curl -s -S -f http://169.254.169.254/2016-09-02/"$1"; }
+                  asg()      { aws --region="${REGION}" autoscaling "$@"; }
 
-                    # Hyperkube binary is not statically linked, so we need to use
-                    # the musl interpreter to be able to run it in this image
-                    # See: https://github.com/kubernetes-incubator/kube-aws/pull/674#discussion_r118889687
-                    kubectl() { /lib/ld-musl-x86_64.so.1 /opt/bin/kubectl "$@"; }
+                  # Hyperkube binary is not statically linked, so we need to use
+                  # the musl interpreter to be able to run it in this image
+                  # See: https://github.com/kubernetes-incubator/kube-aws/pull/674#discussion_r118889687
+                  kubectl() { /lib/ld-musl-x86_64.so.1 /opt/bin/kubectl "$@"; }
 
-                    INSTANCE_ID=$(metadata meta-data/instance-id)
-                    REGION=$(metadata dynamic/instance-identity/document | jq -r .region)
-                    [ -n "${REGION}" ]
+                  INSTANCE_ID=$(metadata meta-data/instance-id)
+                  REGION=$(metadata dynamic/instance-identity/document | jq -r .region)
+                  [ -n "${REGION}" ]
 
-                    # Not customizable, for now
-                    POLL_INTERVAL=10
+                  # Not customizable, for now
+                  POLL_INTERVAL=10
 
-                    # Used to identify the source which requested the instance termination
-                    termination_source=''
+                  # Used to identify the source which requested the instance termination
+                  termination_source=''
 
-                    # Instance termination detection loop
-                    while sleep ${POLL_INTERVAL}; do
+                  # Instance termination detection loop
+                  while sleep ${POLL_INTERVAL}; do
 
-                      # Spot instance termination check
-                      http_status=$(curl -o /dev/null -w '%{http_code}' -sL http://169.254.169.254/latest/meta-data/spot/termination-time)
-                      if [ "${http_status}" -eq 200 ]; then
-                        termination_source=spot
-                        break
-                      fi
+                    # Spot instance termination check
+                    http_status=$(curl -o /dev/null -w '%{http_code}' -sL http://169.254.169.254/latest/meta-data/spot/termination-time)
+                    if [ "${http_status}" -eq 200 ]; then
+                      termination_source=spot
+                      break
+                    fi
 
-                      # Termination ConfigMap check
-                      if [ -e /etc/kube-node-drainer/asg ] && grep -q "${INSTANCE_ID}" /etc/kube-node-drainer/asg; then
-                        termination_source=asg
-                        break
-                      fi
-                    done
+                    # Termination ConfigMap check
+                    if [ -e /etc/kube-node-drainer/asg ] && grep -q "${INSTANCE_ID}" /etc/kube-node-drainer/asg; then
+                      termination_source=asg
+                      break
+                    fi
+                  done
 
-                    # Node draining loop
-                    while true; do
-                      echo Node is terminating, draining it...
+                  # Node draining loop
+                  while true; do
+                    echo Node is terminating, draining it...
 
-                      if ! kubectl drain --ignore-daemonsets=true --delete-local-data=true --force=true --timeout=60s "${NODE_NAME}"; then
-                        echo Not all pods on this host can be evicted, will try again
-                        continue
-                      fi
-                      echo All evictable pods are gone
+                    if ! kubectl drain --ignore-daemonsets=true --delete-local-data=true --force=true --timeout=60s "${NODE_NAME}"; then
+                      echo Not all pods on this host can be evicted, will try again
+                      continue
+                    fi
+                    echo All evictable pods are gone
 
-                      if [ "${termination_source}" == asg ]; then
-                        echo Notifying AutoScalingGroup that instance ${INSTANCE_ID} can be shutdown
-                        ASG_NAME=$(asg describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}" | jq -r '.AutoScalingInstances[].AutoScalingGroupName')
-                        HOOK_NAME=$(asg describe-lifecycle-hooks --auto-scaling-group-name "${ASG_NAME}" | jq -r '.LifecycleHooks[].LifecycleHookName' | grep -i nodedrainer)
-                        asg complete-lifecycle-action --lifecycle-action-result CONTINUE --instance-id "${INSTANCE_ID}" --lifecycle-hook-name "${HOOK_NAME}" --auto-scaling-group-name "${ASG_NAME}"
-                      fi
+                    if [ "${termination_source}" == asg ]; then
+                      echo Notifying AutoScalingGroup that instance ${INSTANCE_ID} can be shutdown
+                      ASG_NAME=$(asg describe-auto-scaling-instances --instance-ids "${INSTANCE_ID}" | jq -r '.AutoScalingInstances[].AutoScalingGroupName')
+                      HOOK_NAME=$(asg describe-lifecycle-hooks --auto-scaling-group-name "${ASG_NAME}" | jq -r '.LifecycleHooks[].LifecycleHookName' | grep -i nodedrainer)
+                      asg complete-lifecycle-action --lifecycle-action-result CONTINUE --instance-id "${INSTANCE_ID}" --lifecycle-hook-name "${HOOK_NAME}" --auto-scaling-group-name "${ASG_NAME}"
+                    fi
 
-                      # Expect instance will be shut down in defined drain timeout
-                      sleep {{.Experimental.NodeDrainer.DrainTimeoutInSeconds}}
-                    done
-                  volumeMounts:
-                  - mountPath: /opt/bin
-                    name: workdir
-                  - mountPath: /etc/kube-node-drainer
+                    # Expect instance will be shut down in defined drain timeout
+                    sleep {{.Experimental.NodeDrainer.DrainTimeoutInSeconds}}
+                  done
+                volumeMounts:
+                - mountPath: /opt/bin
+                  name: workdir
+                - mountPath: /etc/kube-node-drainer
+                  name: kube-node-drainer-status
+                  readOnly: true
+            volumes:
+            - name: workdir
+              emptyDir: {}
+            - name: kube-node-drainer-status
+              projected:
+                sources:
+                - configMap:
                     name: kube-node-drainer-status
-                    readOnly: true
-              volumes:
-              - name: workdir
-                emptyDir: {}
-              - name: kube-node-drainer-status
-                projected:
-                  sources:
-                  - configMap:
-                      name: kube-node-drainer-status
-                      optional: true
+                    optional: true
 {{end}}
 
   # TODO: remove the following binding once the TLS Bootstrapping feature is enabled by default, see:
@@ -2849,114 +2865,114 @@ write_files:
   # needed when TLS bootstrapping is disabled
   - path: /srv/kubernetes/rbac/cluster-role-bindings/node.yaml
     content: |
-        kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1
-        metadata:
-          name: kube-aws:node
-        subjects:
-          - kind: User
-            name: kube-worker
-        roleRef:
-          kind: ClusterRole
-          name: system:node
-          apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: kube-aws:node
+      subjects:
+        - kind: User
+          name: kube-worker
+      roleRef:
+        kind: ClusterRole
+        name: system:node
+        apiGroup: rbac.authorization.k8s.io
 
   # We need to give nodes a few extra permissions so that both the node
   # draining and node labeling with AWS metadata work as expected
   - path: /srv/kubernetes/rbac/cluster-roles/node-extensions.yaml
     content: |
-        kind: ClusterRole
-        apiVersion: rbac.authorization.k8s.io/v1
-        metadata:
-            name: kube-aws:node-extensions
-        rules:
-          - apiGroups: ["extensions"]
-            resources:
-            - daemonsets
-            verbs:
-            - get
-          # Can be removed if node authorizer is enabled
-          - apiGroups: [""]
-            resources:
-            - nodes
-            verbs:
-            - patch
-            - update
-          - apiGroups: ["extensions"]
-            resources:
-            - replicasets
-            verbs:
-            - get
-          - apiGroups: ["batch"]
-            resources:
-            - jobs
-            verbs:
-            - get
-          - apiGroups: [""]
-            resources:
-            - replicationcontrollers
-            verbs:
-            - get
-          - apiGroups: [""]
-            resources:
-            - pods/eviction
-            verbs:
-            - create
-          - nonResourceURLs: ["*"]
-            verbs: ["*"]
+      kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+          name: kube-aws:node-extensions
+      rules:
+        - apiGroups: ["extensions"]
+          resources:
+          - daemonsets
+          verbs:
+          - get
+        # Can be removed if node authorizer is enabled
+        - apiGroups: [""]
+          resources:
+          - nodes
+          verbs:
+          - patch
+          - update
+        - apiGroups: ["extensions"]
+          resources:
+          - replicasets
+          verbs:
+          - get
+        - apiGroups: ["batch"]
+          resources:
+          - jobs
+          verbs:
+          - get
+        - apiGroups: [""]
+          resources:
+          - replicationcontrollers
+          verbs:
+          - get
+        - apiGroups: [""]
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+        - nonResourceURLs: ["*"]
+          verbs: ["*"]
 
   # Grants super-user permissions to the kube-admin user
   - path: /srv/kubernetes/rbac/cluster-role-bindings/kube-admin.yaml
     content: |
-        kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1
-        metadata:
-          name: kube-aws:admin
-        subjects:
-          - kind: User
-            name: kube-admin
-        roleRef:
-          kind: ClusterRole
-          name: cluster-admin
-          apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: kube-aws:admin
+      subjects:
+        - kind: User
+          name: kube-admin
+      roleRef:
+        kind: ClusterRole
+        name: cluster-admin
+        apiGroup: rbac.authorization.k8s.io
 
   # Also allows `kube-worker` user to perform actions needed by the
   # `kube-proxy` component.
   - path: /srv/kubernetes/rbac/cluster-role-bindings/node-proxier.yaml
     content: |
-        kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1
-        metadata:
-          name: kube-aws:node-proxier
-        subjects:
-          - kind: User
-            name: kube-worker
-          - kind: ServiceAccount
-            name: kube-proxy
-            namespace: kube-system
-          # Not needed after migrating to DaemonSet-based kube-proxy
-          - kind: Group
-            name: system:nodes
-        roleRef:
-          kind: ClusterRole
-          name: system:node-proxier
-          apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: kube-aws:node-proxier
+      subjects:
+        - kind: User
+          name: kube-worker
+        - kind: ServiceAccount
+          name: kube-proxy
+          namespace: kube-system
+        # Not needed after migrating to DaemonSet-based kube-proxy
+        - kind: Group
+          name: system:nodes
+      roleRef:
+        kind: ClusterRole
+        name: system:node-proxier
+        apiGroup: rbac.authorization.k8s.io
 
   # Allows add-ons running with the default service account in kube-sytem to have super-user access
   - path: /srv/kubernetes/rbac/cluster-role-bindings/system-worker.yaml
     content: |
-        kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1
-        metadata:
-          name: kube-aws:system-worker
-        subjects:
-          - kind: ServiceAccount
-            namespace: kube-system
-            name: default
-        roleRef:
-          kind: ClusterRole
-          name: cluster-admin
-          apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: kube-aws:system-worker
+      subjects:
+        - kind: ServiceAccount
+          namespace: kube-system
+          name: default
+      roleRef:
+        kind: ClusterRole
+        name: cluster-admin
+        apiGroup: rbac.authorization.k8s.io
 
   # TODO: remove the following binding once the TLS Bootstrapping feature is enabled by default, see:
   # https://github.com/kubernetes-incubator/kube-aws/pull/618#discussion_r115162048
@@ -2966,19 +2982,19 @@ write_files:
   # extra kube-aws features (like node draining) work as expected
   - path: /srv/kubernetes/rbac/cluster-role-bindings/node-extensions.yaml
     content: |
-        kind: ClusterRoleBinding
-        apiVersion: rbac.authorization.k8s.io/v1
-        metadata:
-          name: kube-aws:node-extensions
-        subjects:
-          - kind: User
-            name: kube-worker
-          - kind: Group
-            name: system:nodes
-        roleRef:
-          kind: ClusterRole
-          name: kube-aws:node-extensions
-          apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: kube-aws:node-extensions
+      subjects:
+        - kind: User
+          name: kube-worker
+        - kind: Group
+          name: system:nodes
+      roleRef:
+        kind: ClusterRole
+        name: kube-aws:node-extensions
+        apiGroup: rbac.authorization.k8s.io
 
   # RBAC Rules to Allow Kubelet authentication to be enabled but accept unauthenticated GET calls to the /metrics endpoint
   - path: /srv/kubernetes/rbac/cluster-roles/node-access.yaml
@@ -3043,87 +3059,87 @@ write_files:
   # metrics-server
   - path: /srv/kubernetes/rbac/cluster-role-bindings/metrics-server.yaml
     content: |
-        apiVersion: rbac.authorization.k8s.io/v1beta1
-        kind: ClusterRoleBinding
-        metadata:
-          name: metrics-server:system:auth-delegator
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: system:auth-delegator
-        subjects:
-        - kind: ServiceAccount
-          name: metrics-server
-          namespace: kube-system
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          name: system:metrics-server
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: system:metrics-server
-        subjects:
-        - kind: ServiceAccount
-          name: metrics-server
-          namespace: kube-system
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: ClusterRoleBinding
+      metadata:
+        name: metrics-server:system:auth-delegator
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:auth-delegator
+      subjects:
+      - kind: ServiceAccount
+        name: metrics-server
+        namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: system:metrics-server
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:metrics-server
+      subjects:
+      - kind: ServiceAccount
+        name: metrics-server
+        namespace: kube-system
 
   - path: /srv/kubernetes/rbac/role-bindings/metrics-server.yaml
     content: |
-        apiVersion: rbac.authorization.k8s.io/v1beta1
-        kind: RoleBinding
-        metadata:
-          name: metrics-server-auth-reader
-          namespace: kube-system
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: Role
-          name: extension-apiserver-authentication-reader
-        subjects:
-        - kind: ServiceAccount
-          name: metrics-server
-          namespace: kube-system
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: RoleBinding
+      metadata:
+        name: metrics-server-auth-reader
+        namespace: kube-system
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: extension-apiserver-authentication-reader
+      subjects:
+      - kind: ServiceAccount
+        name: metrics-server
+        namespace: kube-system
 
   - path: /srv/kubernetes/rbac/cluster-roles/metrics-server.yaml
     content: |
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRole
-        metadata:
-          name: system:metrics-server
-        rules:
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - nodes
-          - nodes/stats
-          - namespaces
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - "extensions"
-          resources:
-          - deployments
-          verbs:
-          - get
-          - list
-          - watch
-        ---
-        kind: ClusterRole
-        apiVersion: rbac.authorization.k8s.io/v1
-        metadata:
-          name: system:aggregated-metrics-reader
-          labels:
-            rbac.authorization.k8s.io/aggregate-to-view: "true"
-            rbac.authorization.k8s.io/aggregate-to-edit: "true"
-            rbac.authorization.k8s.io/aggregate-to-admin: "true"
-        rules:
-        - apiGroups: ["metrics.k8s.io"]
-          resources: ["pods"]
-          verbs: ["get", "list", "watch"]
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: system:metrics-server
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - pods
+        - nodes
+        - nodes/stats
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - "extensions"
+        resources:
+        - deployments
+        verbs:
+        - get
+        - list
+        - watch
+      ---
+      kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: system:aggregated-metrics-reader
+        labels:
+          rbac.authorization.k8s.io/aggregate-to-view: "true"
+          rbac.authorization.k8s.io/aggregate-to-edit: "true"
+          rbac.authorization.k8s.io/aggregate-to-admin: "true"
+      rules:
+      - apiGroups: ["metrics.k8s.io"]
+        resources: ["pods"]
+        verbs: ["get", "list", "watch"]
 
   - path: /srv/kubernetes/rbac/cluster-role-bindings/nodes-can-create-csrs.yaml
     content: |
@@ -3208,68 +3224,71 @@ write_files:
 
   - path: /srv/kubernetes/manifests/kube-proxy-ds.yaml
     content: |
-        apiVersion: apps/v1
-        kind: DaemonSet
-        metadata:
-          name: kube-proxy
-          namespace: kube-system
-          labels:
-            k8s-app: kube-proxy
-        spec:
-          updateStrategy:
-            rollingUpdate:
-              maxUnavailable: 100%
-            type: RollingUpdate
-          template:
-            metadata:
-              labels:
-                k8s-app: kube-proxy
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ''
-            spec:
-              priorityClassName: system-node-critical
-              serviceAccountName: kube-proxy
-              tolerations:
-              - operator: Exists
-                effect: NoSchedule
-              - operator: Exists
-                effect: NoExecute
-              - operator: Exists
-                key: CriticalAddonsOnly
-              hostNetwork: true
-              containers:
-              - name: kube-proxy
-                image: {{.HyperkubeImage.RepoWithTag}}
-                command:
-                - /hyperkube
-                - kube-proxy
-                - --config=/etc/kubernetes/kube-proxy/kube-proxy-config.yaml
-                securityContext:
-                  privileged: true
-                volumeMounts:
-                {{if .KubeProxy.IPVSMode.Enabled -}}
-                - mountPath: /lib/modules
-                  name: lib-modules
-                  readOnly: true
-                {{end -}}
-                - mountPath: /etc/kubernetes/kubeconfig
-                  name: kubeconfig
-                  readOnly: true
-                - mountPath: /etc/kubernetes/kube-proxy
-                  name: kube-proxy-config
-                  readOnly: true
-              volumes:
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: kube-proxy
+        namespace: kube-system
+        labels:
+          k8s-app: kube-proxy
+      spec:
+        updateStrategy:
+          rollingUpdate:
+            maxUnavailable: 100%
+          type: RollingUpdate
+      selector:
+        matchLabels:
+          k8s-app: kube-proxy
+        template:
+          metadata:
+            labels:
+              k8s-app: kube-proxy
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            priorityClassName: system-node-critical
+            serviceAccountName: kube-proxy
+            tolerations:
+            - operator: Exists
+              effect: NoSchedule
+            - operator: Exists
+              effect: NoExecute
+            - operator: Exists
+              key: CriticalAddonsOnly
+            hostNetwork: true
+            containers:
+            - name: kube-proxy
+              image: {{.HyperkubeImage.RepoWithTag}}
+              command:
+              - /hyperkube
+              - kube-proxy
+              - --config=/etc/kubernetes/kube-proxy/kube-proxy-config.yaml
+              securityContext:
+                privileged: true
+              volumeMounts:
               {{if .KubeProxy.IPVSMode.Enabled -}}
-              - name: lib-modules
-                hostPath:
-                  path: /lib/modules
+              - mountPath: /lib/modules
+                name: lib-modules
+                readOnly: true
               {{end -}}
-              - name: kubeconfig
-                hostPath:
-                  path: /etc/kubernetes/kubeconfig
-              - name: kube-proxy-config
-                configMap:
-                  name: kube-proxy-config
+              - mountPath: /etc/kubernetes/kubeconfig
+                name: kubeconfig
+                readOnly: true
+              - mountPath: /etc/kubernetes/kube-proxy
+                name: kube-proxy-config
+                readOnly: true
+            volumes:
+            {{if .KubeProxy.IPVSMode.Enabled -}}
+            - name: lib-modules
+              hostPath:
+                path: /lib/modules
+            {{end -}}
+            - name: kubeconfig
+              hostPath:
+                path: /etc/kubernetes/kubeconfig
+            - name: kube-proxy-config
+              configMap:
+                name: kube-proxy-config
 
   - path: /etc/kubernetes/manifests/kube-apiserver.yaml
     content: |
@@ -3631,6 +3650,9 @@ write_files:
           kubernetes.io/name: "Rescheduler"
       spec:
         # `replicas` should always be the default of 1, rescheduler crashes otherwise
+        selector:
+          matchLabels:
+            k8s-app: kube-rescheduler
         template:
           metadata:
             labels:
@@ -3817,588 +3839,594 @@ write_files:
             {{- end }}
   - path: /srv/kubernetes/manifests/kube-proxy-sa.yaml
     content: |
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: kube-proxy
-          namespace: kube-system
-          labels:
-            kubernetes.io/cluster-service: "true"
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kube-proxy
+        namespace: kube-system
+        labels:
+          kubernetes.io/cluster-service: "true"
 
 {{- if eq .KubeDns.Provider "coredns" }}
   - path: /srv/kubernetes/manifests/coredns-sa.yaml
     content: |
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: coredns
-          namespace: kube-system
-          labels:
-            kubernetes.io/cluster-service: "true"
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: coredns
+        namespace: kube-system
+        labels:
+          kubernetes.io/cluster-service: "true"
 
   - path: /srv/kubernetes/manifests/coredns-cr.yaml
     content: |
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRole
-        metadata:
-          labels:
-            kubernetes.io/bootstrapping: rbac-defaults
-            addonmanager.kubernetes.io/mode: EnsureExists
-          name: system:coredns
-        rules:
-        - apiGroups:
-          - ""
-          resources:
-          - endpoints
-          - services
-          - pods
-          - namespaces
-          verbs:
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - nodes
-          verbs:
-          - get
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        labels:
+          kubernetes.io/bootstrapping: rbac-defaults
+          addonmanager.kubernetes.io/mode: EnsureExists
+        name: system:coredns
+      rules:
+      - apiGroups:
+        - ""
+        resources:
+        - endpoints
+        - services
+        - pods
+        - namespaces
+        verbs:
+        - list
+        - watch
+      - apiGroups:
+        - ""
+        resources:
+        - nodes
+        verbs:
+        - get
 
   - path: /srv/kubernetes/manifests/coredns-crb.yaml
     content: |
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          annotations:
-            rbac.authorization.kubernetes.io/autoupdate: "true"
-          labels:
-            kubernetes.io/bootstrapping: rbac-defaults
-            addonmanager.kubernetes.io/mode: EnsureExists
-          name: system:coredns
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: system:coredns
-        subjects:
-        - kind: ServiceAccount
-          name: coredns
-          namespace: kube-system
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        annotations:
+          rbac.authorization.kubernetes.io/autoupdate: "true"
+        labels:
+          kubernetes.io/bootstrapping: rbac-defaults
+          addonmanager.kubernetes.io/mode: EnsureExists
+        name: system:coredns
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:coredns
+      subjects:
+      - kind: ServiceAccount
+        name: coredns
+        namespace: kube-system
 
   - path: /srv/kubernetes/manifests/coredns-cm.yaml
     content: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: coredns
-          namespace: kube-system
-        data:
-          Corefile: |
-            .:53 {
-                errors
-                health
-                kubernetes cluster.local in-addr.arpa ip6.arpa {
-                    pods insecure
-                    upstream
-                    fallthrough in-addr.arpa ip6.arpa
-                    ttl {{ .KubeDns.TTL }}
-                }
-                forward . /etc/resolv.conf {
-                    except cluster.local
-                    health_check 5s
-                }
-                {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.ExtraCoreDNSConfig }}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: coredns
+        namespace: kube-system
+      data:
+        Corefile: |
+          .:53 {
+              errors
+              health
+              kubernetes cluster.local in-addr.arpa ip6.arpa {
+                  pods insecure
+                  upstream
+                  fallthrough in-addr.arpa ip6.arpa
+                  ttl {{ .KubeDns.TTL }}
+              }
+              forward . /etc/resolv.conf {
+                  except cluster.local
+                  health_check 5s
+              }
+              {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.ExtraCoreDNSConfig }}
 {{ .KubeDns.ExtraCoreDNSConfig | indent 16 }}
-                {{- end }}
-                prometheus :9153
-                cache {{ .KubeDns.TTL }}
-                loop
-                reload
-                loadbalance
-            }
+              {{- end }}
+              prometheus :9153
+              cache {{ .KubeDns.TTL }}
+              loop
+              reload
+              loadbalance
+          }
 {{- else }}
   - path: /srv/kubernetes/manifests/kube-dns-sa.yaml
     content: |
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: kube-dns
-          namespace: kube-system
-          labels:
-            kubernetes.io/cluster-service: "true"
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kube-dns
+        namespace: kube-system
+        labels:
+          kubernetes.io/cluster-service: "true"
 
   - path: /srv/kubernetes/manifests/kube-dns-cm.yaml
     content: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: kube-dns
-          namespace: kube-system
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-dns
+        namespace: kube-system
 {{- end }}
 
   - path: /srv/kubernetes/manifests/kube-dns-autoscaler-de.yaml
     content: |
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: kube-dns-autoscaler
-          namespace: kube-system
-          labels:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kube-dns-autoscaler
+        namespace: kube-system
+        labels:
+          k8s-app: kube-dns-autoscaler
+          kubernetes.io/cluster-service: "true"
+      spec:
+        selector:
+          matchLabels:
             k8s-app: kube-dns-autoscaler
-            kubernetes.io/cluster-service: "true"
-        spec:
-          template:
-            metadata:
-              labels:
-                k8s-app: kube-dns-autoscaler
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ''
-            spec:
-              priorityClassName: system-cluster-critical
-              tolerations:
-              - key: "CriticalAddonsOnly"
-                operator: "Exists"
-              containers:
-              - name: autoscaler
-                image: {{ .ClusterProportionalAutoscalerImage.RepoWithTag }}
-                resources:
-                    requests:
-                        cpu: "20m"
-                        memory: "10Mi"
-                command:
-                  - /cluster-proportional-autoscaler
-                  - --namespace=kube-system
-                  - --configmap=kube-dns-autoscaler
-                  {{- if eq .KubeDns.Provider "coredns" }}
-                  - --target=Deployment/coredns
-                  {{- else }}
-                  - --target=Deployment/kube-dns
-                  {{- end }}
-                  - --default-params={"linear":{"coresPerReplica":{{ .KubeDns.Autoscaler.CoresPerReplica }},"nodesPerReplica":{{ .KubeDns.Autoscaler.NodesPerReplica }},"min":{{ .KubeDns.Autoscaler.Min}}}}
-                  - --v=2
-                  - --logtostderr
+        template:
+          metadata:
+            labels:
+              k8s-app: kube-dns-autoscaler
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            priorityClassName: system-cluster-critical
+            tolerations:
+            - key: "CriticalAddonsOnly"
+              operator: "Exists"
+            containers:
+            - name: autoscaler
+              image: {{ .ClusterProportionalAutoscalerImage.RepoWithTag }}
+              resources:
+                  requests:
+                      cpu: "20m"
+                      memory: "10Mi"
+              command:
+                - /cluster-proportional-autoscaler
+                - --namespace=kube-system
+                - --configmap=kube-dns-autoscaler
+                {{- if eq .KubeDns.Provider "coredns" }}
+                - --target=Deployment/coredns
+                {{- else }}
+                - --target=Deployment/kube-dns
+                {{- end }}
+                - --default-params={"linear":{"coresPerReplica":{{ .KubeDns.Autoscaler.CoresPerReplica }},"nodesPerReplica":{{ .KubeDns.Autoscaler.NodesPerReplica }},"min":{{ .KubeDns.Autoscaler.Min}}}}
+                - --v=2
+                - --logtostderr
 
 {{ if .KubeDns.NodeLocalResolver }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-ds.yaml
     content: |
-        apiVersion: apps/v1
-        kind: DaemonSet
-        metadata:
-          name: dnsmasq-node
-          namespace: kube-system
-          labels:
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: dnsmasq-node
+        namespace: kube-system
+        labels:
+          k8s-app: dnsmasq-node
+      spec:
+        updateStrategy:
+          rollingUpdate:
+            maxUnavailable: 100%
+          type: RollingUpdate
+        selector:
+          matchLabels:
             k8s-app: dnsmasq-node
-        spec:
-          updateStrategy:
-            rollingUpdate:
-              maxUnavailable: 100%
-            type: RollingUpdate
-          template:
-            metadata:
-              labels:
-                k8s-app: dnsmasq-node
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ''
-            spec:
-              priorityClassName: system-node-critical
-              tolerations:
-              - operator: Exists
-                effect: NoSchedule
-              - operator: Exists
-                effect: NoExecute
-              - operator: Exists
-                key: CriticalAddonsOnly
-              volumes:
-              - name: kube-dns-config
-                configMap:
-                  name: kube-dns
-                  optional: true
-              containers:
-              - name: dnsmasq
-                image: {{ .KubeDnsMasqImage.RepoWithTag }}
-                livenessProbe:
-                  httpGet:
-                    path: /healthcheck/dnsmasq
-                    port: 10054
-                    scheme: HTTP
-                  initialDelaySeconds: 60
-                  timeoutSeconds: 5
-                  successThreshold: 1
-                  failureThreshold: 5
-                args:
-                - -v=2
-                - -logtostderr
-                - -configDir=/etc/k8s/dns/dnsmasq-nanny
-                - -restartDnsmasq=true
-                - --
-                - -k
-                - --min-port=1024
-                - --cache-size=1000
-                - --server=//{{.DNSServiceIP}}
-                - --server=/cluster.local/{{.DNSServiceIP}}
-                - --server=/in-addr.arpa/{{.DNSServiceIP}}
-                - --server=/ip6.arpa/{{.DNSServiceIP}}
-                - --log-facility=-
-                {{- if ne (len .KubeDns.NodeLocalResolverOptions) 0 }}
-                  {{- range .KubeDns.NodeLocalResolverOptions }}
-                - {{.}}
-                  {{- end }}
+        template:
+          metadata:
+            labels:
+              k8s-app: dnsmasq-node
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            priorityClassName: system-node-critical
+            tolerations:
+            - operator: Exists
+              effect: NoSchedule
+            - operator: Exists
+              effect: NoExecute
+            - operator: Exists
+              key: CriticalAddonsOnly
+            volumes:
+            - name: kube-dns-config
+              configMap:
+                name: kube-dns
+                optional: true
+            containers:
+            - name: dnsmasq
+              image: {{ .KubeDnsMasqImage.RepoWithTag }}
+              livenessProbe:
+                httpGet:
+                  path: /healthcheck/dnsmasq
+                  port: 10054
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                successThreshold: 1
+                failureThreshold: 5
+              args:
+              - -v=2
+              - -logtostderr
+              - -configDir=/etc/k8s/dns/dnsmasq-nanny
+              - -restartDnsmasq=true
+              - --
+              - -k
+              - --min-port=1024
+              - --cache-size=1000
+              - --server=//{{.DNSServiceIP}}
+              - --server=/cluster.local/{{.DNSServiceIP}}
+              - --server=/in-addr.arpa/{{.DNSServiceIP}}
+              - --server=/ip6.arpa/{{.DNSServiceIP}}
+              - --log-facility=-
+              {{- if ne (len .KubeDns.NodeLocalResolverOptions) 0 }}
+                {{- range .KubeDns.NodeLocalResolverOptions }}
+              - {{.}}
                 {{- end }}
-                ports:
-                - containerPort: 53
-                  name: dns
-                  protocol: UDP
-                - containerPort: 53
-                  name: dns-tcp
-                  protocol: TCP
-                # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
-                resources:
-                  requests:
-                    cpu: 150m
-                    memory: 20Mi
-                volumeMounts:
-                - name: kube-dns-config
-                  mountPath: /etc/k8s/dns/dnsmasq-nanny
-              - name: sidecar
-                image: {{ .DnsMasqMetricsImage.RepoWithTag }}
-                livenessProbe:
-                  httpGet:
-                    path: /metrics
-                    port: 10054
-                    scheme: HTTP
-                  initialDelaySeconds: 60
-                  timeoutSeconds: 5
-                  successThreshold: 1
-                  failureThreshold: 5
-                args:
-                - --v=2
-                - --logtostderr
-                - --probe=dnsmasq,127.0.0.1:53,ec2.amazonaws.com,5,A
-                ports:
-                - containerPort: 10054
-                  name: metrics
-                  protocol: TCP
-                resources:
-                  requests:
-                    memory: 20Mi
-              hostNetwork: true
-              dnsPolicy: Default
-              automountServiceAccountToken: false
+              {{- end }}
+              ports:
+              - containerPort: 53
+                name: dns
+                protocol: UDP
+              - containerPort: 53
+                name: dns-tcp
+                protocol: TCP
+              # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+              resources:
+                requests:
+                  cpu: 150m
+                  memory: 20Mi
+              volumeMounts:
+              - name: kube-dns-config
+                mountPath: /etc/k8s/dns/dnsmasq-nanny
+            - name: sidecar
+              image: {{ .DnsMasqMetricsImage.RepoWithTag }}
+              livenessProbe:
+                httpGet:
+                  path: /metrics
+                  port: 10054
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                successThreshold: 1
+                failureThreshold: 5
+              args:
+              - --v=2
+              - --logtostderr
+              - --probe=dnsmasq,127.0.0.1:53,ec2.amazonaws.com,5,A
+              ports:
+              - containerPort: 10054
+                name: metrics
+                protocol: TCP
+              resources:
+                requests:
+                  memory: 20Mi
+            hostNetwork: true
+            dnsPolicy: Default
+            automountServiceAccountToken: false
 {{ end }}
 
 {{- if eq .KubeDns.Provider "coredns" }}
   - path: /srv/kubernetes/manifests/coredns-de.yaml
     content: |
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: coredns
-          namespace: kube-system
-          labels:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: coredns
+        namespace: kube-system
+        labels:
+          k8s-app: kube-dns
+          kubernetes.io/cluster-service: "true"
+          addonmanager.kubernetes.io/mode: Reconcile
+          kubernetes.io/name: "CoreDNS"
+      spec:
+        # replicas: not specified here:
+        # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+        # 2. Default is 1.
+        # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+        strategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 1
+        selector:
+          matchLabels:
             k8s-app: kube-dns
-            kubernetes.io/cluster-service: "true"
-            addonmanager.kubernetes.io/mode: Reconcile
-            kubernetes.io/name: "CoreDNS"
-        spec:
-          # replicas: not specified here:
-          # 1. In order to make Addon Manager do not reconcile this replicas parameter.
-          # 2. Default is 1.
-          # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
-          strategy:
-            type: RollingUpdate
-            rollingUpdate:
-              maxUnavailable: 1
-          selector:
-            matchLabels:
+        template:
+          metadata:
+            labels:
               k8s-app: kube-dns
-          template:
-            metadata:
-              labels:
-                k8s-app: kube-dns
-              annotations:
-                prometheus.io/port: "9153"
-                prometheus.io/scrape: "true"
-                seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
-            spec:
-              priorityClassName: system-node-critical
-              serviceAccountName: coredns
-              {{ if or .KubeDns.DeployToControllers .KubeDns.AntiAffinityAvailabilityZone -}}
-              affinity:
-                {{- if .KubeDns.DeployToControllers }}
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: node.kubernetes.io/role
+            annotations:
+              prometheus.io/port: "9153"
+              prometheus.io/scrape: "true"
+              seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+          spec:
+            priorityClassName: system-node-critical
+            serviceAccountName: coredns
+            {{ if or .KubeDns.DeployToControllers .KubeDns.AntiAffinityAvailabilityZone -}}
+            affinity:
+              {{- if .KubeDns.DeployToControllers }}
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: node.kubernetes.io/role
+                      operator: In
+                      values:
+                      - "master"
+              {{- end }}
+              {{- if .KubeDns.AntiAffinityAvailabilityZone }}
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                      - key: k8s-app
                         operator: In
                         values:
-                        - "master"
-                {{- end }}
-                {{- if .KubeDns.AntiAffinityAvailabilityZone }}
-                podAntiAffinity:
-                  preferredDuringSchedulingIgnoredDuringExecution:
-                  - podAffinityTerm:
-                      labelSelector:
-                        matchExpressions:
-                        - key: k8s-app
-                          operator: In
-                          values:
-                          - "kube-dns"
-                      topologyKey: "failure-domain.beta.kubernetes.io/zone"
-                    weight: 1
-                {{- end }}
-              tolerations:
-               - key: "CriticalAddonsOnly"
-                 operator: "Exists"
-               - key: "node.kubernetes.io/role"
-                 operator: "Equal"
-                 value: "master"
-                 effect: "NoSchedule"
-              {{ else -}}
-              tolerations:
+                        - "kube-dns"
+                    topologyKey: "failure-domain.beta.kubernetes.io/zone"
+                  weight: 1
+              {{- end }}
+            tolerations:
               - key: "CriticalAddonsOnly"
                 operator: "Exists"
-              {{ end -}}
-              containers:
-              - name: coredns
-                image: {{ .CoreDnsImage.RepoWithTag }}
-                imagePullPolicy: IfNotPresent
-                resources:
-                  limits:
-                    cpu: {{ .KubeDns.DnsDeploymentResources.Limits.Cpu }}
-                    memory: {{ .KubeDns.DnsDeploymentResources.Limits.Memory }}
-                  requests:
-                    cpu: {{ .KubeDns.DnsDeploymentResources.Requests.Cpu }}
-                    memory: {{ .KubeDns.DnsDeploymentResources.Requests.Memory }}
-                args: [ "-conf", "/etc/coredns/Corefile" ]
-                volumeMounts:
-                - name: config-volume
-                  mountPath: /etc/coredns
-                ports:
-                - containerPort: 53
-                  name: dns
-                  protocol: UDP
-                - containerPort: 53
-                  name: dns-tcp
-                  protocol: TCP
-                - containerPort: 9153
-                  name: metrics
-                  protocol: TCP
-                livenessProbe:
-                  httpGet:
-                    path: /health
-                    port: 8080
-                    scheme: HTTP
-                  initialDelaySeconds: 60
-                  timeoutSeconds: 5
-                  successThreshold: 1
-                  failureThreshold: 5
-              dnsPolicy: Default
-              volumes:
-                - name: config-volume
-                  configMap:
-                    name: coredns
-                    items:
-                    - key: Corefile
-                      path: Corefile
+              - key: "node.kubernetes.io/role"
+                operator: "Equal"
+                value: "master"
+                effect: "NoSchedule"
+            {{ else -}}
+            tolerations:
+            - key: "CriticalAddonsOnly"
+              operator: "Exists"
+            {{ end -}}
+            containers:
+            - name: coredns
+              image: {{ .CoreDnsImage.RepoWithTag }}
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: {{ .KubeDns.DnsDeploymentResources.Limits.Cpu }}
+                  memory: {{ .KubeDns.DnsDeploymentResources.Limits.Memory }}
+                requests:
+                  cpu: {{ .KubeDns.DnsDeploymentResources.Requests.Cpu }}
+                  memory: {{ .KubeDns.DnsDeploymentResources.Requests.Memory }}
+              args: [ "-conf", "/etc/coredns/Corefile" ]
+              volumeMounts:
+              - name: config-volume
+                mountPath: /etc/coredns
+              ports:
+              - containerPort: 53
+                name: dns
+                protocol: UDP
+              - containerPort: 53
+                name: dns-tcp
+                protocol: TCP
+              - containerPort: 9153
+                name: metrics
+                protocol: TCP
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                successThreshold: 1
+                failureThreshold: 5
+            dnsPolicy: Default
+            volumes:
+              - name: config-volume
+                configMap:
+                  name: coredns
+                  items:
+                  - key: Corefile
+                    path: Corefile
 {{- else }}
   - path: /srv/kubernetes/manifests/kube-dns-de.yaml
     content: |
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: kube-dns
-          namespace: kube-system
-          labels:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kube-dns
+        namespace: kube-system
+        labels:
+          k8s-app: kube-dns
+          kubernetes.io/cluster-service: "true"
+      spec:
+        # replicas: not specified here:
+        # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+        # 2. Default is 1.
+        # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+        strategy:
+          rollingUpdate:
+            maxSurge: 10%
+            maxUnavailable: 0
+        selector:
+          matchLabels:
             k8s-app: kube-dns
-            kubernetes.io/cluster-service: "true"
-        spec:
-          # replicas: not specified here:
-          # 1. In order to make Addon Manager do not reconcile this replicas parameter.
-          # 2. Default is 1.
-          # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
-          strategy:
-            rollingUpdate:
-              maxSurge: 10%
-              maxUnavailable: 0
-          selector:
-            matchLabels:
+        template:
+          metadata:
+            labels:
               k8s-app: kube-dns
-          template:
-            metadata:
-              labels:
-                k8s-app: kube-dns
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ''
-            spec:
-              priorityClassName: system-cluster-critical
-              volumes:
-              - name: kube-dns-config
-                configMap:
-                  name: kube-dns
-                  optional: true
-              {{ if .KubeDns.DeployToControllers -}}
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: node.kubernetes.io/role
-                        operator: In
-                        values:
-                        - "master"
-              tolerations:
-               - key: "CriticalAddonsOnly"
-                 operator: "Exists"
-               - key: "node.kubernetes.io/role"
-                 operator: "Equal"
-                 value: "master"
-                 effect: "NoSchedule"
-              {{ else -}}
-              tolerations:
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            priorityClassName: system-cluster-critical
+            volumes:
+            - name: kube-dns-config
+              configMap:
+                name: kube-dns
+                optional: true
+            {{ if .KubeDns.DeployToControllers -}}
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: node.kubernetes.io/role
+                      operator: In
+                      values:
+                      - "master"
+            tolerations:
               - key: "CriticalAddonsOnly"
                 operator: "Exists"
-              {{ end -}}
-              containers:
-              - name: kubedns
-                image: {{ .KubeDnsImage.RepoWithTag }}
-                resources:
-                  limits:
-                    cpu: {{ .KubeDns.DnsDeploymentResources.Limits.Cpu }}
-                    memory: {{ .KubeDns.DnsDeploymentResources.Limits.Memory }}
-                  requests:
-                    cpu: {{ .KubeDns.DnsDeploymentResources.Requests.Cpu }}
-                    memory: {{ .KubeDns.DnsDeploymentResources.Requests.Memory }}
-                livenessProbe:
-                  httpGet:
-                    path: /healthcheck/kubedns
-                    port: 10054
-                    scheme: HTTP
-                  initialDelaySeconds: 60
-                  timeoutSeconds: 5
-                  successThreshold: 1
-                  failureThreshold: 5
-                readinessProbe:
-                  httpGet:
-                    path: /readiness
-                    port: 8081
-                    scheme: HTTP
-                  initialDelaySeconds: 3
-                  timeoutSeconds: 5
-                args:
-                - --domain=cluster.local.
-                - --dns-port=10053
-                - --config-dir=/kube-dns-config
-                # This should be set to v=2 only after the new image (cut from 1.5) has
-                # been released, otherwise we will flood the logs.
-                - --v=2
-                env:
-                - name: PROMETHEUS_PORT
-                  value: "10055"
-                ports:
-                - containerPort: 10053
-                  name: dns-local
-                  protocol: UDP
-                - containerPort: 10053
-                  name: dns-tcp-local
-                  protocol: TCP
-                - containerPort: 10055
-                  name: metrics
-                  protocol: TCP
-                volumeMounts:
-                - name: kube-dns-config
-                  mountPath: /kube-dns-config
-              - name: dnsmasq
-                image: {{ .KubeDnsMasqImage.RepoWithTag }}
-                livenessProbe:
-                  httpGet:
-                    path: /healthcheck/dnsmasq
-                    port: 10054
-                    scheme: HTTP
-                  initialDelaySeconds: 60
-                  timeoutSeconds: 5
-                  successThreshold: 1
-                  failureThreshold: 5
-                args:
-                - -v=2
-                - -logtostderr
-                - -configDir=/etc/k8s/dns/dnsmasq-nanny
-                - -restartDnsmasq=true
-                - --
-                - -k
-                - --cache-size=1000
-                - --log-facility=-
-                - --server=/cluster.local/127.0.0.1#10053
-                - --server=/in-addr.arpa/127.0.0.1#10053
-                - --server=/ip6.arpa/127.0.0.1#10053
-                ports:
-                - containerPort: 53
-                  name: dns
-                  protocol: UDP
-                - containerPort: 53
-                  name: dns-tcp
-                  protocol: TCP
-                # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
-                resources:
-                  requests:
-                    cpu: 150m
-                    memory: 20Mi
-                volumeMounts:
-                - name: kube-dns-config
-                  mountPath: /etc/k8s/dns/dnsmasq-nanny
-              - name: sidecar
-                image: {{ .DnsMasqMetricsImage.RepoWithTag }}
-                livenessProbe:
-                  httpGet:
-                    path: /metrics
-                    port: 10054
-                    scheme: HTTP
-                  initialDelaySeconds: 60
-                  timeoutSeconds: 5
-                  successThreshold: 1
-                  failureThreshold: 5
-                args:
-                - --v=2
-                - --logtostderr
-                - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,A
-                - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,A
-                ports:
-                - containerPort: 10054
-                  name: metrics
-                  protocol: TCP
-                resources:
-                  requests:
-                    memory: 20Mi
-                    cpu: 10m
-              dnsPolicy: Default
-              serviceAccountName: kube-dns
+              - key: "node.kubernetes.io/role"
+                operator: "Equal"
+                value: "master"
+                effect: "NoSchedule"
+            {{ else -}}
+            tolerations:
+            - key: "CriticalAddonsOnly"
+              operator: "Exists"
+            {{ end -}}
+            containers:
+            - name: kubedns
+              image: {{ .KubeDnsImage.RepoWithTag }}
+              resources:
+                limits:
+                  cpu: {{ .KubeDns.DnsDeploymentResources.Limits.Cpu }}
+                  memory: {{ .KubeDns.DnsDeploymentResources.Limits.Memory }}
+                requests:
+                  cpu: {{ .KubeDns.DnsDeploymentResources.Requests.Cpu }}
+                  memory: {{ .KubeDns.DnsDeploymentResources.Requests.Memory }}
+              livenessProbe:
+                httpGet:
+                  path: /healthcheck/kubedns
+                  port: 10054
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                successThreshold: 1
+                failureThreshold: 5
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: 8081
+                  scheme: HTTP
+                initialDelaySeconds: 3
+                timeoutSeconds: 5
+              args:
+              - --domain=cluster.local.
+              - --dns-port=10053
+              - --config-dir=/kube-dns-config
+              # This should be set to v=2 only after the new image (cut from 1.5) has
+              # been released, otherwise we will flood the logs.
+              - --v=2
+              env:
+              - name: PROMETHEUS_PORT
+                value: "10055"
+              ports:
+              - containerPort: 10053
+                name: dns-local
+                protocol: UDP
+              - containerPort: 10053
+                name: dns-tcp-local
+                protocol: TCP
+              - containerPort: 10055
+                name: metrics
+                protocol: TCP
+              volumeMounts:
+              - name: kube-dns-config
+                mountPath: /kube-dns-config
+            - name: dnsmasq
+              image: {{ .KubeDnsMasqImage.RepoWithTag }}
+              livenessProbe:
+                httpGet:
+                  path: /healthcheck/dnsmasq
+                  port: 10054
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                successThreshold: 1
+                failureThreshold: 5
+              args:
+              - -v=2
+              - -logtostderr
+              - -configDir=/etc/k8s/dns/dnsmasq-nanny
+              - -restartDnsmasq=true
+              - --
+              - -k
+              - --cache-size=1000
+              - --log-facility=-
+              - --server=/cluster.local/127.0.0.1#10053
+              - --server=/in-addr.arpa/127.0.0.1#10053
+              - --server=/ip6.arpa/127.0.0.1#10053
+              ports:
+              - containerPort: 53
+                name: dns
+                protocol: UDP
+              - containerPort: 53
+                name: dns-tcp
+                protocol: TCP
+              # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+              resources:
+                requests:
+                  cpu: 150m
+                  memory: 20Mi
+              volumeMounts:
+              - name: kube-dns-config
+                mountPath: /etc/k8s/dns/dnsmasq-nanny
+            - name: sidecar
+              image: {{ .DnsMasqMetricsImage.RepoWithTag }}
+              livenessProbe:
+                httpGet:
+                  path: /metrics
+                  port: 10054
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                successThreshold: 1
+                failureThreshold: 5
+              args:
+              - --v=2
+              - --logtostderr
+              - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,A
+              - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,A
+              ports:
+              - containerPort: 10054
+                name: metrics
+                protocol: TCP
+              resources:
+                requests:
+                  memory: 20Mi
+                  cpu: 10m
+            dnsPolicy: Default
+            serviceAccountName: kube-dns
 {{- end }}
 
   - path: /srv/kubernetes/manifests/kube-dns-svc.yaml
     content: |
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: kube-dns
-          namespace: kube-system
-          labels:
-            k8s-app: kube-dns
-            kubernetes.io/cluster-service: "true"
-            addonmanager.kubernetes.io/mode: Reconcile
-            {{- if eq .KubeDns.Provider "coredns" }}
-            kubernetes.io/name: "CoreDNS"
-            {{- else }}
-            kubernetes.io/name: "KubeDNS"
-            {{- end }}
-        spec:
-          selector:
-            k8s-app: kube-dns
-          clusterIP: {{.DNSServiceIP}}
-          ports:
-          - name: dns
-            port: 53
-            protocol: UDP
-          - name: dns-tcp
-            port: 53
-            protocol: TCP
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: kube-dns
+        namespace: kube-system
+        labels:
+          k8s-app: kube-dns
+          kubernetes.io/cluster-service: "true"
+          addonmanager.kubernetes.io/mode: Reconcile
+          {{- if eq .KubeDns.Provider "coredns" }}
+          kubernetes.io/name: "CoreDNS"
+          {{- else }}
+          kubernetes.io/name: "KubeDNS"
+          {{- end }}
+      spec:
+        selector:
+          k8s-app: kube-dns
+        clusterIP: {{.DNSServiceIP}}
+        ports:
+        - name: dns
+          port: 53
+          protocol: UDP
+        - name: dns-tcp
+          port: 53
+          protocol: TCP
 
   - path: /srv/kubernetes/manifests/kube-dns-pdb.yaml
     content: |
@@ -4424,190 +4452,194 @@ write_files:
 
   - path: /srv/kubernetes/manifests/metrics-server-de.yaml
     content: |
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: metrics-server
-          namespace: kube-system
-          labels:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: metrics-server
+        namespace: kube-system
+        labels:
+          k8s-app: metrics-server
+        annotations:
+          scheduler.alpha.kubernetes.io/critical-pod: ''
+      spec:
+        selector:
+          matchLabels:
             k8s-app: metrics-server
-          annotations:
-            scheduler.alpha.kubernetes.io/critical-pod: ''
-        spec:
-          selector:
-            matchLabels:
+        template:
+          metadata:
+            name: metrics-server
+            labels:
               k8s-app: metrics-server
-          template:
-            metadata:
-              name: metrics-server
-              labels:
-                k8s-app: metrics-server
-            spec:
-              priorityClassName: system-cluster-critical
-              serviceAccountName: metrics-server
-              containers:
-              - name: metrics-server
-                image: {{ .MetricsServerImage.RepoWithTag }}
-                imagePullPolicy: Always
-                command:
-                - /metrics-server
-                - --logtostderr
-                - --v=2
-                - --kubelet-insecure-tls
-                - --requestheader-client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                - --requestheader-username-headers=X-Remote-User
-                - --requestheader-group-headers=X-Remote-Group
-                - --requestheader-extra-headers-prefix=X-Remote-Extra
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 512Mi
-                  requests:
-                    cpu: 80m
-                    memory: 200Mi
-                volumeMounts:
-                - name: tmp-dir
-                  mountPath: /tmp
-              volumes:
+          spec:
+            priorityClassName: system-cluster-critical
+            serviceAccountName: metrics-server
+            containers:
+            - name: metrics-server
+              image: {{ .MetricsServerImage.RepoWithTag }}
+              imagePullPolicy: Always
+              command:
+              - /metrics-server
+              - --logtostderr
+              - --v=2
+              - --kubelet-insecure-tls
+              - --requestheader-client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              - --requestheader-username-headers=X-Remote-User
+              - --requestheader-group-headers=X-Remote-Group
+              - --requestheader-extra-headers-prefix=X-Remote-Extra
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 80m
+                  memory: 200Mi
+              volumeMounts:
               - name: tmp-dir
-                emptyDir: {}
+                mountPath: /tmp
+            volumes:
+            - name: tmp-dir
+              emptyDir: {}
 
   - path: /srv/kubernetes/manifests/metrics-server-apisvc.yaml
     content: |
-        apiVersion: apiregistration.k8s.io/v1beta1
-        kind: APIService
-        metadata:
-          name: v1beta1.metrics.k8s.io
-        spec:
-          service:
-            name: metrics-server
-            namespace: kube-system
-          group: metrics.k8s.io
-          version: v1beta1
-          insecureSkipTLSVerify: true
-          groupPriorityMinimum: 100
-          versionPriority: 100
+      apiVersion: apiregistration.k8s.io/v1beta1
+      kind: APIService
+      metadata:
+        name: v1beta1.metrics.k8s.io
+      spec:
+        service:
+          name: metrics-server
+          namespace: kube-system
+        group: metrics.k8s.io
+        version: v1beta1
+        insecureSkipTLSVerify: true
+        groupPriorityMinimum: 100
+        versionPriority: 100
 
   - path: /srv/kubernetes/manifests/metrics-server-svc.yaml
     content: |
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: metrics-server
-          namespace: kube-system
-          labels:
-            kubernetes.io/name: "Metrics-server"
-            kubernetes.io/cluster-service: "true"
-        spec:
-          selector:
-            k8s-app: metrics-server
-          ports:
-          - port: 443
-            protocol: TCP
-            targetPort: 443
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: metrics-server
+        namespace: kube-system
+        labels:
+          kubernetes.io/name: "Metrics-server"
+          kubernetes.io/cluster-service: "true"
+      spec:
+        selector:
+          k8s-app: metrics-server
+        ports:
+        - port: 443
+          protocol: TCP
+          targetPort: 443
 
   - path: /srv/kubernetes/manifests/tiller.yaml
     content: |
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          creationTimestamp: null
-          labels:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: helm
+          name: tiller
+        name: tiller-deploy
+        namespace: kube-system
+      spec:
+        selector:
+          matchLabels:
             app: helm
             name: tiller
-          name: tiller-deploy
-          namespace: kube-system
-        spec:
-          strategy: {}
-          template:
-            metadata:
-              creationTimestamp: null
-              labels:
-                app: helm
+        strategy: {}
+        template:
+          metadata:
+            creationTimestamp: null
+            labels:
+              app: helm
+              name: tiller
+            # Addition to the default tiller deployment for prioritizing tiller over other non-critical pods with rescheduler
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            serviceAccountName: tiller
+            priorityClassName: system-cluster-critical
+            tolerations:
+            # Additions to the default tiller deployment for allowing to schedule tiller onto controller nodes
+            # so that helm can be used to install pods running only on controller nodes
+            - key: "node.kubernetes.io/role"
+              operator: "Equal"
+              value: "master"
+              effect: "NoSchedule"
+            - key: "CriticalAddonsOnly"
+              operator: "Exists"
+            containers:
+            - env:
+              - name: TILLER_NAMESPACE
+                value: kube-system
+              image: {{.TillerImage.RepoWithTag}}
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /liveness
+                  port: 44135
+                initialDelaySeconds: 1
+                timeoutSeconds: 1
+              name: tiller
+              ports:
+              - containerPort: 44134
                 name: tiller
-              # Addition to the default tiller deployment for prioritizing tiller over other non-critical pods with rescheduler
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ''
-            spec:
-              serviceAccountName: tiller
-              priorityClassName: system-cluster-critical
-              tolerations:
-              # Additions to the default tiller deployment for allowing to schedule tiller onto controller nodes
-              # so that helm can be used to install pods running only on controller nodes
-              - key: "node.kubernetes.io/role"
-                operator: "Equal"
-                value: "master"
-                effect: "NoSchedule"
-              - key: "CriticalAddonsOnly"
-                operator: "Exists"
-              containers:
-              - env:
-                - name: TILLER_NAMESPACE
-                  value: kube-system
-                image: {{.TillerImage.RepoWithTag}}
-                imagePullPolicy: IfNotPresent
-                livenessProbe:
-                  httpGet:
-                    path: /liveness
-                    port: 44135
-                  initialDelaySeconds: 1
-                  timeoutSeconds: 1
-                name: tiller
-                ports:
-                - containerPort: 44134
-                  name: tiller
-                readinessProbe:
-                  httpGet:
-                    path: /readiness
-                    port: 44135
-                  initialDelaySeconds: 1
-                  timeoutSeconds: 1
-                resources: {}
-              nodeSelector:
-                beta.kubernetes.io/os: linux
-        status: {}
-        ---
-        apiVersion: v1
-        kind: Service
-        metadata:
-          creationTimestamp: null
-          labels:
-            app: helm
-            name: tiller
-          name: tiller-deploy
-          namespace: kube-system
-        spec:
-          ports:
-          - name: tiller
-            port: 44134
-            targetPort: tiller
-          selector:
-            app: helm
-            name: tiller
-          type: ClusterIP
-        status:
-          loadBalancer: {}
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: 44135
+                initialDelaySeconds: 1
+                timeoutSeconds: 1
+              resources: {}
+            nodeSelector:
+              beta.kubernetes.io/os: linux
+      status: {}
+      ---
+      apiVersion: v1
+      kind: Service
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: helm
+          name: tiller
+        name: tiller-deploy
+        namespace: kube-system
+      spec:
+        ports:
+        - name: tiller
+          port: 44134
+          targetPort: tiller
+        selector:
+          app: helm
+          name: tiller
+        type: ClusterIP
+      status:
+        loadBalancer: {}
 
   - path: /srv/kubernetes/manifests/tiller-rbac.yaml
     content: |
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: tiller
-          namespace: kube-system
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          name: tiller
-        subjects:
-        - kind: ServiceAccount
-          name: tiller
-          namespace: kube-system
-        roleRef:
-          kind: ClusterRole
-          name: cluster-admin
-          apiGroup: rbac.authorization.k8s.io
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: tiller
+        namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: tiller
+      subjects:
+      - kind: ServiceAccount
+        name: tiller
+        namespace: kube-system
+      roleRef:
+        kind: ClusterRole
+        name: cluster-admin
+        apiGroup: rbac.authorization.k8s.io
 
   - path: {{.KubernetesManifestPlugin.ManifestListFile.Path}}
     encoding: gzip+base64
@@ -4655,65 +4687,65 @@ write_files:
 {{- if checkVersion ">= 1.14" .K8sVer }}
   - path: /etc/kubernetes/kubeconfig/worker-bootstrap.yaml
     content: |
-        apiVersion: v1
-        kind: Config
-        clusters:
-        - name: local
-          cluster:
-            certificate-authority: /etc/kubernetes/ssl/ca.pem
-            server: https://127.0.0.1
-        users:
-        - name: tls-bootstrap
-          user:
-            token: $KUBELET_BOOTSTRAP_TOKEN
-        contexts:
-        - context:
-            cluster: local
-            user: tls-bootstrap
-          name: tls-bootstrap-context
-        current-context: tls-bootstrap-context
+      apiVersion: v1
+      kind: Config
+      clusters:
+      - name: local
+        cluster:
+          certificate-authority: /etc/kubernetes/ssl/ca.pem
+          server: https://127.0.0.1
+      users:
+      - name: tls-bootstrap
+        user:
+          token: $KUBELET_BOOTSTRAP_TOKEN
+      contexts:
+      - context:
+          cluster: local
+          user: tls-bootstrap
+        name: tls-bootstrap-context
+      current-context: tls-bootstrap-context
 
   - path: /etc/kubernetes/kubeconfig/kubelet.yaml
     content: |
-        apiVersion: v1
-        kind: Config
-        clusters:
-        - name: local
-          cluster:
-            certificate-authority: /etc/kubernetes/ssl/ca.pem
-            server: https://127.0.0.1
-        users:
-        - name: kubelet
-          user:
-            client-certificate: /etc/kubernetes/ssl/kubelet-client-current.pem
-            client-key: /etc/kubernetes/ssl/kubelet.key
-        contexts:
-        - context:
-            cluster: local
-            user: kubelet
-          name: kubelet-context
-        current-context: kubelet-context
+      apiVersion: v1
+      kind: Config
+      clusters:
+      - name: local
+        cluster:
+          certificate-authority: /etc/kubernetes/ssl/ca.pem
+          server: https://127.0.0.1
+      users:
+      - name: kubelet
+        user:
+          client-certificate: /etc/kubernetes/ssl/kubelet-client-current.pem
+          client-key: /etc/kubernetes/ssl/kubelet.key
+      contexts:
+      - context:
+          cluster: local
+          user: kubelet
+        name: kubelet-context
+      current-context: kubelet-context
 {{- else }}
   - path: /etc/kubernetes/kubeconfig/kubelet.yaml
     content: |
-        apiVersion: v1
-        kind: Config
-        clusters:
-        - name: local
-          cluster:
-            certificate-authority: /etc/kubernetes/ssl/ca.pem
-            server: https://127.0.0.1
-        users:
-        - name: kubelet
-          user:
-            client-certificate: /etc/kubernetes/ssl/worker.pem
-            client-key: /etc/kubernetes/ssl/worker-key.pem
-        contexts:
-        - context:
-            cluster: local
-            user: kubelet
-          name: kubelet-context
-        current-context: kubelet-context
+      apiVersion: v1
+      kind: Config
+      clusters:
+      - name: local
+        cluster:
+          certificate-authority: /etc/kubernetes/ssl/ca.pem
+          server: https://127.0.0.1
+      users:
+      - name: kubelet
+        user:
+          client-certificate: /etc/kubernetes/ssl/worker.pem
+          client-key: /etc/kubernetes/ssl/worker-key.pem
+      contexts:
+      - context:
+          cluster: local
+          user: kubelet
+        name: kubelet-context
+      current-context: kubelet-context
 {{- end }}
 
   - path: /etc/kubernetes/ssl/worker.pem
@@ -4792,86 +4824,87 @@ write_files:
   # File needed on every node (used by the kube-proxy DaemonSet), including controllers
   - path: /etc/kubernetes/kubeconfig/kube-proxy.yaml
     content: |
-        apiVersion: v1
-        kind: Config
-        clusters:
-        - name: local
-          cluster:
-            certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            server: https://127.0.0.1
-        users:
-        - name: kube-proxy
-          user:
-            tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-        contexts:
-        - context:
-            cluster: local
-            user: kube-proxy
-          name: kube-proxy-context
-        current-context: kube-proxy-context
+      apiVersion: v1
+      kind: Config
+      clusters:
+      - name: local
+        cluster:
+          certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          server: https://127.0.0.1
+      users:
+      - name: kube-proxy
+        user:
+          tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      contexts:
+      - context:
+          cluster: local
+          user: kube-proxy
+        name: kube-proxy-context
+      current-context: kube-proxy-context
 
   - path: /etc/kubernetes/kubeconfig/kube-controller-manager.yaml
     content: |
-        apiVersion: v1
-        kind: Config
-        clusters:
-        - name: local
-          cluster:
-            certificate-authority: /etc/kubernetes/ssl/ca.pem
-            server: https://127.0.0.1
-        users:
-        - name: kube-controller-manager
-          user:
-            client-certificate: /etc/kubernetes/ssl/kube-controller-manager.pem
-            client-key: /etc/kubernetes/ssl/kube-controller-manager-key.pem
-        contexts:
-        - context:
-            cluster: local
-            user: kube-controller-manager
-          name: kube-controller-manager-context
-        current-context: kube-controller-manager-context
+      apiVersion: v1
+      kind: Config
+      clusters:
+      - name: local
+        cluster:
+          certificate-authority: /etc/kubernetes/ssl/ca.pem
+          server: https://127.0.0.1
+      users:
+      - name: kube-controller-manager
+        user:
+          client-certificate: /etc/kubernetes/ssl/kube-controller-manager.pem
+          client-key: /etc/kubernetes/ssl/kube-controller-manager-key.pem
+      contexts:
+      - context:
+          cluster: local
+          user: kube-controller-manager
+        name: kube-controller-manager-context
+      current-context: kube-controller-manager-context
 
   - path: /etc/kubernetes/kubeconfig/kube-scheduler.yaml
     content: |
-        apiVersion: v1
-        kind: Config
-        clusters:
-        - name: local
-          cluster:
-            certificate-authority: /etc/kubernetes/ssl/ca.pem
-            server: https://127.0.0.1
-        users:
-        - name: kube-scheduler
-          user:
-            client-certificate: /etc/kubernetes/ssl/kube-scheduler.pem
-            client-key: /etc/kubernetes/ssl/kube-scheduler-key.pem
-        contexts:
-        - context:
-            cluster: local
-            user: kube-scheduler
-          name: kube-scheduler-context
-        current-context: kube-scheduler-context
+      apiVersion: v1
+      kind: Config
+      clusters:
+      - name: local
+        cluster:
+          certificate-authority: /etc/kubernetes/ssl/ca.pem
+          server: https://127.0.0.1
+      users:
+      - name: kube-scheduler
+        user:
+          client-certificate: /etc/kubernetes/ssl/kube-scheduler.pem
+          client-key: /etc/kubernetes/ssl/kube-scheduler-key.pem
+      contexts:
+      - context:
+          cluster: local
+          user: kube-scheduler
+        name: kube-scheduler-context
+      current-context: kube-scheduler-context
 
   - path: /etc/kubernetes/kubeconfig/admin.yaml
     content: |
-        apiVersion: v1
-        kind: Config
-        clusters:
-        - name: local
-          cluster:
-            certificate-authority: /etc/kubernetes/ssl/ca.pem
-            server: https://127.0.0.1
-        users:
-        - name: admin
-          user:
-            client-certificate: /etc/kubernetes/ssl/admin.pem
-            client-key: /etc/kubernetes/ssl/admin-key.pem
-        contexts:
-        - context:
-            cluster: local
-            user: admin
-          name: admin-context
-        current-context: admin-context
+      apiVersion: v1
+      kind: Config
+      clusters:
+      - name: local
+        cluster:
+          certificate-authority: /etc/kubernetes/ssl/ca.pem
+          server: https://127.0.0.1
+      users:
+      - name: admin
+        user:
+          client-certificate: /etc/kubernetes/ssl/admin.pem
+          client-key: /etc/kubernetes/ssl/admin-key.pem
+      contexts:
+      - context:
+          cluster: local
+          user: admin
+        name: admin-context
+      current-context: admin-context
+
 # AdvancedAuditing is enabled by default since K8S v1.8.
 # With AdvancedAuditing, you have to provide a audit policy file.
 # Otherwise no audit logs are recorded at all.
@@ -5203,6 +5236,9 @@ write_files:
           rollingUpdate:
             maxUnavailable: 100%
           type: RollingUpdate
+        selector:
+          matchLabels:
+            name: nvidia-driver-installer
         template:
           metadata:
             labels:
@@ -5267,6 +5303,9 @@ write_files:
           rollingUpdate:
             maxUnavailable: 100%
           type: RollingUpdate
+        selector:
+          matchLabels:
+            k8s-app: nvidia-gpu-device-plugin
         template:
           metadata:
             labels:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3236,9 +3236,9 @@ write_files:
           rollingUpdate:
             maxUnavailable: 100%
           type: RollingUpdate
-      selector:
-        matchLabels:
-          k8s-app: kube-proxy
+        selector:
+          matchLabels:
+            k8s-app: kube-proxy
         template:
           metadata:
             labels:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -349,6 +349,9 @@ coreos:
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /srv/kubernetes/manifests  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
         ExecStartPre=-/bin/docker rm -f kubelet
         ExecStart=/bin/sh -c "docker run --name kubelet --privileged --net=host --pid=host \
+        -v /:/rootfs:ro \
+        -v /sys:/sys:ro \
+        -v /dev:/dev \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /etc/resolv.conf:/etc/resolv.conf:ro \
         -v /var/lib/cni:/var/lib/cni:rw \
@@ -590,8 +593,6 @@ write_files:
     content: |
       kind: KubeletConfiguration
       apiVersion: kubelet.config.k8s.io/v1beta1
-      kubeletCgroups: /systemd/system.slice
-      SystemCgroups: /systemd/system.slice
       evictionHard:
         memory.available:  "200Mi"
       staticPodPath: /etc/kubernetes/manifests

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -329,6 +329,7 @@ coreos:
         After=decrypt-assets.service
 
         [Service]
+
         # EnvironmentFile=/etc/environment allows the reading of COREOS_PRIVATE_IPV4
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/etcd-environment
@@ -342,6 +343,7 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
+        ExecStartPre=/usr/bin/mkdir -p /var/lib/docker
         ExecStartPre=/bin/bash -c "if ! grep -q "/var/lib/kubelet" /proc/mounts; then mount --bind /var/lib/kubelet /var/lib/kubelet && mount --make-shared /var/lib/kubelet; fi"
         ExecStartPre=/bin/sed -e "s/COREOS_PRIVATE_IPV4/${COREOS_PRIVATE_IPV4}/g" -i /etc/kubernetes/config/kubelet.yaml
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /srv/kubernetes/manifests  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
@@ -356,6 +358,7 @@ coreos:
         -v /opt/cni/bin:/opt/cni/bin:rw \
         -v /etc/kubernetes:/etc/kubernetes:rw \
         -v /var/lib/kubelet:/var/lib/kubelet:shared \
+        -v /var/lib/docker:/var/lib/docker:rshared \
         {{- if gt (len .Kubelet.Mounts) 0 }}
           {{- range .Kubelet.Mounts }}
         {{ .MountDockerRW }} \
@@ -587,6 +590,8 @@ write_files:
     content: |
       kind: KubeletConfiguration
       apiVersion: kubelet.config.k8s.io/v1beta1
+      kubeletCgroups: /systemd/system.slice
+      SystemCgroups: /systemd/system.slice
       evictionHard:
         memory.available:  "200Mi"
       staticPodPath: /etc/kubernetes/manifests

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -362,7 +362,7 @@ coreos:
           {{- end }}
         {{- end }}
         {{ .HyperkubeImage.RepoWithTag }} /kubelet \
-        {{ if checkVersion ">= 1.14" .K8sVer -}}
+        {{- if checkVersion ">= 1.14" .K8sVer }}
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- end }}
         {{ if .Kubelet.Kubeconfig -}}

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -283,7 +283,7 @@ coreos:
           content: |
             [Service]
             Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
-    
+
     - name: flanneld.service
       enable: false
     {{ if .AssetsEncryptionEnabled -}}
@@ -304,40 +304,17 @@ coreos:
       runtime: true
       content: |
         [Unit]
-        Wants=rpc-statd.service        
+        Wants=rpc-statd.service
         Wants=decrypt-assets.service
         After=decrypt-assets.service
         {{- if .Gpu.Nvidia.IsEnabledOn .InstanceType }}
         Requires=nvidia-start.service
         After=nvidia-start.service
         {{- end }}
-        
+
         [Service]
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/default/kubelet
-        Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
-        Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
-        Environment="RKT_RUN_ARGS={{.HyperkubeImage.Options}}\
-        --volume dns,kind=host,source=/etc/resolv.conf \
-        --mount volume=dns,target=/etc/resolv.conf \
-        {{ if eq .ContainerRuntime "rkt" -}}
-        --volume rkt,kind=host,source=/opt/bin/host-rkt \
-        --mount volume=rkt,target=/usr/bin/rkt \
-        --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
-        --mount volume=var-lib-rkt,target=/var/lib/rkt \
-        --volume stage,kind=host,source=/tmp \
-        --mount volume=stage,target=/tmp \
-        {{ end -}}
-        --volume var-lib-cni,kind=host,source=/var/lib/cni \
-        --mount volume=var-lib-cni,target=/var/lib/cni \
-        --volume var-run-calico,kind=host,source=/var/run/calico \
-        --mount volume=var-run-calico,target=/var/run/calico \
-        --volume var-lib-calico,kind=host,source=/var/lib/calico \
-        --mount volume=var-lib-calico,target=/var/lib/calico \
-        --volume var-log,kind=host,source=/var/log \
-        --mount volume=var-log,target=/var/log \
-        --volume cni-bin,kind=host,source=/opt/cni/bin \
-        --mount volume=cni-bin,target=/opt/cni/bin"
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
@@ -345,14 +322,37 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
+        ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
+        ExecStartPre=/bin/bash -c "if ! grep -q "/var/lib/kubelet" /proc/mounts; then mount --bind /var/lib/kubelet /var/lib/kubelet && mount --make-shared /var/lib/kubelet; fi"
         ExecStartPre=/bin/sed -e "s/COREOS_PRIVATE_IPV4/${COREOS_PRIVATE_IPV4}/g" -i /etc/kubernetes/config/kubelet.yaml
-        ExecStart=/bin/sh -c "exec /usr/lib/coreos/kubelet-wrapper \
+        ExecStartPre=-/bin/docker rm -f kubelet
+        ExecStart=/bin/sh -c "docker run --name kubelet --privileged --net=host --pid=host \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /etc/resolv.conf:/etc/resolv.conf:ro \
+        -v /var/lib/cni:/var/lib/cni:rw \
+        -v /var/run/calico:/var/run/calico:rw \
+        -v /var/lib/calico:/var/lib/calico:rw \
+        -v /var/log:/var/log:rw \
+        -v /opt/cni/bin:/opt/cni/bin:rw \
+        -v /etc/kubernetes:/etc/kubernetes:rw \
+        -v /var/lib/kubelet:/var/lib/kubelet:shared \
+        {{ if eq .ContainerRuntime "rkt" -}}
+        -v /opt/bin/host-rkt:/opt/bin/host-rkt:rw \
+        -v /usr/bin/rkt:/usr/bin/rkt:ro \
+        -v /var/lib/rkt:/usr/lib/rkt:rw \
+        -v /tmp:/tmp:rw \
+        {{- end }}
+        {{- if gt (len .Kubelet.Mounts) 0 }}
+          {{- range .Kubelet.Mounts }}
+        {{ .MountDockerRW }} \
+          {{- end }}
+        {{- end }}
+        {{ .HyperkubeImage.RepoWithTag }} /kubelet \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
-        {{/* Work-around until https://github.com/kubernetes/kubernetes/issues/43967 is fixed via https://github.com/kubernetes/kubernetes/pull/43995 */ -}}
         --cni-bin-dir=/opt/cni/bin \
         --network-plugin={{.K8sNetworkPlugin}} \
         --container-runtime={{.ContainerRuntime}} \
-        --node-labels=node.kubernetes.io/role="node",node.kubernetes.io/role="{{ toLabel .NodePoolName }}",kubernetes.io/role=node,node-role.kubernetes.io/node=\"\",node-role.kubernetes.io/{{ toLabel .NodePoolName }}=\"\"{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
+        --node-labels=node.kubernetes.io/role="node",node.kubernetes.io/role="{{ toLabel .NodePoolName }}"{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-node=true \
         --config=/etc/kubernetes/config/kubelet.yaml \
         {{- if .Taints }}
@@ -479,7 +479,7 @@ coreos:
         [Service]
         Type=oneshot
         EnvironmentFile={{.StackNameEnvFileName}}
-        ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl  --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null ; then break ; fi;  done"
+        ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl  --insecure -s -m 20 -f  > /dev/null ; then break ; fi;  done"
         ExecStart=/opt/bin/cfn-signal
 {{end}}
 
@@ -620,7 +620,7 @@ write_files:
         memory.available:  "200Mi"
       staticPodPath: /etc/kubernetes/manifests
       clusterDomain: cluster.local
-      clusterDNS: 
+      clusterDNS:
       - {{ if .KubeDns.NodeLocalResolver }}COREOS_PRIVATE_IPV4{{ else }}{{.DNSServiceIP}}{{end}}
       serverTLSBootstrap: false
       rotateCertificates: true
@@ -646,7 +646,7 @@ write_files:
       {{- end }}
       {{- if .FeatureGates.Enabled }}
       featureGates:
-{{.FeatureGates.Yaml | indent 8}} 
+{{.FeatureGates.Yaml | indent 8}}
       {{- end }}
 
   {{ if .CustomFiles -}}

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -484,7 +484,7 @@ coreos:
         [Service]
         Type=oneshot
         EnvironmentFile={{.StackNameEnvFileName}}
-        ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl  --insecure -s -m 20 -f  > /dev/null ; then break ; fi;  done"
+        ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl  --insecure -s -m 20 -f https://127.0.0.1:10250/healthz >/dev/null ; then break ; fi;  done"
         ExecStart=/opt/bin/cfn-signal
 {{end}}
 

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -323,6 +323,7 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
+        ExecStartPre=/usr/bin/mkdir -p /var/lib/docker
         ExecStartPre=/bin/bash -c "if ! grep -q "/var/lib/kubelet" /proc/mounts; then mount --bind /var/lib/kubelet /var/lib/kubelet && mount --make-shared /var/lib/kubelet; fi"
         ExecStartPre=/bin/sed -e "s/COREOS_PRIVATE_IPV4/${COREOS_PRIVATE_IPV4}/g" -i /etc/kubernetes/config/kubelet.yaml
         ExecStartPre=-/bin/docker rm -f kubelet
@@ -336,6 +337,7 @@ coreos:
         -v /opt/cni/bin:/opt/cni/bin:rw \
         -v /etc/kubernetes:/etc/kubernetes:rw \
         -v /var/lib/kubelet:/var/lib/kubelet:shared \
+        -v /var/lib/docker:/var/lib/docker:rshared \
         {{ if eq .ContainerRuntime "rkt" -}}
         -v /opt/bin/host-rkt:/opt/bin/host-rkt:rw \
         -v /usr/bin/rkt:/usr/bin/rkt:ro \
@@ -616,6 +618,8 @@ write_files:
     content: |
       kind: KubeletConfiguration
       apiVersion: kubelet.config.k8s.io/v1beta1
+      kubeletCgroups: /systemd/system.slice
+      SystemCgroups: /systemd/system.slice
       evictionHard:
         memory.available:  "200Mi"
       staticPodPath: /etc/kubernetes/manifests

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -328,6 +328,9 @@ coreos:
         ExecStartPre=/bin/sed -e "s/COREOS_PRIVATE_IPV4/${COREOS_PRIVATE_IPV4}/g" -i /etc/kubernetes/config/kubelet.yaml
         ExecStartPre=-/bin/docker rm -f kubelet
         ExecStart=/bin/sh -c "docker run --name kubelet --privileged --net=host --pid=host \
+        -v /:/rootfs:ro \
+        -v /sys:/sys:ro \
+        -v /dev:/dev \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /etc/resolv.conf:/etc/resolv.conf:ro \
         -v /var/lib/cni:/var/lib/cni:rw \
@@ -618,8 +621,6 @@ write_files:
     content: |
       kind: KubeletConfiguration
       apiVersion: kubelet.config.k8s.io/v1beta1
-      kubeletCgroups: /systemd/system.slice
-      SystemCgroups: /systemd/system.slice
       evictionHard:
         memory.available:  "200Mi"
       staticPodPath: /etc/kubernetes/manifests

--- a/contrib/dex/dex.de.yaml
+++ b/contrib/dex/dex.de.yaml
@@ -14,6 +14,10 @@ spec:
   strategy:
     rollingUpdate:
       maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: dex
+      component: identity
   template:
     metadata:
       name: dex

--- a/contrib/dex/dex.de.yaml
+++ b/contrib/dex/dex.de.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dex
@@ -7,7 +7,7 @@ metadata:
     app: dex
     component: identity
   annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ''
+    scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
   replicas: 1
   minReadySeconds: 30
@@ -22,44 +22,44 @@ spec:
         component: identity
     spec:
       volumes:
-      - name: config
-        configMap:
-          name: dex
-          items:
-          - key: config.yaml
-            path: config.yaml
-      containers:
-      - name: dex
-        imagePullPolicy: IfNotPresent
-        image: quay.io/coreos/dex:v2.5.0
-        command: ["/usr/local/bin/dex", "serve", "/etc/dex/config.yaml"]
-        volumeMounts:
         - name: config
-          mountPath: /etc/dex
-        ports:
-        - containerPort: 5556
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 5556
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
-        env:
-        - name: GITHUB_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name: dex
-              key: client-id
-        - name: GITHUB_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: dex
-              key: client-secret
-        resources:
-          requests:
-            cpu: 100m
-            memory: 50Mi
-          limits:
-            cpu: 100m
-            memory: 50Mi
+          configMap:
+            name: dex
+            items:
+              - key: config.yaml
+                path: config.yaml
+      containers:
+        - name: dex
+          imagePullPolicy: IfNotPresent
+          image: quay.io/coreos/dex:v2.5.0
+          command: ["/usr/local/bin/dex", "serve", "/etc/dex/config.yaml"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex
+          ports:
+            - containerPort: 5556
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 5556
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          env:
+            - name: GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dex
+                  key: client-id
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dex
+                  key: client-secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50Mi
+            limits:
+              cpu: 100m
+              memory: 50Mi

--- a/contrib/dex/ingress/dex.nginx.ing.yaml
+++ b/contrib/dex/ingress/dex.nginx.ing.yaml
@@ -16,7 +16,7 @@ spec:
     - host: dex.example.com
       http:
         paths:
-        - path: /
-          backend:
-            serviceName: dex
-            servicePort: 5556
+          - path: /
+            backend:
+              serviceName: dex
+              servicePort: 5556

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -20,11 +20,11 @@ var KUBERNETES_VERSION = "v99.99"
 
 const (
 	// Experimental SelfHosting feature default images.
-	kubeNetworkingSelfHostingDefaultCalicoNodeImageTag = "v3.9.1"
-	kubeNetworkingSelfHostingDefaultCalicoCniImageTag  = "v3.9.1"
+	kubeNetworkingSelfHostingDefaultCalicoNodeImageTag = "v3.11.1"
+	kubeNetworkingSelfHostingDefaultCalicoCniImageTag  = "v3.11.1"
 	kubeNetworkingSelfHostingDefaultFlannelImageTag    = "v0.11.0"
 	kubeNetworkingSelfHostingDefaultFlannelCniImageTag = "v0.3.0"
-	kubeNetworkingSelfHostingDefaultTyphaImageTag      = "v3.9.1"
+	kubeNetworkingSelfHostingDefaultTyphaImageTag      = "v3.11.1"
 )
 
 func NewDefaultCluster() *Cluster {

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -254,4 +254,8 @@ func (m ContainerVolumeMount) ToRktRunArgs() []string {
 	return args
 }
 
+func (m ContainerVolumeMount) MountDockerRW() string {
+	return fmt.Sprintf("-v %s:%s:rw", m, m)
+}
+
 type Values map[string]interface{}


### PR DESCRIPTION
ETCD_VERSION="v3.4.3"
KUBERNETES_VERSION="v1.16.4"
Decommission old v1beta1 apis
Add selectors to all DaemonSets and Deployments
Kubelet moves into a Docker container (issues with rkt fly container)
Calico bumped to version 3.11.1
