### PR TITLE
[v0.16.0] Switch kubernetes.io/cluster/X tag value to "owned".

### DIFF
--- a/builtin/files/plugins/cluster-autoscaler/plugin.yaml
+++ b/builtin/files/plugins/cluster-autoscaler/plugin.yaml
@@ -83,7 +83,7 @@ spec:
                   {
                     "Key": "k8s.io/cluster-autoscaler/enabled",
                     "PropagateAtLaunch": "true",
-                    "Value": ""
+                    "Value": "true"
                   }
                 ]
               }

--- a/builtin/files/stack-templates/root.json.tmpl
+++ b/builtin/files/stack-templates/root.json.tmpl
@@ -48,7 +48,7 @@
         "Tags" : [
           {
             "Key": "kubernetes.io/cluster/{{$.ClusterName}}",
-            "Value": "true"
+            "Value": "owned"
           }{{range $k, $v := $.ControlPlane.Tags}},
           {
             "Key":"{{$k}}",
@@ -96,7 +96,7 @@
         "Tags" : [
           {
             "Key": "kubernetes.io/cluster/{{$.ClusterName}}",
-            "Value": "true"
+            "Value": "owned"
           }{{range $k, $v := $p.Tags}},
           {
             "Key":"{{$k}}",


### PR DESCRIPTION
## Changes

Having these values as "true" causes stack drift, as we later update them to be "owned". In order to ensure we don't needlessly roll pools we should update the CloudFormation so that "owned" is the expected value.