### PR TITLE
cloud-controller-manager/CSI - experimental features

### DIFF
--- a/build
+++ b/build
@@ -7,7 +7,7 @@ BRANCH=$(git branch | grep \* | cut -d ' ' -f2 | sed -e 's/[^a-zA-Z0-9+=._:/-]*/
 OUTPUT_PATH=${OUTPUT_PATH:-"bin/kube-aws"}
 VERSION=""
 ETCD_VERSION="v3.4.3"
-KUBERNETES_VERSION="v1.16.4"
+KUBERNETES_VERSION="v1.16.7"
 
 if [ -z "$TAG" ]; then
         [[ -n "$BRANCH" ]] && VERSION="${BRANCH}/"

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1449,6 +1449,37 @@ experimental:
     usernameClaim: "email"
     groupsClaim: "groups"
 
+  # Enable cloudControllerManager to move AWS cloud-provider code out of the kube-controller-manager and into a separate cloud-controller-manager
+  # WARNING: enabling the cloud-controller-manager removes legacy PVC/Storage code - you will need to enable the alpha
+  # ContainerStorageInterface experimental feature to priovide EBS volume integtation and you risk losing any existing volumes.
+  cloudControllerManager:
+    enabled: false
+
+  # Enable experimental Container Storage Interface (CSI)
+  # This subsystem is designed to replace legacy in-tree storage code with a standard interface (CSI) and external compliant drivers
+  # WARNING: this is for testing purposes only - their is no guarantee that your existing in-tree provisioned volumes will continue to
+  # work once CSI has been enabled (and they didn't work during my testing, although new volumes appeared to work)
+  containerStorageInterface:
+    enabled: false
+    # debug - toggle debug logging levels
+    # debug: false
+    # Change default CSI and EBS Driver images: -
+    # csiProvisioner:
+    #   repo: quay.io/k8scsi/csi-provisioner
+    #   tag: v1.3.1
+    # csiAttacher:
+    #   repo: quay.io/k8scsi/csi-attacher
+    #   tag: v1.2.1
+    # csiLivenessProbe:
+    #   repo: quay.io/k8scsi/livenessprobe
+    #   tag: v1.1.0
+    # csiNodeDriverRegistrar:
+    #   repo: quay.io/k8scsi/csi-node-driver-registrar
+    #   tag: v1.2.0
+    # amazonEBSDriver:
+    #   repo: amazon/aws-ebs-csi-driver
+    #   tag: v0.4.0
+
   # When set to true this configures the k8s aws provider so that it doesn't modify every node's security group
   # to include an additional ingress rule per an ELB created for a k8s service whose type is "LoadBalancer".
   # It requires that the user has setup a rule that allows inbound traffic on kubelet ports

--- a/builtin/files/etcdadm/etcdadm
+++ b/builtin/files/etcdadm/etcdadm
@@ -1026,11 +1026,11 @@ import_keyfile() {
 
   if [[ -n "${ttl}" ]]; then
     id=$(member_etcdctl lease grant ${ttl} | awk '{print $2}')
-    command="while read -u 10 k; do read -u 10 v; echo \"saving \$k with lease=${id} ttl=${ttl}\"; echo \"\$v\" | base64 -d | etcdctl --endpoints='$(member_client_url)' put \$k --lease=${id}; done 10<$(member_snapshots_dir_name)/$file_name"
+    command="cat $(member_snapshots_dir_name)/$file_name | while read k; do read v; echo \"saving \$k with lease=${id} ttl=${ttl}\" >&2; echo \"\$v\" | base64 -d | etcdctl --endpoints='$(member_client_url)' put \$k --lease=${id}; done"
     echo "command is $command"
     raw_etcdctl /bin/sh -c "'${command}'" 2>&1
   else
-    command="while read -u 10 k; do read -u 10 v; echo \"saving \$k\"; echo \"\$v\" | base64 -d | etcdctl --endpoints='$(member_client_url)' put \$k; done 10<$(member_snapshots_dir_name)/$file_name"
+    command="cat $(member_snapshots_dir_name)/$file_name | while read k; do read v; echo \"saving \$k\" >&2; echo \"\$v\" | base64 -d | etcdctl --endpoints='$(member_client_url)' put \$k; done"
     echo "command is $command"
     raw_etcdctl /bin/sh -c "'${command}'" 2>&1
   fi

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -387,6 +387,11 @@ coreos:
         --node-labels=node.kubernetes.io/role="master",service-cidr={{ .ServiceCIDR | toLabel }}{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-with-taints=node.kubernetes.io/role=master:NoSchedule \
         --config=/etc/kubernetes/config/kubelet.yaml \
+        {{- if .Experimental.CloudControllerManager.Enabled }}
+        --cloud-provider=external \
+        {{- else }}
+        --cloud-provider=aws \
+        {{- end }}
         {{- if .Kubernetes.Networking.AmazonVPC.Enabled }}
         --node-ip=$$(curl http://169.254.169.254/latest/meta-data/local-ipv4) \
         --max-pods=$$(/opt/bin/aws-k8s-cni-max-pods) \
@@ -1006,9 +1011,19 @@ write_files:
         "${mfdir}/kube-proxy-cm.yaml" \
         "${mfdir}/kube-proxy-ds.yaml"
 
+      {{- if .Experimental.CloudControllerManager.Enabled }}
       # CLOUD_CONTROLLER_MANAGER
       deploy "${mfdir}/cloud-controller-manager.yaml"
 
+      {{- end }}
+      {{- if .Experimental.ContainerStorageInterface.Enabled }}
+      # CSI
+      deploy "${mfdir}/csi-controller.yaml"
+      deploy "${mfdir}/csi-node.yaml"
+      deploy "${mfdir}/csi-rbac.yaml"
+      deploy "${mfdir}/csi-driver.yaml"
+
+      {{- end }}
       # TLS BOOTSTRAP
       deploy "${rbac}/cluster-role-bindings"/{nodes-can-create-csrs,automatically-sign-node-certificate-requests,automatically-sign-node-certificate-renewals}".yaml"
 
@@ -3526,6 +3541,9 @@ write_files:
           - kube-controller-manager
           {{/* mandatory flags below */}}
           - --cluster-name={{.ClusterName}}
+          {{- if not .Experimental.CloudControllerManager.Enabled }}
+          - --cloud-provider=aws
+          {{- end }}
           - --kubeconfig=/etc/kubernetes/kubeconfig/kube-controller-manager.yaml
           - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kube-controller-manager.yaml
           - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kube-controller-manager.yaml
@@ -3542,6 +3560,7 @@ write_files:
           {{ if not .Kubernetes.Networking.AmazonVPC.Enabled -}}
           - --allocate-node-cidrs=true
           - --cluster-cidr={{.PodCIDR}}
+          - --configure-cloud-routes=false
           {{ end -}}
           - --service-cluster-ip-range={{.ServiceCIDR}} {{/* removes the service CIDR range from the cluster CIDR if it intersects */}}
           {{ if not .Addons.MetricsServer.Enabled -}}
@@ -3680,6 +3699,7 @@ write_files:
                   memory: 100Mi
   {{- end }}
 
+  {{- if .Experimental.CloudControllerManager.Enabled }}
   - path: /srv/kubernetes/manifests/cloud-controller-manager.yaml
     content: |
       ---
@@ -3811,10 +3831,10 @@ write_files:
               - --cluster-name={{.ClusterName}}
               - --allocate-node-cidrs=false
               - --configure-cloud-routes=false
-              {{ if .Experimental.DisableSecurityGroupIngress -}}
+              {{- if .Experimental.DisableSecurityGroupIngress }}
               - --cloud-config=/etc/kubernetes/cloud-controller-manager/cloud.config
               {{- end }}
-              {{ if .Experimental.DisableSecurityGroupIngress -}}
+              {{- if .Experimental.DisableSecurityGroupIngress }}
               volumeMounts:
               - mountPath: /etc/kubernetes
                 name: etc-kubernetes
@@ -3843,6 +3863,355 @@ write_files:
                 path: /etc/kubernetes
               name: etc-kubernetes
             {{- end }}
+  {{- end }}
+
+  {{- if .Experimental.ContainerStorageInterface.Enabled }}
+  - path: /srv/kubernetes/manifests/csi-controller.yaml
+    content: |
+      ---
+      # Controller Service
+      kind: Deployment
+      apiVersion: apps/v1
+      metadata:
+        name: ebs-csi-controller
+        namespace: kube-system
+      spec:
+        replicas: 2
+        selector:
+          matchLabels:
+            app: ebs-csi-controller
+        template:
+          metadata:
+            labels:
+              app: ebs-csi-controller
+          spec:
+            nodeSelector:
+              beta.kubernetes.io/os: linux
+              node.kubernetes.io/role: master
+            serviceAccount: ebs-csi-controller-sa
+            priorityClassName: system-cluster-critical
+            tolerations:
+              - key: "node.kubernetes.io/role"
+                operator: "Equal"
+                value: "master"
+                effect: "NoSchedule"
+              - key: "CriticalAddonsOnly"
+                operator: "Exists"
+            containers:
+              - name: ebs-plugin
+                image: {{ .Experimental.ContainerStorageInterface.AmazonEBSDriver.RepoWithTag }}
+                args :
+                # - {all,controller,node} # specify the driver mode
+                  - --endpoint=$(CSI_ENDPOINT)
+                  - --logtostderr
+                  {{- if .Experimental.ContainerStorageInterface.Debug }}
+                  - --v=9
+                  {{- end }}
+                env:
+                  - name: CSI_ENDPOINT
+                    value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+                  - name: AWS_ACCESS_KEY_ID
+                    valueFrom:
+                      secretKeyRef:
+                        name: aws-secret
+                        key: key_id
+                        optional: true
+                  - name: AWS_SECRET_ACCESS_KEY
+                    valueFrom:
+                      secretKeyRef:
+                        name: aws-secret
+                        key: access_key
+                        optional: true
+                # overwrite the AWS region instead of looking it up dynamically via the AWS EC2 metadata svc
+                # - name: AWS_REGION
+                #   value: us-east-1
+                volumeMounts:
+                  - name: socket-dir
+                    mountPath: /var/lib/csi/sockets/pluginproxy/
+                ports:
+                  - name: healthz
+                    containerPort: 9808
+                    protocol: TCP
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: healthz
+                  initialDelaySeconds: 10
+                  timeoutSeconds: 3
+                  periodSeconds: 10
+                  failureThreshold: 5
+              - name: csi-provisioner
+                image: {{ .Experimental.ContainerStorageInterface.CSIProvisioner.RepoWithTag }}
+                args:
+                  - --csi-address=$(ADDRESS)
+                  {{- if .Experimental.ContainerStorageInterface.Debug }}
+                  - --v=9
+                  {{- end }}
+                  - --feature-gates=Topology=true
+                  - --enable-leader-election
+                  - --leader-election-type=leases
+                env:
+                  - name: ADDRESS
+                    value: /var/lib/csi/sockets/pluginproxy/csi.sock
+                volumeMounts:
+                  - name: socket-dir
+                    mountPath: /var/lib/csi/sockets/pluginproxy/
+              - name: csi-attacher
+                image: {{ .Experimental.ContainerStorageInterface.CSIAttacher.RepoWithTag }}
+                args:
+                  - --csi-address=$(ADDRESS)
+                  {{- if .Experimental.ContainerStorageInterface.Debug }}
+                  - --v=9
+                  {{- end }}
+                env:
+                  - name: ADDRESS
+                    value: /var/lib/csi/sockets/pluginproxy/csi.sock
+                volumeMounts:
+                  - name: socket-dir
+                    mountPath: /var/lib/csi/sockets/pluginproxy/
+              - name: liveness-probe
+                image: {{ .Experimental.ContainerStorageInterface.CSILivenessProbe.RepoWithTag }}
+                args:
+                  - --csi-address=/csi/csi.sock
+                volumeMounts:
+                  - name: socket-dir
+                    mountPath: /csi
+            volumes:
+              - name: socket-dir
+                emptyDir: {}
+  - path: /srv/kubernetes/manifests/csi-node.yaml
+    content: |
+      ---
+      # Node Service
+      kind: DaemonSet
+      apiVersion: apps/v1
+      metadata:
+        name: ebs-csi-node
+        namespace: kube-system
+      spec:
+        selector:
+          matchLabels:
+            app: ebs-csi-node
+        template:
+          metadata:
+            labels:
+              app: ebs-csi-node
+          spec:
+            nodeSelector:
+              beta.kubernetes.io/os: linux
+            hostNetwork: true
+            priorityClassName: system-node-critical
+            tolerations:
+              - operator: Exists
+            containers:
+              - name: ebs-plugin
+                securityContext:
+                  privileged: true
+                image: {{ .Experimental.ContainerStorageInterface.AmazonEBSDriver.RepoWithTag }}
+                args:
+                  - --endpoint=$(CSI_ENDPOINT)
+                  - --logtostderr
+                  {{- if .Experimental.ContainerStorageInterface.Debug }}
+                  - --v=9
+                  {{- end }}
+                env:
+                  - name: CSI_ENDPOINT
+                    value: unix:/csi/csi.sock
+                volumeMounts:
+                  - name: kubelet-dir
+                    mountPath: /var/lib/kubelet
+                    mountPropagation: "Bidirectional"
+                  - name: plugin-dir
+                    mountPath: /csi
+                  - name: device-dir
+                    mountPath: /dev
+                ports:
+                  - name: healthz
+                    containerPort: 9808
+                    protocol: TCP
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: healthz
+                  initialDelaySeconds: 10
+                  timeoutSeconds: 3
+                  periodSeconds: 10
+                  failureThreshold: 5
+              - name: node-driver-registrar
+                image: {{ .Experimental.ContainerStorageInterface.CSINodeDriverRegistrar.RepoWithTag }}
+                args:
+                  - --csi-address=$(ADDRESS)
+                  - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                  {{- if .Experimental.ContainerStorageInterface.Debug }}
+                  - --v=5
+                  {{- end }}
+                lifecycle:
+                  preStop:
+                    exec:
+                      command: ["/bin/sh", "-c", "rm -rf /registration/ebs.csi.aws.com-reg.sock /csi/csi.sock"]
+                env:
+                  - name: ADDRESS
+                    value: /csi/csi.sock
+                  - name: DRIVER_REG_SOCK_PATH
+                    value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
+                volumeMounts:
+                  - name: plugin-dir
+                    mountPath: /csi
+                  - name: registration-dir
+                    mountPath: /registration
+              - name: liveness-probe
+                image: {{ .Experimental.ContainerStorageInterface.CSILivenessProbe.RepoWithTag }}
+                args:
+                  - --csi-address=/csi/csi.sock
+                volumeMounts:
+                  - name: plugin-dir
+                    mountPath: /csi
+            volumes:
+              - name: kubelet-dir
+                hostPath:
+                  path: /var/lib/kubelet
+                  type: Directory
+              - name: plugin-dir
+                hostPath:
+                  path: /var/lib/kubelet/plugins/ebs.csi.aws.com/
+                  type: DirectoryOrCreate
+              - name: registration-dir
+                hostPath:
+                  path: /var/lib/kubelet/plugins_registry/
+                  type: Directory
+              - name: device-dir
+                hostPath:
+                  path: /dev
+                  type: Directory
+  - path: /srv/kubernetes/manifests/csi-rbac.yaml
+    content: |
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+        #Enable if EKS IAM for SA is used
+        #annotations:
+        #  eks.amazonaws.com/role-arn: arn:aws:iam::586565787010:role/ebs-csi-role
+      ---
+      kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ebs-external-provisioner-role
+      rules:
+        - apiGroups: [""]
+          resources: ["persistentvolumes"]
+          verbs: ["get", "list", "watch", "create", "delete"]
+        - apiGroups: [""]
+          resources: ["persistentvolumeclaims"]
+          verbs: ["get", "list", "watch", "update"]
+        - apiGroups: ["storage.k8s.io"]
+          resources: ["storageclasses"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["events"]
+          verbs: ["list", "watch", "create", "update", "patch"]
+        - apiGroups: ["snapshot.storage.k8s.io"]
+          resources: ["volumesnapshots"]
+          verbs: ["get", "list"]
+        - apiGroups: ["snapshot.storage.k8s.io"]
+          resources: ["volumesnapshotcontents"]
+          verbs: ["get", "list"]
+        - apiGroups: ["storage.k8s.io"]
+          resources: ["csinodes"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["nodes"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["coordination.k8s.io"]
+          resources: ["leases"]
+          verbs: ["get", "watch", "list", "delete", "update", "create"]
+      ---
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ebs-csi-provisioner-binding
+      subjects:
+        - kind: ServiceAccount
+          name: ebs-csi-controller-sa
+          namespace: kube-system
+      roleRef:
+        kind: ClusterRole
+        name: ebs-external-provisioner-role
+        apiGroup: rbac.authorization.k8s.io
+      ---
+      kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ebs-external-attacher-role
+      rules:
+        - apiGroups: [""]
+          resources: ["persistentvolumes"]
+          verbs: ["get", "list", "watch", "update"]
+        - apiGroups: [""]
+          resources: ["nodes"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["csi.storage.k8s.io"]
+          resources: ["csinodeinfos"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["storage.k8s.io"]
+          resources: ["volumeattachments"]
+          verbs: ["get", "list", "watch", "update"]
+      ---
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ebs-csi-attacher-binding
+      subjects:
+        - kind: ServiceAccount
+          name: ebs-csi-controller-sa
+          namespace: kube-system
+      roleRef:
+        kind: ClusterRole
+        name: ebs-external-attacher-role
+        apiGroup: rbac.authorization.k8s.io
+      # Fix for nodes being able to access volumeattachment objects
+      # see https://github.com/rancher/k3s/issues/732
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: system:nodes:volumeattachments
+      rules:
+      - apiGroups:
+        - storage.k8s.io
+        resources:
+        - volumeattachments
+        verbs:
+        - list
+        - get
+        - create
+        - watch
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: system:nodes:volumeattachments
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:nodes:volumeattachments
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:nodes
+  - path: /srv/kubernetes/manifests/csi-driver.yaml
+    content: |
+      ---
+      apiVersion: storage.k8s.io/v1beta1
+      kind: CSIDriver
+      metadata:
+        name: ebs.csi.aws.com
+      spec:
+        attachRequired: true
+        podInfoOnMount: false
+  {{- end }}
+
   - path: /srv/kubernetes/manifests/kube-proxy-sa.yaml
     content: |
       apiVersion: v1

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -339,7 +339,7 @@ coreos:
         -v /var/log:/var/log:rw \
         -v /opt/cni/bin:/opt/cni/bin:rw \
         -v /etc/kubernetes:/etc/kubernetes:rw \
-        -v /var/lib/kubelet:/var/lib/kubelet:shared \
+        -v /var/lib/kubelet:/var/lib/kubelet:rshared \
         -v /var/lib/docker:/var/lib/docker:rshared \
         {{ if eq .ContainerRuntime "rkt" -}}
         -v /opt/bin/host-rkt:/opt/bin/host-rkt:rw \
@@ -363,7 +363,11 @@ coreos:
         {{- if .Taints }}
         --register-with-taints={{.Taints.String}} \
         {{- end }}
+        {{- if .Experimental.CloudControllerManager.Enabled }}
         --cloud-provider=external \
+        {{- else }}
+        --cloud-provider=aws \
+        {{- end }}
         --cert-dir=/etc/kubernetes/ssl \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- if .Kubelet.Kubeconfig }}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -17,22 +17,38 @@ type Kubelet struct {
 }
 
 type Experimental struct {
-	Admission                        Admission             `yaml:"admission"`
-	AuditLog                         AuditLog              `yaml:"auditLog"`
-	Authentication                   Authentication        `yaml:"authentication"`
-	AwsEnvironment                   AwsEnvironment        `yaml:"awsEnvironment"`
-	AwsNodeLabels                    AwsNodeLabels         `yaml:"awsNodeLabels"`
-	EphemeralImageStorage            EphemeralImageStorage `yaml:"ephemeralImageStorage"`
-	GpuSupport                       GpuSupport            `yaml:"gpuSupport,omitempty"`
-	KubeletOpts                      string                `yaml:"kubeletOpts,omitempty"`
-	LoadBalancer                     LoadBalancer          `yaml:"loadBalancer"`
-	TargetGroup                      TargetGroup           `yaml:"targetGroup"`
-	NodeDrainer                      NodeDrainer           `yaml:"nodeDrainer"`
-	Oidc                             Oidc                  `yaml:"oidc"`
-	DisableSecurityGroupIngress      bool                  `yaml:"disableSecurityGroupIngress"`
-	NodeMonitorGracePeriod           string                `yaml:"nodeMonitorGracePeriod"`
-	SkipIOPerformanceEtcdVolumeCheck bool                  `yaml:"skipIOPerformanceEtcdVolumeCheck"`
+	Admission                        Admission                 `yaml:"admission"`
+	AuditLog                         AuditLog                  `yaml:"auditLog"`
+	Authentication                   Authentication            `yaml:"authentication"`
+	AwsEnvironment                   AwsEnvironment            `yaml:"awsEnvironment"`
+	AwsNodeLabels                    AwsNodeLabels             `yaml:"awsNodeLabels"`
+	EphemeralImageStorage            EphemeralImageStorage     `yaml:"ephemeralImageStorage"`
+	GpuSupport                       GpuSupport                `yaml:"gpuSupport,omitempty"`
+	KubeletOpts                      string                    `yaml:"kubeletOpts,omitempty"`
+	LoadBalancer                     LoadBalancer              `yaml:"loadBalancer"`
+	TargetGroup                      TargetGroup               `yaml:"targetGroup"`
+	NodeDrainer                      NodeDrainer               `yaml:"nodeDrainer"`
+	Oidc                             Oidc                      `yaml:"oidc"`
+	DisableSecurityGroupIngress      bool                      `yaml:"disableSecurityGroupIngress"`
+	NodeMonitorGracePeriod           string                    `yaml:"nodeMonitorGracePeriod"`
+	SkipIOPerformanceEtcdVolumeCheck bool                      `yaml:"skipIOPerformanceEtcdVolumeCheck"`
+	CloudControllerManager           CloudControllerManager    `yaml:"cloudControllerManager"`
+	ContainerStorageInterface        ContainerStorageInterface `yaml:"containerStorageInterface"`
 	UnknownKeys                      `yaml:",inline"`
+}
+
+type CloudControllerManager struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type ContainerStorageInterface struct {
+	Enabled                bool  `yaml:"enabled"`
+	Debug                  bool  `yaml:"debug"`
+	CSIProvisioner         Image `yaml:"csiProvisioner"`
+	CSIAttacher            Image `yaml:"csiAttacher"`
+	CSILivenessProbe       Image `yaml:"csiLivenessProbe"`
+	CSINodeDriverRegistrar Image `yaml:"csiNodeDriverRegistrar"`
+	AmazonEBSDriver        Image `yaml:"amazonEBSDriver"`
 }
 
 func (c Experimental) Validate(name string) error {

--- a/pkg/model/node_pool_compile.go
+++ b/pkg/model/node_pool_compile.go
@@ -24,6 +24,8 @@ func nodePoolPreprocess(c api.WorkerNodePool, main *Config) (*api.WorkerNodePool
 	c.HostOS = main.HostOS
 	c.Experimental.NodeDrainer = main.DeploymentSettings.Experimental.NodeDrainer
 	c.Experimental.GpuSupport = main.DeploymentSettings.Experimental.GpuSupport
+	c.Experimental.CloudControllerManager = main.DeploymentSettings.Experimental.CloudControllerManager
+	c.Experimental.ContainerStorageInterface = main.DeploymentSettings.Experimental.ContainerStorageInterface
 	c.Kubelet.SystemReservedResources = main.DeploymentSettings.Kubelet.SystemReservedResources
 	c.Kubelet.KubeReservedResources = main.DeploymentSettings.Kubelet.KubeReservedResources
 

--- a/pkg/model/node_pool_config.go
+++ b/pkg/model/node_pool_config.go
@@ -76,6 +76,13 @@ func (c NodePoolConfig) FeatureGates() api.FeatureGates {
 	if c.Experimental.GpuSupport.Enabled {
 		gates["DevicePlugins"] = "true"
 	}
+	if c.Experimental.ContainerStorageInterface.Enabled {
+		gates["CSINodeInfo"] = "true"
+		gates["CSIDriverRegistry"] = "true"
+		gates["CSIBlockVolume"] = "true"
+		gates["CSIMigration"] = "true"
+		gates["CSIMigrationAWS"] = "true"
+	}
 	return gates
 }
 

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -139,6 +139,32 @@ func TestMainClusterConfig(t *testing.T) {
 				UsernameClaim: "email",
 				GroupsClaim:   "groups",
 			},
+			CloudControllerManager: api.CloudControllerManager{
+				Enabled: false,
+			},
+			ContainerStorageInterface: api.ContainerStorageInterface{
+				Enabled: false,
+				CSIProvisioner: api.Image{
+					Repo: "quay.io/k8scsi/csi-provisioner",
+					Tag:  api.CSIDefaultProvisionerImageTag,
+				},
+				CSIAttacher: api.Image{
+					Repo: "quay.io/k8scsi/csi-attacher",
+					Tag:  api.CSIDefaultAttacherImageTag,
+				},
+				CSILivenessProbe: api.Image{
+					Repo: "quay.io/k8scsi/livenessprobe",
+					Tag:  api.CSIDefaultLivenessProbeImageTag,
+				},
+				CSINodeDriverRegistrar: api.Image{
+					Repo: "quay.io/k8scsi/csi-node-driver-registrar",
+					Tag:  api.CSIDefaultNodeDriverRegistrarTag,
+				},
+				AmazonEBSDriver: api.Image{
+					Repo: "amazon/aws-ebs-csi-driver",
+					Tag:  api.CSIDefaultAmazonEBSDriverImageTag,
+				},
+			},
 			NodeDrainer: api.NodeDrainer{
 				Enabled:      false,
 				DrainTimeout: 5,
@@ -1368,6 +1394,32 @@ worker:
 							ClientId:      "kubernetes",
 							UsernameClaim: "email",
 							GroupsClaim:   "groups",
+						},
+						CloudControllerManager: api.CloudControllerManager{
+							Enabled: false,
+						},
+						ContainerStorageInterface: api.ContainerStorageInterface{
+							Enabled: false,
+							CSIProvisioner: api.Image{
+								Repo: "quay.io/k8scsi/csi-provisioner",
+								Tag:  api.CSIDefaultProvisionerImageTag,
+							},
+							CSIAttacher: api.Image{
+								Repo: "quay.io/k8scsi/csi-attacher",
+								Tag:  api.CSIDefaultAttacherImageTag,
+							},
+							CSILivenessProbe: api.Image{
+								Repo: "quay.io/k8scsi/livenessprobe",
+								Tag:  api.CSIDefaultLivenessProbeImageTag,
+							},
+							CSINodeDriverRegistrar: api.Image{
+								Repo: "quay.io/k8scsi/csi-node-driver-registrar",
+								Tag:  api.CSIDefaultNodeDriverRegistrarTag,
+							},
+							AmazonEBSDriver: api.Image{
+								Repo: "amazon/aws-ebs-csi-driver",
+								Tag:  api.CSIDefaultAmazonEBSDriverImageTag,
+							},
 						},
 						NodeDrainer: api.NodeDrainer{
 							Enabled:      true,


### PR DESCRIPTION
Allow cloud-controller-manager and CSI in master branch for further testing.
Both are disabled by default.  We need to test these in readiness for when EBS volume provisioning will be removed from the kube-controller-manager in-tree drivers.
By adding CSI we can provision EBS volumes without the in-tree drivers.
Both cloud-controller-manager and CSI are working in new clusters but the migration code is problematic and can get stuck detaching a volume from a removed non-csi node...

```
E0217 22:32:13.112266       1 reconciler.go:238] attacherDetacher.DetachVolume failed to start for volume "pvc-5b937379-4cf4-4cb9-877d-c978ca30626f" (UniqueName: "kubernetes.io/aws-ebs/aws://eu-west-2a/vol-05515c17b1d470bdd") on node "ip-172-31-30-191.eu-west-2.compute.internal" : DetachVolume.NodeUsingCSIPlugin failed for volume "pvc-5b937379-4cf4-4cb9-877d-c978ca30626f" (UniqueName: "kubernetes.io/aws-ebs/aws://eu-west-2a/vol-05515c17b1d470bdd") on node "ip-172-31-30-191.eu-west-2.compute.internal" : csinode.storage.k8s.io "ip-172-31-30-191.eu-west-2.compute.internal" not found
E0217 22:32:13.212540       1 reconciler.go:238] attacherDetacher.DetachVolume failed to start for volume "pvc-5b937379-4cf4-4cb9-877d-c978ca30626f" (UniqueName: "kubernetes.io/aws-ebs/aws://eu-west-2a/vol-05515c17b1d470bdd") on node "ip-172-31-30-191.eu-west-2.compute.internal" : DetachVolume.NodeUsingCSIPlugin failed for volume "pvc-5b937379-4cf4-4cb9-877d-c978ca30626f" (UniqueName: "kubernetes.io/aws-ebs/aws://eu-west-2a/vol-05515c17b1d470bdd") on node "ip-172-31-30-191.eu-west-2.compute.internal" : csinode.storage.k8s.io "ip-172-31-30-191.eu-west-2.compute.internal" not found
E0217 22:32:13.312775       1 reconciler.go:238] attacherDetacher.DetachVolume failed to start for volume "pvc-5b937379-4cf4-4cb9-877d-c978ca30626f" (UniqueName: "kubernetes.io/aws-ebs/aws://eu-west-2a/vol-05515c17b1d470bdd") on node "ip-172-31-30-191.eu-west-2.compute.internal" : DetachVolume.NodeUsingCSIPlugin failed for volume "pvc-5b937379-4cf4-4cb9-877d-c978ca30626f" (UniqueName: "kubernetes.io/aws-ebs/aws://eu-west-2a/vol-05515c17b1d470bdd") on node "ip-172-31-30-191.eu-west-2.compute.internal" : csinode.storage.k8s.io "ip-172-31-30-191.eu-west-2.compute.internal" not found
```