### PR TITLE
[v0.14.5] Allow custom port name for kiam server

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1474,6 +1474,7 @@ experimental:
   # This is intended to be used in combination with .controller.iam.role.name. See #297 for more information.
   kiamSupport:
     enabled: false
+    # portName: grpclb
     # image:
     #  repo: quay.io/uswitch/kiam
     #  tag: v3.2

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4445,7 +4445,8 @@ write_files:
           selector:
             k8s-app: metrics-server
           ports:
-          - port: 443
+          - name: https
+            port: 443
             protocol: TCP
             targetPort: 443
 
@@ -4569,7 +4570,8 @@ write_files:
             - port: 9090
               targetPort: 9090
             {{ else }}
-            - port: 443
+            - name: https
+              port: 443
               targetPort: 8443
             {{ end }}
           selector:
@@ -5642,7 +5644,7 @@ write_files:
           app: kiam
           role: server
         ports:
-        - name: grpclb
+        - name:  {{ if .Experimental.KIAMSupport.PortName }}{{ .Experimental.KIAMSupport.PortName }}{{ else }}grpclb{{ end }}
           port: 443
           targetPort: 443
           protocol: TCP

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -118,6 +118,7 @@ type EphemeralImageStorage struct {
 type KIAMSupport struct {
 	Enabled         bool                `yaml:"enabled"`
 	Image           Image               `yaml:"image,omitempty"`
+	PortName        string              `yaml:"portName,omitempty"`
 	SessionDuration string              `yaml:"sessionDuration,omitempty"`
 	ServerAddresses KIAMServerAddresses `yaml:"serverAddresses,omitempty"`
 	ServerResources ComputeResources    `yaml:"serverResources,omitempty"`


### PR DESCRIPTION
## Changes

The port name grpclb breaks installations of Isito, as kiam-server is running on 443, this causes all external SSL traffic to blackhole. 