### PR TITLE
[v0.16.0] Allow custom port name for kiam

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1630,6 +1630,7 @@ kubeAwsPlugins:
     # tag: v3.2
     # sessionDuration: 30m
     # server:
+    #  portName: grpclb
     #  address: localhost:443
     #  resources:
     #    requests:

--- a/builtin/files/plugins/dashboard/manifests/deployment.yaml
+++ b/builtin/files/plugins/dashboard/manifests/deployment.yaml
@@ -99,10 +99,12 @@ metadata:
 spec:
   ports:
     {{ if .Values.tls.enabled -}}
-    - port: 443
+    - name: https
+      port: 443
       targetPort: 8443
     {{ else -}}
-    - port: 9090
+    - name: http
+      port: 9090
       targetPort: 9090
     {{- end }}
   selector:

--- a/builtin/files/plugins/kiam/manifests/service.yaml
+++ b/builtin/files/plugins/kiam/manifests/service.yaml
@@ -9,7 +9,7 @@ spec:
     app: kiam
     role: server
   ports:
-  - name: grpclb
+  - name: {{ .Values.server.portName }}
     port: 443
     targetPort: 443
     protocol: TCP

--- a/builtin/files/plugins/kiam/plugin.yaml
+++ b/builtin/files/plugins/kiam/plugin.yaml
@@ -8,6 +8,7 @@ spec:
       tag: v3.2
       sessionDuration: 30m
       server:
+        portName: grpclb
         address: localhost:443
         resources:
           requests:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4911,7 +4911,8 @@ write_files:
         selector:
           k8s-app: metrics-server
         ports:
-        - port: 443
+        - name: https
+          port: 443
           protocol: TCP
           targetPort: 443
 


### PR DESCRIPTION
## Changes

The port name grpclb breaks installations of Isito, as kiam-server is running on 443, this causes all external SSL traffic to blackhole. 