### PR TITLE
make flannel subnetLen configurable for big clusters

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1218,6 +1218,14 @@ kubernetes:
 #      typhaImage:
 #        repo: quay.io/calico/typha
 #        tag: v3.9.1
+#      # By default, flannel assigns a /24 per node for pod's ips, this is effectively limiting your cluster size
+#      # to 255 nodes since each lease will be preserved for 24h.
+#      # If you have a bigger cluster you may want to tune this number to assign an smaller block per node.
+#      # Be aware that network should be able to accomodate at least 4 subnets, and networks smaller than /28
+#      # will make flannel panic and exit.
+#      # Ref: https://github.com/coreos/flannel/blob/62a1314e51047e25606b4e4e30bd23d7a8d746bc/subnet/config.go#L69
+#      flannelConfig:
+#        subnetLen: 24
 
 # Create MountTargets to subnets managed by kube-aws for a pre-existing Elastic File System (Amazon EFS),
 # and then mount to every node.

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1339,6 +1339,9 @@ write_files:
         net-conf.json: |
           {
             "Network": "{{ .PodCIDR }}",
+            {{ if gt .Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen 0 -}}
+            "SubnetLen": "{{ .Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen }}",
+            {{- end }}
             "Backend": {
               "Type": "vxlan"
             }
@@ -2348,6 +2351,9 @@ write_files:
         net-conf.json: |
           {
             "Network": "{{ .PodCIDR }}",
+             {{ if gt .Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen 0 -}}
+            "SubnetLen": "{{ .Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen }}",
+            {{- end }}
             "Backend": {
               "Type": "vxlan"
             }

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -242,6 +242,7 @@ func NewDefaultCluster() *Cluster {
 						FlannelImage:    Image{Repo: "quay.io/coreos/flannel", Tag: kubeNetworkingSelfHostingDefaultFlannelImageTag, RktPullDocker: false},
 						FlannelCniImage: Image{Repo: "quay.io/coreos/flannel-cni", Tag: kubeNetworkingSelfHostingDefaultFlannelCniImageTag, RktPullDocker: false},
 						TyphaImage:      Image{Repo: "quay.io/calico/typha", Tag: kubeNetworkingSelfHostingDefaultTyphaImageTag, RktPullDocker: false},
+						FlannelConfig:   FlannelConfig{SubnetLen: int32(0)},
 					},
 				},
 			},

--- a/pkg/api/networking.go
+++ b/pkg/api/networking.go
@@ -14,4 +14,9 @@ type SelfHosting struct {
 	FlannelImage    Image            `yaml:"flannelImage"`
 	FlannelCniImage Image            `yaml:"flannelCniImage"`
 	TyphaImage      Image            `yaml:"typhaImage"`
+	FlannelConfig   FlannelConfig    `yaml:"flannelConfig"`
+}
+
+type FlannelConfig struct {
+	SubnetLen int32 `yaml:"subnetLen"`
 }


### PR DESCRIPTION
We had an issue in a big cluster (around 200 nodes) when rolling upgrade a change and replacing instances we ran out of subnet leases, that causes that new workers were unable to get a flannel lease and hence setting up the network  and were killed due to not sending the cfn-signal in time.

This patch aims to make subnetLen configurable for big clusters, using kube-aws default flannel config the maximum is 255 nodes which means around 127 nodes and a rolling upgrade that replaces all instances (like updating the base AMI).

In the case of being unset, flanneld will keep using the default which is /24 per node.
