### PR TITLE
bugfix: flannel SubnetLen expects an int not an string

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1340,7 +1340,7 @@ write_files:
           {
             "Network": "{{ .PodCIDR }}",
             {{ if gt .Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen 0 -}}
-            "SubnetLen": "{{ .Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen }}",
+            "SubnetLen": "{{ int (.Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen ) }}",
             {{- end }}
             "Backend": {
               "Type": "vxlan"
@@ -2352,7 +2352,7 @@ write_files:
           {
             "Network": "{{ .PodCIDR }}",
              {{ if gt .Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen 0 -}}
-            "SubnetLen": "{{ .Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen }}",
+            "SubnetLen": "{{ int (.Kubernetes.Networking.SelfHosting.FlannelConfig.SubnetLen) }}",
             {{- end }}
             "Backend": {
               "Type": "vxlan"


### PR DESCRIPTION
I was creating a cluster from latest and it seems that flannel expects an int