### PR TITLE
[v0.14.x] Improve Canal Configuration

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1726,6 +1726,7 @@ write_files:
                   path: /etc/kubernetes/cni/net.d
               # Used to create per-pod Unix Domain Sockets
               - name: policysync
+                hostPath:
                   type: DirectoryOrCreate
                   path: /var/run/nodeagent
 

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1320,6 +1320,9 @@ write_files:
         typha_service_name: "none"
         {{- end }}
 
+        # Configure the MTU to use
+        veth_mtu: "1440"
+
         # The CNI network configuration to install on each node.
         cni_network_config: |-
           {
@@ -1502,6 +1505,7 @@ write_files:
           metadata:
             labels:
               k8s-app: canal-master
+              role.kubernetes.io/networking: "1"
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
           spec:
@@ -1531,16 +1535,44 @@ write_files:
             # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
             terminationGracePeriodSeconds: 0
             initContainers:
-              - name: remove-cni-networks
-                image: {{.HyperkubeImage.RepoWithTag}}
-                command:
-                - /bin/rm
-                - -rf
-                - /etc/kubernetes/cni/net.d/10-flannel.conflist
-                - /etc/kubernetes/cni/net.d/10-calico.conf
+              # This container installs the CNI binaries
+              # and CNI network config file on each node.
+              - name: install-cni
+                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
+                command: ["/install-cni.sh"]
+                env:
+                  - name: CNI_NET_DIR
+                    value: /etc/kubernetes/cni/net.d
+                  # Name of the CNI config file to create.
+                  - name: CNI_CONF_NAME
+                    value: "10-canal.conflist"
+                  # The CNI network config to install on each node.
+                  - name: CNI_NETWORK_CONFIG
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: cni_network_config
+                  # Set the hostname based on the k8s node name.
+                  - name: KUBERNETES_NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  # CNI MTU Config variable
+                  - name: CNI_MTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: veth_mtu
+                  # Prevents the container from sleeping forever.
+                  - name: SLEEP
+                    value: "false"
                 volumeMounts:
-                - mountPath: /etc/kubernetes/cni/net.d
-                  name: cni-net-dir
+                  - mountPath: /host/opt/cni/bin
+                    name: cni-bin-dir
+                  - mountPath: /host/etc/cni/net.d
+                    name: cni-net-dir
+                securityContext:
+                  privileged: true
             containers:
               # Runs calico/node container on each Kubernetes node.  This
               # container programs network policy and routes on each
@@ -1551,6 +1583,9 @@ write_files:
                   # Use Kubernetes API as the backing datastore.
                   - name: DATASTORE_TYPE
                     value: "kubernetes"
+                  # Configure route aggregation based on pod CIDR.
+                  - name: USE_POD_CIDR
+                    value: "true"
                   # Enable felix logging.
                   - name: FELIX_LOGSEVERITYSYS
                     value: "info"
@@ -1578,6 +1613,12 @@ write_files:
                   # Typha support: is never enabled on masters
                   - name: FELIX_TYPHAK8SSERVICENAME
                     value: "none"
+                  # Set MTU for tunnel device used if ipip is enabled
+                  - name: FELIX_IPINIPMTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: veth_mtu
                   - name: NODENAME
                     valueFrom:
                       fieldRef:
@@ -1612,37 +1653,17 @@ write_files:
                   - mountPath: /lib/modules
                     name: lib-modules
                     readOnly: true
+                  - mountPath: /run/xtables.lock
+                    name: xtables-lock
+                    readOnly: false
                   - mountPath: /var/run/calico
                     name: var-run-calico
                     readOnly: false
                   - mountPath: /var/lib/calico
                     name: var-lib-calico
                     readOnly: false
-              # This container installs the Calico CNI binaries
-              # and CNI network config file on each node.
-              - name: install-cni
-                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
-                command: ["/install-cni.sh"]
-                env:
-                  - name: CNI_NET_DIR
-                    value: "/etc/kubernetes/cni/net.d"
-                  - name: CNI_CONF_NAME
-                    value: "10-calico.conflist"
-                  # The CNI network config to install on each node.
-                  - name: CNI_NETWORK_CONFIG
-                    valueFrom:
-                      configMapKeyRef:
-                        name: canal-config
-                        key: cni_network_config
-                  - name: KUBERNETES_NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                volumeMounts:
-                  - mountPath: /host/opt/cni/bin
-                    name: cni-bin-dir
-                  - mountPath: /host/etc/cni/net.d
-                    name: cni-net-dir
+                  - name: policysync
+                    mountPath: /var/run/nodeagent
               # This container runs flannel using the kube-subnet-mgr backend
               # for allocating subnets.
               - name: flannel
@@ -1651,6 +1672,8 @@ write_files:
                 securityContext:
                   privileged: true
                 env:
+                  - name: FLANNELD_IPTABLES_FORWARD_RULES
+                    value: "false"
                   - name: POD_NAME
                     valueFrom:
                       fieldRef:
@@ -1670,12 +1693,13 @@ write_files:
                         name: canal-config
                         key: masquerade
                 volumeMounts:
-                - name: run
-                  mountPath: /run
-                - name: flannel-cfg
-                  mountPath: /etc/kube-flannel/
+                  - mountPath: /run/xtables.lock
+                    name: xtables-lock
+                    readOnly: false
+                  - name: flannel-cfg
+                    mountPath: /etc/kube-flannel/
             volumes:
-              # Used by calico/node.
+              # Used by canal.
               - name: lib-modules
                 hostPath:
                   path: /lib/modules
@@ -1685,6 +1709,14 @@ write_files:
               - name: var-lib-calico
                 hostPath:
                   path: /var/lib/calico
+              - name: xtables-lock
+                hostPath:
+                  path: /run/xtables.lock
+                  type: FileOrCreate
+              # Used by flannel.
+              - name: flannel-cfg
+                configMap:
+                  name: canal-config
               # Used to install CNI.
               - name: cni-bin-dir
                 hostPath:
@@ -1692,13 +1724,10 @@ write_files:
               - name: cni-net-dir
                 hostPath:
                   path: /etc/kubernetes/cni/net.d
-              # Used by flannel.
-              - name: run
-                hostPath:
-                  path: /run
-              - name: flannel-cfg
-                configMap:
-                  name: canal-config
+              # Used to create per-pod Unix Domain Sockets
+              - name: policysync
+                  type: DirectoryOrCreate
+                  path: /var/run/nodeagent
 
       # Canal DaemonSet for Nodes - Typha can be enabled.
       ---
@@ -1712,6 +1741,7 @@ write_files:
         namespace: kube-system
         labels:
           k8s-app: canal-node
+          role.kubernetes.io/networking: "1"
       spec:
         selector:
           matchLabels:
@@ -1753,16 +1783,44 @@ write_files:
             # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
             terminationGracePeriodSeconds: 0
             initContainers:
-              - name: remove-cni-networks
-                image: {{.HyperkubeImage.RepoWithTag}}
-                command:
-                - /bin/rm
-                - -rf
-                - /etc/kubernetes/cni/net.d/10-flannel.conflist
-                - /etc/kubernetes/cni/net.d/10-calico.conf
+              # This container installs the CNI binaries
+              # and CNI network config file on each node.
+              - name: install-cni
+                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
+                command: ["/install-cni.sh"]
+                env:
+                  - name: CNI_NET_DIR
+                    value: /etc/kubernetes/cni/net.d
+                  # Name of the CNI config file to create.
+                  - name: CNI_CONF_NAME
+                    value: "10-canal.conflist"
+                  # The CNI network config to install on each node.
+                  - name: CNI_NETWORK_CONFIG
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: cni_network_config
+                  # Set the hostname based on the k8s node name.
+                  - name: KUBERNETES_NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  # CNI MTU Config variable
+                  - name: CNI_MTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: veth_mtu
+                  # Prevents the container from sleeping forever.
+                  - name: SLEEP
+                    value: "false"
                 volumeMounts:
-                - mountPath: /etc/kubernetes/cni/net.d
-                  name: cni-net-dir
+                  - mountPath: /host/opt/cni/bin
+                    name: cni-bin-dir
+                  - mountPath: /host/etc/cni/net.d
+                    name: cni-net-dir
+                securityContext:
+                  privileged: true
             containers:
               # Runs calico/node container on each Kubernetes node.  This
               # container programs network policy and routes on each
@@ -1773,6 +1831,9 @@ write_files:
                   # Use Kubernetes API as the backing datastore.
                   - name: DATASTORE_TYPE
                     value: "kubernetes"
+                  # Configure route aggregation based on pod CIDR.
+                  - name: USE_POD_CIDR
+                    value: "true"
                   # Enable felix logging.
                   - name: FELIX_LOGSEVERITYSYS
                     value: "info"
@@ -1797,6 +1858,12 @@ write_files:
                   # No IP address needed.
                   - name: IP
                     value: ""
+                  # Set MTU for tunnel device used if ipip is enabled
+                  - name: FELIX_IPINIPMTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: veth_mtu
                   # Typha support: controlled by the ConfigMap.
                   - name: FELIX_TYPHAK8SSERVICENAME
                     valueFrom:
@@ -1846,31 +1913,8 @@ write_files:
                   - mountPath: /var/lib/calico
                     name: var-lib-calico
                     readOnly: false
-              # This container installs the Calico CNI binaries
-              # and CNI network config file on each node.
-              - name: install-cni
-                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
-                command: ["/install-cni.sh"]
-                env:
-                  - name: CNI_NET_DIR
-                    value: "/etc/kubernetes/cni/net.d"
-                  - name: CNI_CONF_NAME
-                    value: "10-calico.conflist"
-                  # The CNI network config to install on each node.
-                  - name: CNI_NETWORK_CONFIG
-                    valueFrom:
-                      configMapKeyRef:
-                        name: canal-config
-                        key: cni_network_config
-                  - name: KUBERNETES_NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                volumeMounts:
-                  - mountPath: /host/opt/cni/bin
-                    name: cni-bin-dir
-                  - mountPath: /host/etc/cni/net.d
-                    name: cni-net-dir
+                  - name: policysync
+                    mountPath: /var/run/nodeagent
               # This container runs flannel using the kube-subnet-mgr backend
               # for allocating subnets.
               - name: flannel
@@ -1879,6 +1923,8 @@ write_files:
                 securityContext:
                   privileged: true
                 env:
+                  - name: FLANNELD_IPTABLES_FORWARD_RULES
+                    value: "false"
                   - name: POD_NAME
                     valueFrom:
                       fieldRef:
@@ -1901,12 +1947,10 @@ write_files:
                 - mountPath: /run/xtables.lock
                   name: xtables-lock
                   readOnly: false
-                - name: run
-                  mountPath: /run
                 - name: flannel-cfg
                   mountPath: /etc/kube-flannel/
             volumes:
-              # Used by calico/node.
+              # Used by canal
               - name: lib-modules
                 hostPath:
                   path: /lib/modules
@@ -1920,6 +1964,10 @@ write_files:
                 hostPath:
                   path: /run/xtables.lock
                   type: FileOrCreate
+              # Used by flannel.
+              - name: flannel-cfg
+                configMap:
+                  name: canal-config
               # Used to install CNI.
               - name: cni-bin-dir
                 hostPath:
@@ -1927,13 +1975,11 @@ write_files:
               - name: cni-net-dir
                 hostPath:
                   path: /etc/kubernetes/cni/net.d
-              # Used by flannel.
-              - name: run
+              # Used to create per-pod Unix Domain Sockets
+              - name: policysync
                 hostPath:
-                  path: /run
-              - name: flannel-cfg
-                configMap:
-                  name: canal-config
+                  type: DirectoryOrCreate
+                  path: /var/run/nodeagent
       ---
       # Source: calico/templates/kdd-crds.yaml
       # Create all the CustomResourceDefinitions needed for


### PR DESCRIPTION
## Changes

This takes the canal configuration from kops, and moves installation into a initContainer as oppose to trying to run both the installation and canal containers side-by-side. 