### PR TITLE
[v0.16.0] Default Admission Controllers

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1386,8 +1386,6 @@ experimental:
     # Please see https://github.com/kubernetes-incubator/kube-aws/pull/1009#discussion_r151197787 for more info.
     alwaysPullImages:
       enabled: false
-    initializers:
-      enabled: false
     OwnerReferencesPermissionEnforcement:
       enabled: false
     # eventRateLimit Note

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3340,7 +3340,8 @@ write_files:
           {{- else }}
           - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .Controller.Count }}{{end}}
           {{- end }}
-          - --enable-admission-plugins=ExtendedResourceToleration,NodeRestriction,PodSecurityPolicy{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{if .Experimental.Admission.Initializers.Enabled}},Initializers{{end}}{{ if .Experimental.Admission.EventRateLimit.Enabled }},EventRateLimit{{end}}
+          
+          - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,RuntimeClass,ResourceQuota,ExtendedResourceToleration,NodeRestriction,PodSecurityPolicy{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{ if .Experimental.Admission.EventRateLimit.Enabled }},EventRateLimit{{end}}
           {{ if .Experimental.Admission.EventRateLimit.Enabled -}}
           - --admission-control-config-file=/etc/kubernetes/auth/admission-control-config.yaml
           {{ end -}}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3339,8 +3339,7 @@ write_files:
           - --endpoint-reconciler-type=lease
           {{- else }}
           - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .Controller.Count }}{{end}}
-          {{- end }}
-          
+          {{- end }}        
           - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,RuntimeClass,ResourceQuota,ExtendedResourceToleration,NodeRestriction,PodSecurityPolicy{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{ if .Experimental.Admission.EventRateLimit.Enabled }},EventRateLimit{{end}}
           {{ if .Experimental.Admission.EventRateLimit.Enabled -}}
           - --admission-control-config-file=/etc/kubernetes/auth/admission-control-config.yaml
@@ -3393,7 +3392,7 @@ write_files:
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem
-          - --runtime-config=networking.k8s.io/v1/networkpolicies=true,policy/v1beta1/podsecuritypolicy=true{{if .Experimental.Admission.Initializers.Enabled}},admissionregistration.k8s.io/v1alpha1{{end}}
+          - --runtime-config=networking.k8s.io/v1/networkpolicies=true,policy/v1beta1/podsecuritypolicy=true
           {{- if .ControllerFeatureGates.Enabled }}
           - --feature-gates={{.ControllerFeatureGates.String}}
           {{- end }}

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -44,9 +44,6 @@ func NewDefaultCluster() *Cluster {
 			AlwaysPullImages{
 				Enabled: false,
 			},
-			Initializers{
-				Enabled: false,
-			},
 			OwnerReferencesPermissionEnforcement{
 				Enabled: false,
 			},

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -61,16 +61,11 @@ func (c Experimental) Validate(name string) error {
 
 type Admission struct {
 	AlwaysPullImages                     AlwaysPullImages                     `yaml:"alwaysPullImages"`
-	Initializers                         Initializers                         `yaml:"initializers"`
 	OwnerReferencesPermissionEnforcement OwnerReferencesPermissionEnforcement `yaml:"ownerReferencesPermissionEnforcement"`
 	EventRateLimit                       EventRateLimit                       `yaml:"eventRateLimit"`
 }
 
 type AlwaysPullImages struct {
-	Enabled bool `yaml:"enabled"`
-}
-
-type Initializers struct {
 	Enabled bool `yaml:"enabled"`
 }
 


### PR DESCRIPTION
## Changes

- This PR explicitly lists the admission controllers enabled by default as described [here]https://v1-16.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/).
- We also remove the `Initializer` admission controller, it hasn't existed since Kubernetes v1.10.x.