### PR TITLE
Creating a switch to disable ICMP Ping instead of the default - allow 0.0.0.0/0

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1360,10 +1360,10 @@ kubeProxy:
 # It is enabled by default.
 #cloudFormationStreaming: true
 
-# When enabled, a security group rule is included on the generated SG to allow ICMP from all traffic (0.0.0.0/0).
-# This is applied to all nodes (worker & control plane) in the cluster
-#openICMP:
-# enabled: true
+# When enabled, a security group rule is included on the generated kube-aws SG to allow ICMP Ping from all traffic (0.0.0.0/0).
+# This is applied to all nodes (worker & control plane) in the cluster.
+openICMP:
+ enabled: true
 
 # Addon features
 addons:

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1360,6 +1360,11 @@ kubeProxy:
 # It is enabled by default.
 #cloudFormationStreaming: true
 
+# When enabled, a security group rule is included on the generated SG to allow ICMP from all traffic (0.0.0.0/0).
+# This is applied to all nodes (worker & control plane) in the cluster
+#openICMP:
+# enabled: true
+
 # Addon features
 addons:
   # When enabled, Kubernetes rescheduler is deployed to the cluster controller(s)

--- a/builtin/files/stack-templates/control-plane.json.tmpl
+++ b/builtin/files/stack-templates/control-plane.json.tmpl
@@ -219,12 +219,14 @@
             "ToPort": 22
           },
           {{end -}}
+          {{ if .openICMP.Enabled -}}
           {
             "CidrIp": "0.0.0.0/0",
             "FromPort": -1,
             "IpProtocol": "icmp",
             "ToPort": -1
-          }
+          },
+          {{end -}}
         ],
         "Tags": [
           {

--- a/builtin/files/stack-templates/network.json.tmpl
+++ b/builtin/files/stack-templates/network.json.tmpl
@@ -91,12 +91,14 @@
           }
         ],
         "SecurityGroupIngress": [
+          {{ if .openICMP.Enabled -}}
           {
             "CidrIp": "0.0.0.0/0",
             "FromPort": -1,
             "IpProtocol": "icmp",
             "ToPort": -1
           },
+          {{end -}}
           {{ range $_, $r := $.SSHAccessAllowedSourceCIDRs -}}
           {
             "CidrIp": "{{$r}}",


### PR DESCRIPTION
Currently kube-aws includes a rule in its security group to allow ping from all traffic (0.0.0.0/0). Unless this is necessary for a reason I have not foreseen, it is an inherent security risk, violates CIS compliance, and is probably superfluous if SG's are managed appropriately.

Therefore, I have created a switch in cluster.yaml to allow removal of this rule. I have left it enabled by default but am conscious that anyone upgrading needs to ensure this is in their cluster.yaml, so am happy to adjust the logic so that there's no impact unless you explicitly ask for it to be disabled. 

I don't think I've missed any other spots where this rule is used. 