### PR TITLE
Bump golang version to v1.13.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.11.x
+  - 1.13.x
 go_import_path: github.com/kubernetes-incubator/kube-aws
 script:
   - travis_wait 40 make test-with-cover


### PR DESCRIPTION
Bump travis build config to use latest golang.

We have already shipped this in Homebrew  v0.14.3 (https://github.com/Homebrew/homebrew-core/pull/47394)