### PR TITLE
[v0.14.x] Allow use of PodAutoscalerUseRestClient without addon metrics-server.

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1178,6 +1178,10 @@ kubernetes:
   encryptionAtRest:
     enabled: false
 
+  # Tells Kubernetes to enable the autoscaler rest client (not using heapster) without the requirement to use metrics-server.
+  podAutoscalerUseRestClient:
+    enabled: false
+
 #  controllerManager:
 #   resources:
 #     requests:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3615,7 +3615,7 @@ write_files:
           {{ end -}}
           - --configure-cloud-routes=false {{/* no need to auto configure cloud routes when using flannel or canal */}}
           - --service-cluster-ip-range={{.ServiceCIDR}} {{/* removes the service CIDR range from the cluster CIDR if it intersects */}}
-          {{ if not .Addons.MetricsServer.Enabled -}}
+          {{ if and (not .Addons.MetricsServer.Enabled) (not .Kubernetes.PodAutoscalerUseRestClient.Enabled) -}}
           - --horizontal-pod-autoscaler-use-rest-clients=false
           {{end}}
           {{range $f := .ControllerFlags -}}

--- a/pkg/api/kubernetes.go
+++ b/pkg/api/kubernetes.go
@@ -1,15 +1,16 @@
 package api
 
 type Kubernetes struct {
-	Authentication    KubernetesAuthentication `yaml:"authentication"`
-	EncryptionAtRest  EncryptionAtRest         `yaml:"encryptionAtRest"`
-	Networking        Networking               `yaml:"networking,omitempty"`
-	ControllerManager ControllerManager        `yaml:"controllerManager,omitempty"`
-	KubeScheduler     KubeScheduler            `yaml:"kubeScheduler,omitempty"`
-	KubeProxy         KubeProxy                `yaml:"kubeProxy,omitempty"`
-	KubeApiServer     KubeApiServer            `yaml:"apiServer,omitempty"`
-	Kubelet           Kubelet                  `yaml:"kubelet,omitempty"`
-	APIServer         KubernetesAPIServer      `yaml:"apiserver,omitempty"`
+	Authentication             KubernetesAuthentication   `yaml:"authentication"`
+	EncryptionAtRest           EncryptionAtRest           `yaml:"encryptionAtRest"`
+	PodAutoscalerUseRestClient PodAutoscalerUseRestClient `yaml:"podAutoscalerUseRestClient"`
+	Networking                 Networking                 `yaml:"networking,omitempty"`
+	ControllerManager          ControllerManager          `yaml:"controllerManager,omitempty"`
+	KubeScheduler              KubeScheduler              `yaml:"kubeScheduler,omitempty"`
+	KubeProxy                  KubeProxy                  `yaml:"kubeProxy,omitempty"`
+	KubeApiServer              KubeApiServer              `yaml:"apiServer,omitempty"`
+	Kubelet                    Kubelet                    `yaml:"kubelet,omitempty"`
+	APIServer                  KubernetesAPIServer        `yaml:"apiserver,omitempty"`
 
 	// Manifests is a list of manifests to be installed to the cluster.
 	// Note that the list is sorted by their names by kube-aws so that it won't result in unnecessarily node replacements.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -109,6 +109,10 @@ type EncryptionAtRest struct {
 	Enabled bool `yaml:"enabled"`
 }
 
+type PodAutoscalerUseRestClient struct {
+	Enabled bool `yaml:"enabled"`
+}
+
 type EphemeralImageStorage struct {
 	Enabled    bool   `yaml:"enabled"`
 	Disk       string `yaml:"disk"`


### PR DESCRIPTION
## Changes

- Allows us to enable `--horizontal-pod-autoscaler-use-rest-clients` without requiring us to use the metrics-server addon. 