### PR TITLE
fixed managedELBImplied logic to check value of ELB RecordSetManaged is true

### DIFF
--- a/pkg/api/api_endpoint_lb.go
+++ b/pkg/api/api_endpoint_lb.go
@@ -152,7 +152,7 @@ func (e APIEndpointLB) managedELBImplied() bool {
 		e.explicitlyPublic() ||
 		e.HostedZone.HasIdentifier() ||
 		len(e.SecurityGroupIds) > 0 ||
-		e.RecordSetManaged != nil
+		(e.RecordSetManaged != nil && *e.RecordSetManaged)
 }
 
 func (e APIEndpointLB) explicitlyPrivate() bool {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -145,6 +145,13 @@ apiEndpoints:
     recordSetManaged: false
     securityGroupIds: []
     apiAccessAllowedSourceCIDRs: []
+`, `
+apiEndpoints:
+- name: public
+  dnsName: test.staging.core-os.net
+  loadBalancer:
+    id: lb-123456
+    recordSetManaged: false
 `,
 }
 
@@ -216,7 +223,7 @@ apiEndpoints:
   dnsName: test.staging.core-os.net
   loadBalancer:
     type: classic
-    recordSetManaged: false
+    recordSetManaged: true
     securityGroupIds: []
     apiAccessAllowedSourceCIDRs: []
 `,


### PR DESCRIPTION
When reusing an existing ELB, I was receiving the following error when attempting to render credentials:

```
Error: failed loading cluster.yaml: invalid cluster: invalid api endpoint config at index 0: no appropriate subnets found for api load balancer with private=<nil>: invalid cluster: invalid api endpoint config at index 0: no appropriate subnets found for api load balancer with private=<nil>
```

Digging into the code a bit, it appears the logic for figuring out if the ELB was implicitly managed checked if the value of `recordSetManaged` was set but never checked that the value was actually `true`.

This PR simply checks that the `recordSetManaged` is set and that it is `true`. Otherwise, the implication is the ELB is not managed.