### PR TITLE
[v0.16.0] Improve Canal Configuration

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1301,6 +1301,9 @@ write_files:
         typha_service_name: "none"
         {{- end }}
 
+        # Configure the MTU to use
+        veth_mtu: "1440"
+
         # The CNI network configuration to install on each node.
         cni_network_config: |-
           {
@@ -1489,6 +1492,7 @@ write_files:
           metadata:
             labels:
               k8s-app: canal-master
+              role.kubernetes.io/networking: "1"
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
           spec:
@@ -1518,16 +1522,44 @@ write_files:
             # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
             terminationGracePeriodSeconds: 0
             initContainers:
-              - name: remove-cni-networks
-                image: {{.HyperkubeImage.RepoWithTag}}
-                command:
-                - /bin/rm
-                - -rf
-                - /etc/kubernetes/cni/net.d/10-flannel.conflist
-                - /etc/kubernetes/cni/net.d/10-calico.conf
+              # This container installs the CNI binaries
+              # and CNI network config file on each node.
+              - name: install-cni
+                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
+                command: ["/install-cni.sh"]
+                env:
+                  - name: CNI_NET_DIR
+                    value: /etc/kubernetes/cni/net.d
+                  # Name of the CNI config file to create.
+                  - name: CNI_CONF_NAME
+                    value: "10-canal.conflist"
+                  # The CNI network config to install on each node.
+                  - name: CNI_NETWORK_CONFIG
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: cni_network_config
+                  # Set the hostname based on the k8s node name.
+                  - name: KUBERNETES_NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  # CNI MTU Config variable
+                  - name: CNI_MTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: veth_mtu
+                  # Prevents the container from sleeping forever.
+                  - name: SLEEP
+                    value: "false"
                 volumeMounts:
-                - mountPath: /etc/kubernetes/cni/net.d
-                  name: cni-net-dir
+                  - mountPath: /host/opt/cni/bin
+                    name: cni-bin-dir
+                  - mountPath: /host/etc/cni/net.d
+                    name: cni-net-dir
+                securityContext:
+                  privileged: true
             containers:
               # Runs calico/node container on each Kubernetes node.  This
               # container programs network policy and routes on each
@@ -1538,6 +1570,9 @@ write_files:
                   # Use Kubernetes API as the backing datastore.
                   - name: DATASTORE_TYPE
                     value: "kubernetes"
+                  # Configure route aggregation based on pod CIDR.
+                  - name: USE_POD_CIDR
+                    value: "true"                    
                   # Enable felix logging.
                   - name: FELIX_LOGSEVERITYSYS
                     value: "Warning"
@@ -1565,6 +1600,12 @@ write_files:
                   # Typha support: is never enabled on masters
                   - name: FELIX_TYPHAK8SSERVICENAME
                     value: "none"
+                  # Set MTU for tunnel device used if ipip is enabled
+                  - name: FELIX_IPINIPMTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: veth_mtu                    
                   - name: NODENAME
                     valueFrom:
                       fieldRef:
@@ -1599,37 +1640,17 @@ write_files:
                   - mountPath: /lib/modules
                     name: lib-modules
                     readOnly: true
+                  - mountPath: /run/xtables.lock
+                    name: xtables-lock
+                    readOnly: false
                   - mountPath: /var/run/calico
                     name: var-run-calico
                     readOnly: false
                   - mountPath: /var/lib/calico
                     name: var-lib-calico
                     readOnly: false
-              # This container installs the Calico CNI binaries
-              # and CNI network config file on each node.
-              - name: install-cni
-                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
-                command: ["/install-cni.sh"]
-                env:
-                  - name: CNI_NET_DIR
-                    value: "/etc/kubernetes/cni/net.d"
-                  - name: CNI_CONF_NAME
-                    value: "10-calico.conflist"
-                  # The CNI network config to install on each node.
-                  - name: CNI_NETWORK_CONFIG
-                    valueFrom:
-                      configMapKeyRef:
-                        name: canal-config
-                        key: cni_network_config
-                  - name: KUBERNETES_NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                volumeMounts:
-                  - mountPath: /host/opt/cni/bin
-                    name: cni-bin-dir
-                  - mountPath: /host/etc/cni/net.d
-                    name: cni-net-dir
+                  - name: policysync
+                    mountPath: /var/run/nodeagent
               # This container runs flannel using the kube-subnet-mgr backend
               # for allocating subnets.
               - name: flannel
@@ -1638,6 +1659,8 @@ write_files:
                 securityContext:
                   privileged: true
                 env:
+                  - name: FLANNELD_IPTABLES_FORWARD_RULES
+                    value: "false"                
                   - name: POD_NAME
                     valueFrom:
                       fieldRef:
@@ -1657,8 +1680,9 @@ write_files:
                         name: canal-config
                         key: masquerade
                 volumeMounts:
-                - name: run
-                  mountPath: /run
+                - mountPath: /run/xtables.lock
+                  name: xtables-lock
+                  readOnly: false
                 - name: flannel-cfg
                   mountPath: /etc/kube-flannel/
             volumes:
@@ -1672,6 +1696,14 @@ write_files:
               - name: var-lib-calico
                 hostPath:
                   path: /var/lib/calico
+              - name: xtables-lock
+                hostPath:
+                  path: /run/xtables.lock
+                  type: FileOrCreate
+              # Used by flannel.
+              - name: flannel-cfg
+                configMap:
+                  name: canal-config
               # Used to install CNI.
               - name: cni-bin-dir
                 hostPath:
@@ -1679,13 +1711,11 @@ write_files:
               - name: cni-net-dir
                 hostPath:
                   path: /etc/kubernetes/cni/net.d
-              # Used by flannel.
-              - name: run
+              # Used to create per-pod Unix Domain Sockets
+              - name: policysync
                 hostPath:
-                  path: /run
-              - name: flannel-cfg
-                configMap:
-                  name: canal-config
+                  type: DirectoryOrCreate
+                  path: /var/run/nodeagent
 
       # Canal DaemonSet for Nodes - Typha can be enabled.
       ---
@@ -1699,6 +1729,7 @@ write_files:
         namespace: kube-system
         labels:
           k8s-app: canal-node
+          role.kubernetes.io/networking: "1"
       spec:
         selector:
           matchLabels:
@@ -1711,6 +1742,7 @@ write_files:
           metadata:
             labels:
               k8s-app: canal-node
+              role.kubernetes.io/networking: "1"
             annotations:
               scheduler.alpha.kubernetes.io/critical-pod: ''
           spec:
@@ -1740,16 +1772,44 @@ write_files:
             # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
             terminationGracePeriodSeconds: 0
             initContainers:
-              - name: remove-cni-networks
-                image: {{.HyperkubeImage.RepoWithTag}}
-                command:
-                - /bin/rm
-                - -rf
-                - /etc/kubernetes/cni/net.d/10-flannel.conflist
-                - /etc/kubernetes/cni/net.d/10-calico.conf
+              # This container installs the CNI binaries
+              # and CNI network config file on each node.
+              - name: install-cni
+                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
+                command: ["/install-cni.sh"]
+                env:
+                  - name: CNI_NET_DIR
+                    value: /etc/kubernetes/cni/net.d
+                  # Name of the CNI config file to create.
+                  - name: CNI_CONF_NAME
+                    value: "10-canal.conflist"
+                  # The CNI network config to install on each node.
+                  - name: CNI_NETWORK_CONFIG
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: cni_network_config
+                  # Set the hostname based on the k8s node name.
+                  - name: KUBERNETES_NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  # CNI MTU Config variable
+                  - name: CNI_MTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: veth_mtu
+                  # Prevents the container from sleeping forever.
+                  - name: SLEEP
+                    value: "false"
                 volumeMounts:
-                - mountPath: /etc/kubernetes/cni/net.d
-                  name: cni-net-dir
+                  - mountPath: /host/opt/cni/bin
+                    name: cni-bin-dir
+                  - mountPath: /host/etc/cni/net.d
+                    name: cni-net-dir
+                securityContext:
+                  privileged: true
             containers:
               # Runs calico/node container on each Kubernetes node.  This
               # container programs network policy and routes on each
@@ -1760,6 +1820,9 @@ write_files:
                   # Use Kubernetes API as the backing datastore.
                   - name: DATASTORE_TYPE
                     value: "kubernetes"
+                  # Configure route aggregation based on pod CIDR.
+                  - name: USE_POD_CIDR
+                    value: "true"
                   # Enable felix logging.
                   - name: FELIX_LOGSEVERITYSYS
                     value: "Warning"
@@ -1784,6 +1847,12 @@ write_files:
                   # No IP address needed.
                   - name: IP
                     value: ""
+                  # Set MTU for tunnel device used if ipip is enabled
+                  - name: FELIX_IPINIPMTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: canal-config
+                        key: veth_mtu
                   # Typha support: controlled by the ConfigMap.
                   - name: FELIX_TYPHAK8SSERVICENAME
                     valueFrom:
@@ -1833,31 +1902,8 @@ write_files:
                   - mountPath: /var/lib/calico
                     name: var-lib-calico
                     readOnly: false
-              # This container installs the Calico CNI binaries
-              # and CNI network config file on each node.
-              - name: install-cni
-                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
-                command: ["/install-cni.sh"]
-                env:
-                  - name: CNI_NET_DIR
-                    value: "/etc/kubernetes/cni/net.d"
-                  - name: CNI_CONF_NAME
-                    value: "10-calico.conflist"
-                  # The CNI network config to install on each node.
-                  - name: CNI_NETWORK_CONFIG
-                    valueFrom:
-                      configMapKeyRef:
-                        name: canal-config
-                        key: cni_network_config
-                  - name: KUBERNETES_NODE_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: spec.nodeName
-                volumeMounts:
-                  - mountPath: /host/opt/cni/bin
-                    name: cni-bin-dir
-                  - mountPath: /host/etc/cni/net.d
-                    name: cni-net-dir
+                  - name: policysync
+                    mountPath: /var/run/nodeagent
               # This container runs flannel using the kube-subnet-mgr backend
               # for allocating subnets.
               - name: flannel
@@ -1866,6 +1912,8 @@ write_files:
                 securityContext:
                   privileged: true
                 env:
+                  - name: FLANNELD_IPTABLES_FORWARD_RULES
+                    value: "false"
                   - name: POD_NAME
                     valueFrom:
                       fieldRef:
@@ -1888,8 +1936,6 @@ write_files:
                 - mountPath: /run/xtables.lock
                   name: xtables-lock
                   readOnly: false
-                - name: run
-                  mountPath: /run
                 - name: flannel-cfg
                   mountPath: /etc/kube-flannel/
             volumes:
@@ -1907,6 +1953,10 @@ write_files:
                 hostPath:
                   path: /run/xtables.lock
                   type: FileOrCreate
+              # Used by flannel.
+              - name: flannel-cfg
+                configMap:
+                  name: canal-config
               # Used to install CNI.
               - name: cni-bin-dir
                 hostPath:
@@ -1914,13 +1964,11 @@ write_files:
               - name: cni-net-dir
                 hostPath:
                   path: /etc/kubernetes/cni/net.d
-              # Used by flannel.
-              - name: run
+              # Used to create per-pod Unix Domain Sockets
+              - name: policysync
                 hostPath:
-                  path: /run
-              - name: flannel-cfg
-                configMap:
-                  name: canal-config
+                  type: DirectoryOrCreate
+                  path: /var/run/nodeagent
       ---
       # Source: calico/templates/kdd-crds.yaml
       # Create all the CustomResourceDefinitions needed for


### PR DESCRIPTION
## Changes

This takes the canal configuration from kops, and moves installation into a initContainer as oppose to trying to run both the installation and canal containers side-by-side. 