### PR TITLE
Added an option to Skip IOPS verification in ETCD

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1455,6 +1455,12 @@ experimental:
   # from the local VPC subnet so that load balancers can access it.  Ref: https://github.com/kubernetes/kubernetes/issues/26670
   disableSecurityGroupIngress: false
 
+  # When set to true will skip the IOPs performance check done when mounting Etcd volumes.
+  # It only makes sense if you have reserved IOPs for your etcd volumes.
+  # This check is by default quite slow because it depends on cloudwatch which usually has some delay for start providing metrics.
+  # The other check 'io-enabled' is still performed
+  skipIOPerformanceEtcdVolumeCheck: false
+
   # Command line flag passed to the controller-manager. (default 40s)
   # This is the amount of time which we allow running Node to be unresponsive before marking it unhealthy.
   # Must be N times more than kubelet's nodeStatusUpdateFrequency (default 10s).

--- a/builtin/files/userdata/cloud-config-etcd
+++ b/builtin/files/userdata/cloud-config-etcd
@@ -650,12 +650,21 @@ write_files:
 
       done
 
+      {{- if .Experimental.SkipIOPerformanceEtcdVolumeCheck }}
+      # Wait until the volume attachment completes
+      until [ "$volume_status" = passed ]; do
+        sleep 3
+        describe_volume_status_result=$(aws ec2 describe-volume-status --volume-id $attached_vol_id)
+        volume_status=$(echo "$describe_volume_status_result" |  jq -r '([] + .VolumeStatuses)[0].VolumeStatus.Details | .[] |select(.Name=="io-enabled") | .Status')
+      done
+      {{- else }}
       # Wait until the volume attachment completes
       until [ "$volume_status" = ok ]; do
         sleep 3
         describe_volume_status_result=$(aws ec2 describe-volume-status --volume-id $attached_vol_id)
         volume_status=$(echo "$describe_volume_status_result" | jq -r "([] + .VolumeStatuses)[0].VolumeStatus.Status")
       done
+      {{- end }}
 
       cat ${state_prefix}.json \
         | jq -r "([] + .Tags)[] | select(.Key == \"$name_tag_key\").Value" \

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -103,6 +103,7 @@ func NewDefaultCluster() *Cluster {
 			UsernameClaim: "email",
 			GroupsClaim:   "groups",
 		},
+		SkipIOPerformanceEtcdVolumeCheck: false,
 	}
 
 	ipvsMode := IPVSMode{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -17,21 +17,22 @@ type Kubelet struct {
 }
 
 type Experimental struct {
-	Admission                   Admission             `yaml:"admission"`
-	AuditLog                    AuditLog              `yaml:"auditLog"`
-	Authentication              Authentication        `yaml:"authentication"`
-	AwsEnvironment              AwsEnvironment        `yaml:"awsEnvironment"`
-	AwsNodeLabels               AwsNodeLabels         `yaml:"awsNodeLabels"`
-	EphemeralImageStorage       EphemeralImageStorage `yaml:"ephemeralImageStorage"`
-	GpuSupport                  GpuSupport            `yaml:"gpuSupport,omitempty"`
-	KubeletOpts                 string                `yaml:"kubeletOpts,omitempty"`
-	LoadBalancer                LoadBalancer          `yaml:"loadBalancer"`
-	TargetGroup                 TargetGroup           `yaml:"targetGroup"`
-	NodeDrainer                 NodeDrainer           `yaml:"nodeDrainer"`
-	Oidc                        Oidc                  `yaml:"oidc"`
-	DisableSecurityGroupIngress bool                  `yaml:"disableSecurityGroupIngress"`
-	NodeMonitorGracePeriod      string                `yaml:"nodeMonitorGracePeriod"`
-	UnknownKeys                 `yaml:",inline"`
+	Admission                        Admission             `yaml:"admission"`
+	AuditLog                         AuditLog              `yaml:"auditLog"`
+	Authentication                   Authentication        `yaml:"authentication"`
+	AwsEnvironment                   AwsEnvironment        `yaml:"awsEnvironment"`
+	AwsNodeLabels                    AwsNodeLabels         `yaml:"awsNodeLabels"`
+	EphemeralImageStorage            EphemeralImageStorage `yaml:"ephemeralImageStorage"`
+	GpuSupport                       GpuSupport            `yaml:"gpuSupport,omitempty"`
+	KubeletOpts                      string                `yaml:"kubeletOpts,omitempty"`
+	LoadBalancer                     LoadBalancer          `yaml:"loadBalancer"`
+	TargetGroup                      TargetGroup           `yaml:"targetGroup"`
+	NodeDrainer                      NodeDrainer           `yaml:"nodeDrainer"`
+	Oidc                             Oidc                  `yaml:"oidc"`
+	DisableSecurityGroupIngress      bool                  `yaml:"disableSecurityGroupIngress"`
+	NodeMonitorGracePeriod           string                `yaml:"nodeMonitorGracePeriod"`
+	SkipIOPerformanceEtcdVolumeCheck bool                  `yaml:"skipIOPerformanceEtcdVolumeCheck"`
+	UnknownKeys                      `yaml:",inline"`
 }
 
 func (c Experimental) Validate(name string) error {


### PR DESCRIPTION
When provisioning ETCDs with EBS volumes and provisioned IOPS
the default check will wait for a full monitorization of the EBS
volume. This actually checks two things, io-enabled and io-performance
(See
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-volume-status.html)

The io-performance checks that the EBS volume is actually able to deliver
the provisioned IOPS. Since it is based on cloudwatch it is very slow
and usually takes more than 5m to be passed. The other check, io-enabled, is usually quite fast.

Since I have to constantly create and destroy clusters (sometimes with 3
or more ETCD nodes) I can save more than 15m per cluster skiping the io-performance verification and trusting io-enabled. 