### PR TITLE
[v0.16.x] Setup Calico Networking Option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.13.x
 
 script:
-  - travis_wait 40 make test-with-cover
+  - travis_wait 50 make test-with-cover
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1226,8 +1226,12 @@ kubernetes:
 #      # Be aware that network should be able to accomodate at least 4 subnets, and networks smaller than /28
 #      # will make flannel panic and exit.
 #      # Ref: https://github.com/coreos/flannel/blob/62a1314e51047e25606b4e4e30bd23d7a8d746bc/subnet/config.go#L69
-#      flannelConfig:
-#        subnetLen: 24
+#     flannelConfig:
+#       subnetLen: 24
+#     calicoConfig:
+#        # If false, we will run with bird in bgp/ip-in-ip mode.
+#        vxlanMode: true
+
 
 # Create MountTargets to subnets managed by kube-aws for a pre-existing Elastic File System (Amazon EFS),
 # and then mount to every node.

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1206,10 +1206,10 @@ kubernetes:
 #          cpu: "250m"
 #          memory: "200Mi"
 #      calicoNodeImage:
-#        repo: quay.io/calico/node
+#        repo: calico/node
 #        tag: v3.9.1
 #      calicoCniImage:
-#        repo: quay.io/calico/cni
+#        repo: calico/cni
 #        tag: v3.9.1
 #      flannelImage:
 #        repo: quay.io/coreos/flannel
@@ -1218,7 +1218,7 @@ kubernetes:
 #        repo: quay.io/coreos/flannel-cni
 #        tag: v0.3.0
 #      typhaImage:
-#        repo: quay.io/calico/typha
+#        repo: calico/typha
 #        tag: v3.9.1
 #      # By default, flannel assigns a /24 per node for pod's ips, this is effectively limiting your cluster size
 #      # to 255 nodes since each lease will be preserved for 24h.

--- a/builtin/files/stack-templates/network.json.tmpl
+++ b/builtin/files/stack-templates/network.json.tmpl
@@ -211,6 +211,7 @@
         "GroupId": {
           "Ref": "SecurityGroupController"
         },
+        "Description": "controller to controller sg",
         "IpProtocol": "-1",
         "SourceSecurityGroupId": {
           "Ref": "SecurityGroupWorker"
@@ -224,6 +225,7 @@
         "GroupId": {
           "Ref": "SecurityGroupController"
         },
+        "Description": "controller to calico",
         "IpProtocol": "udp",
         "SourceSecurityGroupId": {
           "Ref": "SecurityGroupController"
@@ -238,6 +240,7 @@
         "GroupId": {
           "Ref": "SecurityGroupController"
         },
+        "Description": "worker to calico sg",
         "IpProtocol": "udp",
         "SourceSecurityGroupId": {
           "Ref": "SecurityGroupWorker"

--- a/builtin/files/stack-templates/network.json.tmpl
+++ b/builtin/files/stack-templates/network.json.tmpl
@@ -275,34 +275,6 @@
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
     {{ end -}}
-    "SecurityGroupWorkerIngressFromControllerToCalicoBGP": {
-      "Properties": {
-        "FromPort": 179,
-        "GroupId": {
-          "Ref": "SecurityGroupWorker"
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Ref": "SecurityGroupController"
-        },
-        "ToPort": 179
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress"
-    },
-    "SecurityGroupWorkerIngressFromWorkerToCalicoBGP": {
-      "Properties": {
-        "FromPort": 179,
-        "GroupId": {
-          "Ref": "SecurityGroupWorker"
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Ref": "SecurityGroupWorker"
-        },
-        "ToPort": 179
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress"
-    },
    "SecurityGroupWorkerIngressFromControllerToFlannel": {
       "Properties": {
         "FromPort": 8472,
@@ -356,6 +328,62 @@
           "Ref": "SecurityGroupWorker"
         },
         "ToPort": 10250
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromControllerToBGP": {
+      "Properties": {
+        "FromPort": 179,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 179
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToBGP": {
+      "Properties": {
+        "FromPort": 179,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 179
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromControllerToCalico": {
+      "Properties": {
+        "FromPort": 4789,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "udp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 4789
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToCalico": {
+      "Properties": {
+        "FromPort": 4789,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "udp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 4789
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },

--- a/builtin/files/stack-templates/network.json.tmpl
+++ b/builtin/files/stack-templates/network.json.tmpl
@@ -275,6 +275,34 @@
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
     {{ end -}}
+    "SecurityGroupWorkerIngressFromControllerToCalicoBGP": {
+      "Properties": {
+        "FromPort": 179,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 179
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupWorkerIngressFromWorkerToCalicoBGP": {
+      "Properties": {
+        "FromPort": 179,
+        "GroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 179
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
    "SecurityGroupWorkerIngressFromControllerToFlannel": {
       "Properties": {
         "FromPort": 8472,

--- a/builtin/files/stack-templates/network.json.tmpl
+++ b/builtin/files/stack-templates/network.json.tmpl
@@ -194,31 +194,27 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "SecurityGroupControllerIngressFromControllerToBGP": {
+    "SecurityGroupControllerIngressFromControllerToController": {
       "Properties": {
-        "FromPort": 179,
         "GroupId": {
           "Ref": "SecurityGroupController"
         },
-        "IpProtocol": "tcp",
+        "IpProtocol": "-1",
         "SourceSecurityGroupId": {
           "Ref": "SecurityGroupController"
-        },
-        "ToPort": 179
+        }
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "SecurityGroupControllerIngressFromWorkerToBGP": {
+    "SecurityGroupControllerIngressFromWorkerToControllelr": {
       "Properties": {
-        "FromPort": 179,
         "GroupId": {
           "Ref": "SecurityGroupController"
         },
-        "IpProtocol": "tcp",
+        "IpProtocol": "-1",
         "SourceSecurityGroupId": {
           "Ref": "SecurityGroupWorker"
-        },
-        "ToPort": 179
+        }
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
@@ -387,31 +383,27 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "SecurityGroupWorkerIngressFromControllerToBGP": {
+    "SecurityGroupWorkerIngressFromControllerToWorker": {
       "Properties": {
-        "FromPort": 179,
         "GroupId": {
           "Ref": "SecurityGroupWorker"
         },
-        "IpProtocol": "tcp",
+        "IpProtocol": "-1",
         "SourceSecurityGroupId": {
           "Ref": "SecurityGroupController"
-        },
-        "ToPort": 179
+        }
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
-    "SecurityGroupWorkerIngressFromWorkerToBGP": {
+    "SecurityGroupWorkerIngressFromWorkerToWorker": {
       "Properties": {
-        "FromPort": 179,
         "GroupId": {
           "Ref": "SecurityGroupWorker"
         },
-        "IpProtocol": "tcp",
+        "IpProtocol": "-1",
         "SourceSecurityGroupId": {
           "Ref": "SecurityGroupWorker"
-        },
-        "ToPort": 179
+        }
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },

--- a/builtin/files/stack-templates/network.json.tmpl
+++ b/builtin/files/stack-templates/network.json.tmpl
@@ -194,6 +194,62 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    "SecurityGroupControllerIngressFromControllerToBGP": {
+      "Properties": {
+        "FromPort": 179,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 179
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupControllerIngressFromWorkerToBGP": {
+      "Properties": {
+        "FromPort": 179,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 179
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupControllerIngressFromControllerToCalico": {
+      "Properties": {
+        "FromPort": 4789,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "udp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 4789
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "SecurityGroupControllerIngressFromWorkerToCalico": {
+      "Properties": {
+        "FromPort": 4789,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "udp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 4789
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
     "SecurityGroupWorker": {
       "Properties": {
         "GroupDescription": {

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1861,7 +1861,7 @@ write_files:
             securityContext:
               fsGroup: 65534
             containers:
-            - image: calico/typha:v3.13.3
+            - image: {{ .Kubernetes.Networking.SelfHosting.TyphaImage.RepoWithTag }}
               name: calico-typha
               ports:
               - containerPort: 5473
@@ -1969,7 +1969,7 @@ write_files:
               # It can be deleted if this is a fresh installation, or if you have already
               # upgraded to use calico-ipam.
               - name: upgrade-ipam
-                image: calico/cni:v3.13.3
+                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
                 command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
                 env:
                   - name: KUBERNETES_NODE_NAME
@@ -1991,7 +1991,7 @@ write_files:
               # This container installs the CNI binaries
               # and CNI network config file on each node.
               - name: install-cni
-                image: calico/cni:v3.13.3
+                image: {{ .Kubernetes.Networking.SelfHosting.CalicoCniImage.RepoWithTag }}
                 command: ["/install-cni.sh"]
                 env:
                   - name: CNI_NET_DIR
@@ -2040,7 +2040,7 @@ write_files:
               # container programs network policy and routes on each
               # host.
               - name: calico-node
-                image: calico/node:v3.13.3
+                image: {{ .Kubernetes.Networking.SelfHosting.CalicoNodeImage.RepoWithTag }}
                 env:
                   # Use Kubernetes API as the backing datastore.
                   - name: DATASTORE_TYPE

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1848,16 +1848,11 @@ write_files:
             annotations:
               cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
           spec:
-            nodeSelector:
-              kubernetes.io/os: linux
-              kubernetes.io/role: master
             hostNetwork: true
             tolerations:
               # Mark the pod as a critical add-on for rescheduling.
               - key: CriticalAddonsOnly
                 operator: Exists
-              - key: "node-role.kubernetes.io/master"
-                effect: NoSchedule
             # Since Calico can't network a pod until Typha is up, we need to run Typha itself
             # as a host-networked pod.
             serviceAccountName: calico-node
@@ -2247,7 +2242,7 @@ write_files:
               # Mark the pod as a critical add-on for rescheduling.
               - key: CriticalAddonsOnly
                 operator: Exists
-              - key: node-role.kubernetes.io/master
+              - key: node.kubernetes.io/master
                 effect: NoSchedule
             serviceAccountName: calico-kube-controllers
             priorityClassName: system-cluster-critical

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1339,7 +1339,7 @@ write_files:
         typha_service_name: "{{- if .Kubernetes.Networking.SelfHosting.Typha }}calico-typha{{- else -}}none{{- end -}}"
         
         # Configure the backend to use.
-        calico_backend: "bird"
+        calico_backend: "{{- if .Kubernetes.Networking.SelfHosting.CalicoConfig.VxlanMode }}vxlan{{- else -}}bird{{- end -}}"
 
         # Configure the MTU to use
         veth_mtu: "1440"
@@ -2116,7 +2116,7 @@ write_files:
                         key: calico_backend
                   # Cluster type to identify the deployment type
                   - name: CLUSTER_TYPE
-                    value: "kops,bgp"
+                    value: "k8s,bgp"
                   # Auto-detect the BGP IP address.
                   - name: IP
                     value: "autodetect"
@@ -2125,8 +2125,13 @@ write_files:
                   - name: IP6_AUTODETECTION_METHOD
                     value: "first-found"
                   # Enable IPIP
+                  {{- if .Kubernetes.Networking.SelfHosting.CalicoConfig.VxlanMode }}
+                  - name: CALICO_IPV4POOL_VXLAN
+                    value: "Always"
+                  {{- else }}
                   - name: CALICO_IPV4POOL_IPIP
                     value: "Always"
+                  {{- end }}
                   # Set MTU for tunnel device used if ipip is enabled
                   - name: FELIX_IPINIPMTU
                     valueFrom:
@@ -2152,8 +2157,6 @@ write_files:
                     value: "info"
                   - name: FELIX_HEALTHENABLED
                     value: "true"
-
-                  # kops additions
                   # Set Felix iptables binary variant, Legacy or NFT
                   - name: FELIX_IPTABLESBACKEND
                     value: "Auto"
@@ -2188,7 +2191,9 @@ write_files:
                     command:
                     - /bin/calico-node
                     - -felix-ready
+                    {{- if not .Kubernetes.Networking.SelfHosting.CalicoConfig.VxlanMode }}
                     - -bird-ready
+                    {{- end }}
                   periodSeconds: 10
                 volumeMounts:
                   - mountPath: /lib/modules

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -387,6 +387,11 @@ coreos:
         --node-labels=node.kubernetes.io/role="master",service-cidr={{ .ServiceCIDR | toLabel }}{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-with-taints=node.kubernetes.io/role=master:NoSchedule \
         --config=/etc/kubernetes/config/kubelet.yaml \
+        {{- if .Experimental.CloudControllerManager.Enabled }}
+        --cloud-provider=external \
+        {{- else }}
+        --cloud-provider=aws \
+        {{- end }}
         {{- if .Kubernetes.Networking.AmazonVPC.Enabled }}
         --node-ip=$$(curl http://169.254.169.254/latest/meta-data/local-ipv4) \
         --max-pods=$$(/opt/bin/aws-k8s-cni-max-pods) \
@@ -464,6 +469,24 @@ coreos:
         {{end -}}
         ExecStart=/opt/bin/cfn-signal
 {{end}}
+
+    - name: kubernetes-io-node-label.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Label this kubernetes node with kubernetes.io labels.
+        Wants=kubelet.service
+        After=kubelet.service
+        Before=cfn-signal.service
+
+        [Service]
+        Type=oneshot
+        ExecStop=/bin/true
+        RemainAfterExit=true
+        ExecStart=/opt/bin/kubernetes-io-node-label
+
 {{if .Experimental.AwsNodeLabels.Enabled }}
     - name: kube-node-label.service
       enable: true
@@ -720,6 +743,31 @@ write_files:
 
       rkt rm --uuid-file=/var/run/coreos/${id}.uuid || :
 {{ end }}
+
+  - path: /opt/bin/kubernetes-io-node-label
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash -e
+      set -ue
+
+       # FIXME: Remove dependency on the apiserver insecure port
+       until /usr/bin/curl -s -f http://127.0.0.1:8080/version; do echo waiting until apiserver starts; sleep 1; done
+
+       # FIXME: Remove dependency on the apiserver insecure port
+       /usr/bin/curl \
+         --retry 5 \
+         --request PATCH \
+         -H 'Content-Type: application/strategic-merge-patch+json' \
+         -d '{
+              "metadata": {
+                "labels": {
+                  "kubernetes.io/role": "master",
+                  "node-role.kubernetes.io/master": ""
+                 }
+              }
+            }' \
+         http://localhost:8080/api/v1/nodes/$(hostname)
 
   {{if .Experimental.AwsNodeLabels.Enabled -}}
   - path: /opt/bin/kube-node-label

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1045,11 +1045,18 @@ write_files:
       deploy "${mfdir}/aws-k8s-cni.yaml"
       remove "${mfdir}/flannel.yaml"
       remove "${mfdir}/canal.yaml"
+      remove "${mfdir}/calico.yaml"
+      {{- else if eq .Kubernetes.Networking.SelfHosting.Type "calico" }}
+      deploy "${mfdir}/calico.yaml"
+      remove "${mfdir}/flannel.yaml"
+      remove "${mfdir}/canal.yaml"
       {{- else if eq .Kubernetes.Networking.SelfHosting.Type "canal" }}
       remove "${mfdir}/flannel.yaml"
+      remove "${mfdir}/calico.yaml"
       deploy "${mfdir}/canal.yaml"
       {{- else }}
       remove "${mfdir}/canal.yaml"
+      remove "${mfdir}/calico.yaml"
       deploy "${mfdir}/flannel.yaml"
       {{- end }}
 
@@ -1271,6 +1278,1005 @@ write_files:
       # through the api-server. Related issue:
       # https://github.com/coreos/rkt/issues/2878
       exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "$@"
+
+  - path: /srv/kubernetes/manifests/calico.yaml
+    content: |
+    # Pulled and modified from: https://docs.projectcalico.org/v3.13/manifests/calico-typha.yaml
+
+    ---
+    # Source: calico/templates/calico-config.yaml
+    # This ConfigMap is used to configure a self-hosted Calico installation.
+    kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: calico-config
+      namespace: kube-system
+      labels:
+        role.kubernetes.io/networking: "1"
+    data:
+      # You must set a non-zero value for Typha replicas below.
+      typha_service_name: "{{- if .Kubernetes.Networking.SelfHosting.Typha }}calico-typha{{- else -}}none{{- end -}}"
+      
+      # Configure the backend to use.
+      calico_backend: "bird"
+
+      # Configure the MTU to use
+      veth_mtu: "1440"
+
+      # The CNI network configuration to install on each node.  The special
+      # values in this config will be automatically populated.
+      cni_network_config: |-
+        {
+          "name": "k8s-pod-network",
+          "cniVersion": "0.3.1",
+          "plugins": [
+            {
+              "type": "calico",
+              "log_level": "info",
+              "datastore_type": "kubernetes",
+              "nodename": "__KUBERNETES_NODE_NAME__",
+              "mtu": __CNI_MTU__,
+              "ipam": {
+                  "type": "calico-ipam"
+              },
+              "policy": {
+                  "type": "k8s",
+                  "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+              },
+              "kubernetes": {
+                  "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              }
+            },
+            {
+              "type": "portmap",
+              "snat": true,
+              "capabilities": {"portMappings": true}
+            },
+            {
+              "type": "bandwidth",
+              "capabilities": {"bandwidth": true}
+            }
+          ]
+        }
+
+    ---
+    # Source: calico/templates/kdd-crds.yaml
+
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgpconfigurations.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: BGPConfiguration
+        plural: bgpconfigurations
+        singular: bgpconfiguration
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: bgppeers.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: BGPPeer
+        plural: bgppeers
+        singular: bgppeer
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: blockaffinities.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: BlockAffinity
+        plural: blockaffinities
+        singular: blockaffinity
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: clusterinformations.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: ClusterInformation
+        plural: clusterinformations
+        singular: clusterinformation
+
+    ---
+
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: felixconfigurations.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: FelixConfiguration
+        plural: felixconfigurations
+        singular: felixconfiguration
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworkpolicies.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: GlobalNetworkPolicy
+        plural: globalnetworkpolicies
+        singular: globalnetworkpolicy
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: globalnetworksets.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: GlobalNetworkSet
+        plural: globalnetworksets
+        singular: globalnetworkset
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: hostendpoints.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: HostEndpoint
+        plural: hostendpoints
+        singular: hostendpoint
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamblocks.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: IPAMBlock
+        plural: ipamblocks
+        singular: ipamblock
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamconfigs.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: IPAMConfig
+        plural: ipamconfigs
+        singular: ipamconfig
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ipamhandles.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: IPAMHandle
+        plural: ipamhandles
+        singular: ipamhandle
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: ippools.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Cluster
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: IPPool
+        plural: ippools
+        singular: ippool
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networkpolicies.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Namespaced
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: NetworkPolicy
+        plural: networkpolicies
+        singular: networkpolicy
+
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      name: networksets.crd.projectcalico.org
+      labels:
+        role.kubernetes.io/networking: "1"
+    spec:
+      scope: Namespaced
+      group: crd.projectcalico.org
+      version: v1
+      names:
+        kind: NetworkSet
+        plural: networksets
+        singular: networkset
+
+    ---
+    # Source: calico/templates/rbac.yaml
+
+    # Include a clusterrole for the kube-controllers component,
+    # and bind it to the calico-kube-controllers serviceaccount.
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: calico-kube-controllers
+      labels:
+        role.kubernetes.io/networking: "1"
+    rules:
+      # Nodes are watched to monitor for deletions.
+      - apiGroups: [""]
+        resources:
+          - nodes
+        verbs:
+          - watch
+          - list
+          - get
+      # Pods are queried to check for existence.
+      - apiGroups: [""]
+        resources:
+          - pods
+        verbs:
+          - get
+      # IPAM resources are manipulated when nodes are deleted.
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - ippools
+        verbs:
+          - list
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - blockaffinities
+          - ipamblocks
+          - ipamhandles
+        verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+      # Needs access to update clusterinformations.
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - clusterinformations
+        verbs:
+          - get
+          - create
+          - update
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: calico-kube-controllers
+      labels:
+        role.kubernetes.io/networking: "1"
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    ---
+    # Include a clusterrole for the calico-node DaemonSet,
+    # and bind it to the calico-node serviceaccount.
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: calico-node
+      labels:
+        role.kubernetes.io/networking: "1"
+    rules:
+      # The CNI plugin needs to get pods, nodes, and namespaces.
+      - apiGroups: [""]
+        resources:
+          - pods
+          - nodes
+          - namespaces
+        verbs:
+          - get
+      - apiGroups: [""]
+        resources:
+          - endpoints
+          - services
+        verbs:
+          # Used to discover service IPs for advertisement.
+          - watch
+          - list
+          # Used to discover Typhas.
+          - get
+      # Pod CIDR auto-detection on kubeadm needs access to config maps.
+      - apiGroups: [""]
+        resources:
+          - configmaps
+        verbs:
+          - get
+      - apiGroups: [""]
+        resources:
+          - nodes/status
+        verbs:
+          # Needed for clearing NodeNetworkUnavailable flag.
+          - patch
+          # Calico stores some configuration information in node annotations.
+          - update
+      # Watch for changes to Kubernetes NetworkPolicies.
+      - apiGroups: ["networking.k8s.io"]
+        resources:
+          - networkpolicies
+        verbs:
+          - watch
+          - list
+      # Used by Calico for policy information.
+      - apiGroups: [""]
+        resources:
+          - pods
+          - namespaces
+          - serviceaccounts
+        verbs:
+          - list
+          - watch
+      # The CNI plugin patches pods/status.
+      - apiGroups: [""]
+        resources:
+          - pods/status
+        verbs:
+          - patch
+      # Calico monitors various CRDs for config.
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - globalfelixconfigs
+          - felixconfigurations
+          - bgppeers
+          - globalbgpconfigs
+          - bgpconfigurations
+          - ippools
+          - ipamblocks
+          - globalnetworkpolicies
+          - globalnetworksets
+          - networkpolicies
+          - networksets
+          - clusterinformations
+          - hostendpoints
+          - blockaffinities
+        verbs:
+          - get
+          - list
+          - watch
+      # Calico must create and update some CRDs on startup.
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - ippools
+          - felixconfigurations
+          - clusterinformations
+        verbs:
+          - create
+          - update
+      # Calico stores some configuration information on the node.
+      - apiGroups: [""]
+        resources:
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      # These permissions are only required for upgrade from v2.6, and can
+      # be removed after upgrade or on fresh installations.
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - bgpconfigurations
+          - bgppeers
+        verbs:
+          - create
+          - update
+      # These permissions are required for Calico CNI to perform IPAM allocations.
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - blockaffinities
+          - ipamblocks
+          - ipamhandles
+        verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - ipamconfigs
+        verbs:
+          - get
+      # Block affinities must also be watchable by confd for route aggregation.
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - blockaffinities
+        verbs:
+          - watch
+      # The Calico IPAM migration needs to get daemonsets. These permissions can be
+      # removed if not upgrading from an installation using host-local IPAM.
+      - apiGroups: ["apps"]
+        resources:
+          - daemonsets
+        verbs:
+          - get
+
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: calico-node
+      labels:
+        role.kubernetes.io/networking: "1"
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+
+    {{ if .Kubernetes.Networking.SelfHosting.Typha -}}
+    ---
+    # Source: calico/templates/calico-typha.yaml
+    # This manifest creates a Service, which will be backed by Calico's Typha daemon.
+    # Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: calico-typha
+      namespace: kube-system
+      labels:
+        k8s-app: calico-typha
+        role.kubernetes.io/networking: "1"
+    spec:
+      ports:
+        - port: 5473
+          protocol: TCP
+          targetPort: calico-typha
+          name: calico-typha
+      selector:
+        k8s-app: calico-typha
+
+    ---
+
+    # This manifest creates a Deployment of Typha to back the above service.
+
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: calico-typha
+      namespace: kube-system
+      labels:
+        k8s-app: calico-typha
+        role.kubernetes.io/networking: "1"
+    spec:
+      # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
+      # typha_service_name variable in the calico-config ConfigMap above.
+      #
+      # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
+      # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
+      # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
+      replicas: 3
+      revisionHistoryLimit: 2
+      selector:
+        matchLabels:
+          k8s-app: calico-typha
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-typha
+            role.kubernetes.io/networking: "1"
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
+        spec:
+          nodeSelector:
+            kubernetes.io/os: linux
+            kubernetes.io/role: master
+          hostNetwork: true
+          tolerations:
+            # Mark the pod as a critical add-on for rescheduling.
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - key: "node-role.kubernetes.io/master"
+              effect: NoSchedule
+          # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+          # as a host-networked pod.
+          serviceAccountName: calico-node
+          priorityClassName: system-cluster-critical
+          # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
+          securityContext:
+            fsGroup: 65534
+          containers:
+          - image: calico/typha:v3.13.3
+            name: calico-typha
+            ports:
+            - containerPort: 5473
+              name: calico-typha
+              protocol: TCP
+            env:
+              # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
+              - name: TYPHA_LOGSEVERITYSCREEN
+                value: "info"
+              # Disable logging to file and syslog since those don't make sense in Kubernetes.
+              - name: TYPHA_LOGFILEPATH
+                value: "none"
+              - name: TYPHA_LOGSEVERITYSYS
+                value: "none"
+              # Monitor the Kubernetes API to find the number of running instances and rebalance
+              # connections.
+              - name: TYPHA_CONNECTIONREBALANCINGMODE
+                value: "kubernetes"
+              - name: TYPHA_DATASTORETYPE
+                value: "kubernetes"
+              - name: TYPHA_HEALTHENABLED
+                value: "true"
+            livenessProbe:
+              httpGet:
+                path: /liveness
+                port: 9098
+                host: localhost
+              periodSeconds: 30
+              initialDelaySeconds: 30
+            securityContext:
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false
+            readinessProbe:
+              httpGet:
+                path: /readiness
+                port: 9098
+                host: localhost
+              periodSeconds: 10
+
+    ---
+
+    # This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
+
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      name: calico-typha
+      namespace: kube-system
+      labels:
+        k8s-app: calico-typha
+        role.kubernetes.io/networking: "1"
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-typha
+    {{- end }}
+
+    ---
+    # Source: calico/templates/calico-node.yaml
+    # This manifest installs the calico-node container, as well
+    # as the CNI plugins and network config on
+    # each master and worker node in a Kubernetes cluster.
+    kind: DaemonSet
+    apiVersion: apps/v1
+    metadata:
+      name: calico-node
+      namespace: kube-system
+      labels:
+        k8s-app: calico-node
+        role.kubernetes.io/networking: "1"
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: calico-node
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+      template:
+        metadata:
+          labels:
+            k8s-app: calico-node
+            role.kubernetes.io/networking: "1"
+        spec:
+          nodeSelector:
+            kubernetes.io/os: linux
+          hostNetwork: true
+          tolerations:
+            # Make sure calico-node gets scheduled on all nodes.
+            - effect: NoSchedule
+              operator: Exists
+            # Mark the pod as a critical add-on for rescheduling.
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - effect: NoExecute
+              operator: Exists
+          serviceAccountName: calico-node
+          # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+          # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+          terminationGracePeriodSeconds: 0
+          priorityClassName: system-node-critical
+          initContainers:
+            # This container performs upgrade from host-local IPAM to calico-ipam.
+            # It can be deleted if this is a fresh installation, or if you have already
+            # upgraded to use calico-ipam.
+            - name: upgrade-ipam
+              image: calico/cni:v3.13.3
+              command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+              env:
+                - name: KUBERNETES_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                - name: CALICO_NETWORKING_BACKEND
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: calico_backend
+              volumeMounts:
+                - mountPath: /var/lib/cni/networks
+                  name: host-local-net-dir
+                - mountPath: /host/opt/cni/bin
+                  name: cni-bin-dir
+              securityContext:
+                privileged: true
+            # This container installs the CNI binaries
+            # and CNI network config file on each node.
+            - name: install-cni
+              image: calico/cni:v3.13.3
+              command: ["/install-cni.sh"]
+              env:
+                - name: CNI_NET_DIR
+                  value: "/etc/kubernetes/cni/net.d"
+                # Name of the CNI config file to create.
+                - name: CNI_CONF_NAME
+                  value: "10-calico.conflist"
+                # The CNI network config to install on each node.
+                - name: CNI_NETWORK_CONFIG
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: cni_network_config
+                # Set the hostname based on the k8s node name.
+                - name: KUBERNETES_NODE_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                # CNI MTU Config variable
+                - name: CNI_MTU
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: veth_mtu
+                # Prevents the container from sleeping forever.
+                - name: SLEEP
+                  value: "false"
+              volumeMounts:
+                - mountPath: /host/opt/cni/bin
+                  name: cni-bin-dir
+                - mountPath: /host/etc/cni/net.d
+                  name: cni-net-dir
+              securityContext:
+                privileged: true
+            # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
+            # to communicate with Felix over the Policy Sync API.
+            - name: flexvol-driver
+              image: calico/pod2daemon-flexvol:v3.13.3
+              volumeMounts:
+              - name: flexvol-driver-host
+                mountPath: /host/driver
+              securityContext:
+                privileged: true
+          containers:
+            # Runs calico-node container on each Kubernetes node.  This
+            # container programs network policy and routes on each
+            # host.
+            - name: calico-node
+              image: calico/node:v3.13.3
+              env:
+                # Use Kubernetes API as the backing datastore.
+                - name: DATASTORE_TYPE
+                  value: "kubernetes"
+                {{- if .Kubernetes.Networking.SelfHosting.Typha }}
+                # Typha support: controlled by the ConfigMap.
+                - name: FELIX_TYPHAK8SSERVICENAME
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: typha_service_name
+                {{- end }}
+                # Wait for the datastore.
+                - name: WAIT_FOR_DATASTORE
+                  value: "true"
+                # Set based on the k8s node name.
+                - name: NODENAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: spec.nodeName
+                # Choose the backend to use.
+                - name: CALICO_NETWORKING_BACKEND
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: calico_backend
+                # Cluster type to identify the deployment type
+                - name: CLUSTER_TYPE
+                  value: "kops,bgp"
+                # Auto-detect the BGP IP address.
+                - name: IP
+                  value: "autodetect"
+                - name: IP_AUTODETECTION_METHOD
+                  value: "first-found"
+                - name: IP6_AUTODETECTION_METHOD
+                  value: "first-found"
+                # Enable IPIP
+                - name: CALICO_IPV4POOL_IPIP
+                  value: "Always"
+                # Set MTU for tunnel device used if ipip is enabled
+                - name: FELIX_IPINIPMTU
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: veth_mtu
+                # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+                # chosen from this range. Changing this value after installation will have
+                # no effect. This should fall within `--cluster-cidr`.
+                - name: CALICO_IPV4POOL_CIDR
+                  value: "{{ .PodCIDR }}"
+                # Disable file logging so `kubectl logs` works.
+                - name: CALICO_DISABLE_FILE_LOGGING
+                  value: "true"
+                # Set Felix endpoint to host default action to ACCEPT.
+                - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+                  value: "ACCEPT"
+                # Disable IPv6 on Kubernetes.
+                - name: FELIX_IPV6SUPPORT
+                  value: "false"
+                # Set Felix logging to "info"
+                - name: FELIX_LOGSEVERITYSCREEN
+                  value: "info"
+                - name: FELIX_HEALTHENABLED
+                  value: "true"
+
+                # kops additions
+                # Set Felix iptables binary variant, Legacy or NFT
+                - name: FELIX_IPTABLESBACKEND
+                  value: "Auto"
+                # Set to enable the experimental Prometheus metrics server
+                - name: FELIX_PROMETHEUSMETRICSENABLED
+                  value: "false"
+                # TCP port that the Prometheus metrics server should bind to
+                - name: FELIX_PROMETHEUSMETRICSPORT
+                  value: "9091"
+                # Enable Prometheus Go runtime metrics collection
+                - name: FELIX_PROMETHEUSGOMETRICSENABLED
+                  value: "true"
+                # Enable Prometheus process metrics collection
+                - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
+                  value: "true"
+              securityContext:
+                privileged: true
+              resources:
+                requests:
+                  cpu: 100m
+              livenessProbe:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -felix-live
+                  - -bird-live
+                periodSeconds: 10
+                initialDelaySeconds: 10
+                failureThreshold: 6
+              readinessProbe:
+                exec:
+                  command:
+                  - /bin/calico-node
+                  - -felix-ready
+                  - -bird-ready
+                periodSeconds: 10
+              volumeMounts:
+                - mountPath: /lib/modules
+                  name: lib-modules
+                  readOnly: true
+                - mountPath: /run/xtables.lock
+                  name: xtables-lock
+                  readOnly: false
+                - mountPath: /var/run/calico
+                  name: var-run-calico
+                  readOnly: false
+                - mountPath: /var/lib/calico
+                  name: var-lib-calico
+                  readOnly: false
+                - name: policysync
+                  mountPath: /var/run/nodeagent
+          volumes:
+            # Used by calico-node.
+            - name: lib-modules
+              hostPath:
+                path: /lib/modules
+            - name: var-run-calico
+              hostPath:
+                path: /var/run/calico
+            - name: var-lib-calico
+              hostPath:
+                path: /var/lib/calico
+            - name: xtables-lock
+              hostPath:
+                path: /run/xtables.lock
+                type: FileOrCreate
+            # Used to install CNI.
+            - name: cni-bin-dir
+              hostPath:
+                path: /opt/cni/bin
+            - name: cni-net-dir
+              hostPath:
+                path: /etc/kubernetes/cni/net.d
+            # Mount in the directory for host-local IPAM allocations. This is
+            # used when upgrading from host-local to calico-ipam, and can be removed
+            # if not using the upgrade-ipam init container.
+            - name: host-local-net-dir
+              hostPath:
+                path: /var/lib/cni/networks
+            # Used to create per-pod Unix Domain Sockets
+            - name: policysync
+              hostPath:
+                type: DirectoryOrCreate
+                path: /var/run/nodeagent
+            # Used to install Flex Volume Driver
+            - name: flexvol-driver-host
+              hostPath:
+                type: DirectoryOrCreate
+                path: "/var/lib/kubelet/volumeplugins/nodeagent~uds"
+    ---
+
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-node
+      namespace: kube-system
+      labels:
+        role.kubernetes.io/networking: "1"
+
+    ---
+    # Source: calico/templates/calico-kube-controllers.yaml
+
+    # See https://github.com/projectcalico/kube-controllers
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+        role.kubernetes.io/networking: "1"
+    spec:
+      # The controllers can only have a single active instance.
+      replicas: 1
+      selector:
+        matchLabels:
+          k8s-app: calico-kube-controllers
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          name: calico-kube-controllers
+          namespace: kube-system
+          labels:
+            k8s-app: calico-kube-controllers
+            role.kubernetes.io/networking: "1"
+          annotations:
+            scheduler.alpha.kubernetes.io/critical-pod: ''
+        spec:
+          nodeSelector:
+            kubernetes.io/os: linux
+          tolerations:
+            # Mark the pod as a critical add-on for rescheduling.
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - key: node-role.kubernetes.io/master
+              effect: NoSchedule
+          serviceAccountName: calico-kube-controllers
+          priorityClassName: system-cluster-critical
+          containers:
+            - name: calico-kube-controllers
+              image: calico/kube-controllers:v3.13.3
+              env:
+                # Choose which controllers to run.
+                - name: ENABLED_CONTROLLERS
+                  value: node
+                - name: DATASTORE_TYPE
+                  value: kubernetes
+              readinessProbe:
+                exec:
+                  command:
+                  - /usr/bin/check-status
+                  - -r
+
+    ---
+
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        role.kubernetes.io/networking: "1"
 
   - path: /srv/kubernetes/manifests/canal.yaml
     content: |

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -321,13 +321,15 @@ coreos:
       command: start
       runtime: true
       content: |
+{{/* START of kubelet [Unit] */}}
         [Unit]
         Wants=cfn-etcd-environment.service
         After=cfn-etcd-environment.service
         Wants=rpc-statd.service
         Wants=decrypt-assets.service
         After=decrypt-assets.service
-
+{{/* END of kubelet [Unit] */}}
+{{/* START of kubelet [Service] */}}
         [Service]
         # EnvironmentFile=/etc/environment allows the reading of COREOS_PRIVATE_IPV4
         EnvironmentFile=/etc/environment
@@ -402,9 +404,11 @@ coreos:
         ExecStop=/usr/bin/docker rm -f kubelet
         Restart=always
         RestartSec=10
-
+{{/* END of kubelet [Service] */}}
+{{/* START of kubelet [Install] */}}
         [Install]
         WantedBy=multi-user.target
+{{/* END of kubelet [Install] */}}
 
     - name: rpc-statd.service
       command: start

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2374,7 +2374,7 @@ write_files:
       ---
       # This manifest creates a Deployment of Typha to back the above service.
 
-      apiVersion: apps/v1beta1
+      apiVersion: apps/v1
       kind: Deployment
       metadata:
         name: calico-typha

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -329,11 +329,34 @@ coreos:
         After=decrypt-assets.service
 
         [Service]
-
         # EnvironmentFile=/etc/environment allows the reading of COREOS_PRIVATE_IPV4
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/etcd-environment
         EnvironmentFile=-/etc/default/kubelet
+        Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
+        Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
+        Environment="RKT_RUN_ARGS={{.HyperkubeImage.Options}}\
+        --volume dns,kind=host,source=/etc/resolv.conf \
+        --mount volume=dns,target=/etc/resolv.conf \
+        --volume var-lib-cni,kind=host,source=/var/lib/cni \
+        --mount volume=var-lib-cni,target=/var/lib/cni \
+        --volume var-run-calico,kind=host,source=/var/run/calico \
+        --mount volume=var-run-calico,target=/var/run/calico \
+        --volume var-lib-calico,kind=host,source=/var/lib/calico \
+        --mount volume=var-lib-calico,target=/var/lib/calico \
+        --volume var-log,kind=host,source=/var/log \
+        {{ if gt (len .Kubelet.Mounts) 0 -}}
+        {{ range $i, $m := .Kubelet.Mounts -}}
+        {{ range $j, $a := $m.ToRktRunArgs -}}
+        {{ $a }} \
+        {{ end -}}
+        {{ end -}}
+        {{ end -}}
+        --mount volume=var-log,target=/var/log \
+        --volume cni-bin,kind=host,source=/opt/cni/bin \
+        --mount volume=cni-bin,target=/opt/cni/bin \
+        --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
+        --mount volume=etc-kubernetes,target=/etc/kubernetes"
         ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
@@ -342,33 +365,10 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
-        ExecStartPre=/usr/bin/mkdir -p /var/lib/docker
-        ExecStartPre=/bin/bash -c "if ! grep -q "/var/lib/kubelet" /proc/mounts; then mount --bind /var/lib/kubelet /var/lib/kubelet && mount --make-shared /var/lib/kubelet; fi"
         ExecStartPre=/bin/sed -e "s/COREOS_PRIVATE_IPV4/${COREOS_PRIVATE_IPV4}/g" -i /etc/kubernetes/config/kubelet.yaml
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /srv/kubernetes/manifests  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
-        ExecStartPre=-/bin/docker rm -f kubelet
-        ExecStart=/bin/sh -c "docker run --name kubelet --privileged --net=host --pid=host \
-        -v /:/rootfs:ro \
-        -v /sys:/sys:ro \
-        -v /dev:/dev \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -v /etc/resolv.conf:/etc/resolv.conf:ro \
-        -v /var/lib/cni:/var/lib/cni:rw \
-        -v /var/run/calico:/var/run/calico:rw \
-        -v /var/lib/calico:/var/lib/calico:rw \
-        -v /var/log:/var/log:rw \
-        -v /opt/cni/bin:/opt/cni/bin:rw \
-        -v /etc/kubernetes:/etc/kubernetes:rw \
-        -v /var/lib/kubelet:/var/lib/kubelet:shared \
-        -v /var/lib/docker:/var/lib/docker:rshared \
-        {{- if gt (len .Kubelet.Mounts) 0 }}
-          {{- range .Kubelet.Mounts }}
-        {{ .MountDockerRW }} \
-          {{- end }}
-        {{- end }}
-        {{ .HyperkubeImage.RepoWithTag }} /kubelet \
-        {{- if checkVersion ">= 1.14" .K8sVer }}
+        ExecStart=/bin/sh -c "exec /usr/lib/coreos/kubelet-wrapper \
+        {{ if checkVersion ">= 1.14" .K8sVer -}}
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- end }}
         {{ if .Kubelet.Kubeconfig -}}
@@ -387,11 +387,6 @@ coreos:
         --node-labels=node.kubernetes.io/role="master",service-cidr={{ .ServiceCIDR | toLabel }}{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-with-taints=node.kubernetes.io/role=master:NoSchedule \
         --config=/etc/kubernetes/config/kubelet.yaml \
-        {{- if .Experimental.CloudControllerManager.Enabled }}
-        --cloud-provider=external \
-        {{- else }}
-        --cloud-provider=aws \
-        {{- end }}
         {{- if .Kubernetes.Networking.AmazonVPC.Enabled }}
         --node-ip=$$(curl http://169.254.169.254/latest/meta-data/local-ipv4) \
         --max-pods=$$(/opt/bin/aws-k8s-cni-max-pods) \
@@ -399,8 +394,8 @@ coreos:
         {{- range $f := .Kubelet.Flags}}
         --{{$f.Name}}={{$f.Value}} \
         {{- end }}
-        $KUBELET_OPTS"
-        ExecStop=/usr/bin/docker rm -f kubelet
+        $KUBELET_OPTS \
+        "
         Restart=always
         RestartSec=10
 

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -333,30 +333,6 @@ coreos:
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/etcd-environment
         EnvironmentFile=-/etc/default/kubelet
-        Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
-        Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
-        Environment="RKT_RUN_ARGS={{.HyperkubeImage.Options}}\
-        --volume dns,kind=host,source=/etc/resolv.conf \
-        --mount volume=dns,target=/etc/resolv.conf \
-        --volume var-lib-cni,kind=host,source=/var/lib/cni \
-        --mount volume=var-lib-cni,target=/var/lib/cni \
-        --volume var-run-calico,kind=host,source=/var/run/calico \
-        --mount volume=var-run-calico,target=/var/run/calico \
-        --volume var-lib-calico,kind=host,source=/var/lib/calico \
-        --mount volume=var-lib-calico,target=/var/lib/calico \
-        --volume var-log,kind=host,source=/var/log \
-        {{ if gt (len .Kubelet.Mounts) 0 -}}
-        {{ range $i, $m := .Kubelet.Mounts -}}
-        {{ range $j, $a := $m.ToRktRunArgs -}}
-        {{ $a }} \
-        {{ end -}}
-        {{ end -}}
-        {{ end -}}
-        --mount volume=var-log,target=/var/log \
-        --volume cni-bin,kind=host,source=/opt/cni/bin \
-        --mount volume=cni-bin,target=/opt/cni/bin \
-        --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-        --mount volume=etc-kubernetes,target=/etc/kubernetes"
         ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
@@ -365,10 +341,33 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
+        ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
+        ExecStartPre=/usr/bin/mkdir -p /var/lib/docker
+        ExecStartPre=/bin/bash -c "if ! grep -q "/var/lib/kubelet" /proc/mounts; then mount --bind /var/lib/kubelet /var/lib/kubelet && mount --make-shared /var/lib/kubelet; fi"
         ExecStartPre=/bin/sed -e "s/COREOS_PRIVATE_IPV4/${COREOS_PRIVATE_IPV4}/g" -i /etc/kubernetes/config/kubelet.yaml
         ExecStartPre=/bin/sh -ec "find /etc/kubernetes/manifests /srv/kubernetes/manifests  -maxdepth 1 -type f | xargs --no-run-if-empty sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|'"
-        ExecStart=/bin/sh -c "exec /usr/lib/coreos/kubelet-wrapper \
-        {{ if checkVersion ">= 1.14" .K8sVer -}}
+        ExecStartPre=-/bin/docker rm -f kubelet
+        ExecStart=/bin/sh -c "docker run --name kubelet --privileged --net=host --pid=host \
+        -v /:/rootfs:ro \
+        -v /sys:/sys:ro \
+        -v /dev:/dev \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /etc/resolv.conf:/etc/resolv.conf:ro \
+        -v /var/lib/cni:/var/lib/cni:rw \
+        -v /var/run/calico:/var/run/calico:rw \
+        -v /var/lib/calico:/var/lib/calico:rw \
+        -v /var/log:/var/log:rw \
+        -v /opt/cni/bin:/opt/cni/bin:rw \
+        -v /etc/kubernetes:/etc/kubernetes:rw \
+        -v /var/lib/kubelet:/var/lib/kubelet:shared \
+        -v /var/lib/docker:/var/lib/docker:rshared \
+        {{- if gt (len .Kubelet.Mounts) 0 }}
+          {{- range .Kubelet.Mounts }}
+        {{ .MountDockerRW }} \
+          {{- end }}
+        {{- end }}
+        {{ .HyperkubeImage.RepoWithTag }} /kubelet \
+        {{- if checkVersion ">= 1.14" .K8sVer }}
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- end }}
         {{ if .Kubelet.Kubeconfig -}}
@@ -399,8 +398,8 @@ coreos:
         {{- range $f := .Kubelet.Flags}}
         --{{$f.Name}}={{$f.Value}} \
         {{- end }}
-        $KUBELET_OPTS \
-        "
+        $KUBELET_OPTS"
+        ExecStop=/usr/bin/docker rm -f kubelet
         Restart=always
         RestartSec=10
 

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2281,7 +2281,6 @@ write_files:
   - path: /srv/kubernetes/manifests/canal.yaml
     content: |
       # Based on https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/canal/canal.yaml
-
       # This ConfigMap can be used to configure a self-hosted Canal installation.
       kind: ConfigMap
       apiVersion: v1

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1281,1002 +1281,1000 @@ write_files:
 
   - path: /srv/kubernetes/manifests/calico.yaml
     content: |
-    # Pulled and modified from: https://docs.projectcalico.org/v3.13/manifests/calico-typha.yaml
+      # Pulled and modified from: https://docs.projectcalico.org/v3.13/manifests/calico-typha.yaml
+      # Source: calico/templates/calico-config.yaml
+      # This ConfigMap is used to configure a self-hosted Calico installation.
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: calico-config
+        namespace: kube-system
+        labels:
+          role.kubernetes.io/networking: "1"
+      data:
+        # You must set a non-zero value for Typha replicas below.
+        typha_service_name: "{{- if .Kubernetes.Networking.SelfHosting.Typha }}calico-typha{{- else -}}none{{- end -}}"
+        
+        # Configure the backend to use.
+        calico_backend: "bird"
 
-    ---
-    # Source: calico/templates/calico-config.yaml
-    # This ConfigMap is used to configure a self-hosted Calico installation.
-    kind: ConfigMap
-    apiVersion: v1
-    metadata:
-      name: calico-config
-      namespace: kube-system
-      labels:
-        role.kubernetes.io/networking: "1"
-    data:
-      # You must set a non-zero value for Typha replicas below.
-      typha_service_name: "{{- if .Kubernetes.Networking.SelfHosting.Typha }}calico-typha{{- else -}}none{{- end -}}"
-      
-      # Configure the backend to use.
-      calico_backend: "bird"
+        # Configure the MTU to use
+        veth_mtu: "1440"
 
-      # Configure the MTU to use
-      veth_mtu: "1440"
-
-      # The CNI network configuration to install on each node.  The special
-      # values in this config will be automatically populated.
-      cni_network_config: |-
-        {
-          "name": "k8s-pod-network",
-          "cniVersion": "0.3.1",
-          "plugins": [
-            {
-              "type": "calico",
-              "log_level": "info",
-              "datastore_type": "kubernetes",
-              "nodename": "__KUBERNETES_NODE_NAME__",
-              "mtu": __CNI_MTU__,
-              "ipam": {
-                  "type": "calico-ipam"
+        # The CNI network configuration to install on each node.  The special
+        # values in this config will be automatically populated.
+        cni_network_config: |-
+          {
+            "name": "k8s-pod-network",
+            "cniVersion": "0.3.1",
+            "plugins": [
+              {
+                "type": "calico",
+                "log_level": "info",
+                "datastore_type": "kubernetes",
+                "nodename": "__KUBERNETES_NODE_NAME__",
+                "mtu": __CNI_MTU__,
+                "ipam": {
+                    "type": "calico-ipam"
+                },
+                "policy": {
+                    "type": "k8s",
+                    "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+                },
+                "kubernetes": {
+                    "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+                    "kubeconfig": "__KUBECONFIG_FILEPATH__"
+                }
               },
-              "policy": {
-                  "type": "k8s",
-                  "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+              {
+                "type": "portmap",
+                "snat": true,
+                "capabilities": {"portMappings": true}
               },
-              "kubernetes": {
-                  "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-                  "kubeconfig": "__KUBECONFIG_FILEPATH__"
+              {
+                "type": "bandwidth",
+                "capabilities": {"bandwidth": true}
               }
-            },
-            {
-              "type": "portmap",
-              "snat": true,
-              "capabilities": {"portMappings": true}
-            },
-            {
-              "type": "bandwidth",
-              "capabilities": {"bandwidth": true}
-            }
-          ]
-        }
+            ]
+          }
 
-    ---
-    # Source: calico/templates/kdd-crds.yaml
+      ---
+      # Source: calico/templates/kdd-crds.yaml
 
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: bgpconfigurations.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: BGPConfiguration
-        plural: bgpconfigurations
-        singular: bgpconfiguration
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: bgpconfigurations.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: BGPConfiguration
+          plural: bgpconfigurations
+          singular: bgpconfiguration
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: bgppeers.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: BGPPeer
-        plural: bgppeers
-        singular: bgppeer
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: bgppeers.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: BGPPeer
+          plural: bgppeers
+          singular: bgppeer
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: blockaffinities.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: BlockAffinity
-        plural: blockaffinities
-        singular: blockaffinity
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: blockaffinities.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: BlockAffinity
+          plural: blockaffinities
+          singular: blockaffinity
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: clusterinformations.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: ClusterInformation
-        plural: clusterinformations
-        singular: clusterinformation
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: clusterinformations.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: ClusterInformation
+          plural: clusterinformations
+          singular: clusterinformation
 
-    ---
+      ---
 
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: felixconfigurations.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: FelixConfiguration
-        plural: felixconfigurations
-        singular: felixconfiguration
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: felixconfigurations.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: FelixConfiguration
+          plural: felixconfigurations
+          singular: felixconfiguration
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: globalnetworkpolicies.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: GlobalNetworkPolicy
-        plural: globalnetworkpolicies
-        singular: globalnetworkpolicy
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: globalnetworkpolicies.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: GlobalNetworkPolicy
+          plural: globalnetworkpolicies
+          singular: globalnetworkpolicy
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: globalnetworksets.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: GlobalNetworkSet
-        plural: globalnetworksets
-        singular: globalnetworkset
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: globalnetworksets.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: GlobalNetworkSet
+          plural: globalnetworksets
+          singular: globalnetworkset
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: hostendpoints.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: HostEndpoint
-        plural: hostendpoints
-        singular: hostendpoint
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: hostendpoints.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: HostEndpoint
+          plural: hostendpoints
+          singular: hostendpoint
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: ipamblocks.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: IPAMBlock
-        plural: ipamblocks
-        singular: ipamblock
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: ipamblocks.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: IPAMBlock
+          plural: ipamblocks
+          singular: ipamblock
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: ipamconfigs.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: IPAMConfig
-        plural: ipamconfigs
-        singular: ipamconfig
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: ipamconfigs.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: IPAMConfig
+          plural: ipamconfigs
+          singular: ipamconfig
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: ipamhandles.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: IPAMHandle
-        plural: ipamhandles
-        singular: ipamhandle
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: ipamhandles.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: IPAMHandle
+          plural: ipamhandles
+          singular: ipamhandle
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: ippools.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Cluster
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: IPPool
-        plural: ippools
-        singular: ippool
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: ippools.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Cluster
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: IPPool
+          plural: ippools
+          singular: ippool
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: networkpolicies.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Namespaced
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: NetworkPolicy
-        plural: networkpolicies
-        singular: networkpolicy
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: networkpolicies.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Namespaced
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: NetworkPolicy
+          plural: networkpolicies
+          singular: networkpolicy
 
-    ---
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      name: networksets.crd.projectcalico.org
-      labels:
-        role.kubernetes.io/networking: "1"
-    spec:
-      scope: Namespaced
-      group: crd.projectcalico.org
-      version: v1
-      names:
-        kind: NetworkSet
-        plural: networksets
-        singular: networkset
+      ---
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: networksets.crd.projectcalico.org
+        labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        scope: Namespaced
+        group: crd.projectcalico.org
+        version: v1
+        names:
+          kind: NetworkSet
+          plural: networksets
+          singular: networkset
 
-    ---
-    # Source: calico/templates/rbac.yaml
+      ---
+      # Source: calico/templates/rbac.yaml
 
-    # Include a clusterrole for the kube-controllers component,
-    # and bind it to the calico-kube-controllers serviceaccount.
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: calico-kube-controllers
-      labels:
-        role.kubernetes.io/networking: "1"
-    rules:
-      # Nodes are watched to monitor for deletions.
-      - apiGroups: [""]
-        resources:
-          - nodes
-        verbs:
-          - watch
-          - list
-          - get
-      # Pods are queried to check for existence.
-      - apiGroups: [""]
-        resources:
-          - pods
-        verbs:
-          - get
-      # IPAM resources are manipulated when nodes are deleted.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - ippools
-        verbs:
-          - list
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - blockaffinities
-          - ipamblocks
-          - ipamhandles
-        verbs:
-          - get
-          - list
-          - create
-          - update
-          - delete
-      # Needs access to update clusterinformations.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - clusterinformations
-        verbs:
-          - get
-          - create
-          - update
-    ---
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: calico-kube-controllers
-      labels:
-        role.kubernetes.io/networking: "1"
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
+      # Include a clusterrole for the kube-controllers component,
+      # and bind it to the calico-kube-controllers serviceaccount.
       kind: ClusterRole
-      name: calico-kube-controllers
-    subjects:
-    - kind: ServiceAccount
-      name: calico-kube-controllers
-      namespace: kube-system
-    ---
-    # Include a clusterrole for the calico-node DaemonSet,
-    # and bind it to the calico-node serviceaccount.
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1
-    metadata:
-      name: calico-node
-      labels:
-        role.kubernetes.io/networking: "1"
-    rules:
-      # The CNI plugin needs to get pods, nodes, and namespaces.
-      - apiGroups: [""]
-        resources:
-          - pods
-          - nodes
-          - namespaces
-        verbs:
-          - get
-      - apiGroups: [""]
-        resources:
-          - endpoints
-          - services
-        verbs:
-          # Used to discover service IPs for advertisement.
-          - watch
-          - list
-          # Used to discover Typhas.
-          - get
-      # Pod CIDR auto-detection on kubeadm needs access to config maps.
-      - apiGroups: [""]
-        resources:
-          - configmaps
-        verbs:
-          - get
-      - apiGroups: [""]
-        resources:
-          - nodes/status
-        verbs:
-          # Needed for clearing NodeNetworkUnavailable flag.
-          - patch
-          # Calico stores some configuration information in node annotations.
-          - update
-      # Watch for changes to Kubernetes NetworkPolicies.
-      - apiGroups: ["networking.k8s.io"]
-        resources:
-          - networkpolicies
-        verbs:
-          - watch
-          - list
-      # Used by Calico for policy information.
-      - apiGroups: [""]
-        resources:
-          - pods
-          - namespaces
-          - serviceaccounts
-        verbs:
-          - list
-          - watch
-      # The CNI plugin patches pods/status.
-      - apiGroups: [""]
-        resources:
-          - pods/status
-        verbs:
-          - patch
-      # Calico monitors various CRDs for config.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - globalfelixconfigs
-          - felixconfigurations
-          - bgppeers
-          - globalbgpconfigs
-          - bgpconfigurations
-          - ippools
-          - ipamblocks
-          - globalnetworkpolicies
-          - globalnetworksets
-          - networkpolicies
-          - networksets
-          - clusterinformations
-          - hostendpoints
-          - blockaffinities
-        verbs:
-          - get
-          - list
-          - watch
-      # Calico must create and update some CRDs on startup.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - ippools
-          - felixconfigurations
-          - clusterinformations
-        verbs:
-          - create
-          - update
-      # Calico stores some configuration information on the node.
-      - apiGroups: [""]
-        resources:
-          - nodes
-        verbs:
-          - get
-          - list
-          - watch
-      # These permissions are only required for upgrade from v2.6, and can
-      # be removed after upgrade or on fresh installations.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - bgpconfigurations
-          - bgppeers
-        verbs:
-          - create
-          - update
-      # These permissions are required for Calico CNI to perform IPAM allocations.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - blockaffinities
-          - ipamblocks
-          - ipamhandles
-        verbs:
-          - get
-          - list
-          - create
-          - update
-          - delete
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - ipamconfigs
-        verbs:
-          - get
-      # Block affinities must also be watchable by confd for route aggregation.
-      - apiGroups: ["crd.projectcalico.org"]
-        resources:
-          - blockaffinities
-        verbs:
-          - watch
-      # The Calico IPAM migration needs to get daemonsets. These permissions can be
-      # removed if not upgrading from an installation using host-local IPAM.
-      - apiGroups: ["apps"]
-        resources:
-          - daemonsets
-        verbs:
-          - get
-
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: calico-node
-      labels:
-        role.kubernetes.io/networking: "1"
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: calico-kube-controllers
+        labels:
+          role.kubernetes.io/networking: "1"
+      rules:
+        # Nodes are watched to monitor for deletions.
+        - apiGroups: [""]
+          resources:
+            - nodes
+          verbs:
+            - watch
+            - list
+            - get
+        # Pods are queried to check for existence.
+        - apiGroups: [""]
+          resources:
+            - pods
+          verbs:
+            - get
+        # IPAM resources are manipulated when nodes are deleted.
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - ippools
+          verbs:
+            - list
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - blockaffinities
+            - ipamblocks
+            - ipamhandles
+          verbs:
+            - get
+            - list
+            - create
+            - update
+            - delete
+        # Needs access to update clusterinformations.
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - clusterinformations
+          verbs:
+            - get
+            - create
+            - update
+      ---
+      kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: calico-kube-controllers
+        labels:
+          role.kubernetes.io/networking: "1"
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: calico-kube-controllers
+      subjects:
+      - kind: ServiceAccount
+        name: calico-kube-controllers
+        namespace: kube-system
+      ---
+      # Include a clusterrole for the calico-node DaemonSet,
+      # and bind it to the calico-node serviceaccount.
       kind: ClusterRole
-      name: calico-node
-    subjects:
-    - kind: ServiceAccount
-      name: calico-node
-      namespace: kube-system
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: calico-node
+        labels:
+          role.kubernetes.io/networking: "1"
+      rules:
+        # The CNI plugin needs to get pods, nodes, and namespaces.
+        - apiGroups: [""]
+          resources:
+            - pods
+            - nodes
+            - namespaces
+          verbs:
+            - get
+        - apiGroups: [""]
+          resources:
+            - endpoints
+            - services
+          verbs:
+            # Used to discover service IPs for advertisement.
+            - watch
+            - list
+            # Used to discover Typhas.
+            - get
+        # Pod CIDR auto-detection on kubeadm needs access to config maps.
+        - apiGroups: [""]
+          resources:
+            - configmaps
+          verbs:
+            - get
+        - apiGroups: [""]
+          resources:
+            - nodes/status
+          verbs:
+            # Needed for clearing NodeNetworkUnavailable flag.
+            - patch
+            # Calico stores some configuration information in node annotations.
+            - update
+        # Watch for changes to Kubernetes NetworkPolicies.
+        - apiGroups: ["networking.k8s.io"]
+          resources:
+            - networkpolicies
+          verbs:
+            - watch
+            - list
+        # Used by Calico for policy information.
+        - apiGroups: [""]
+          resources:
+            - pods
+            - namespaces
+            - serviceaccounts
+          verbs:
+            - list
+            - watch
+        # The CNI plugin patches pods/status.
+        - apiGroups: [""]
+          resources:
+            - pods/status
+          verbs:
+            - patch
+        # Calico monitors various CRDs for config.
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - globalfelixconfigs
+            - felixconfigurations
+            - bgppeers
+            - globalbgpconfigs
+            - bgpconfigurations
+            - ippools
+            - ipamblocks
+            - globalnetworkpolicies
+            - globalnetworksets
+            - networkpolicies
+            - networksets
+            - clusterinformations
+            - hostendpoints
+            - blockaffinities
+          verbs:
+            - get
+            - list
+            - watch
+        # Calico must create and update some CRDs on startup.
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - ippools
+            - felixconfigurations
+            - clusterinformations
+          verbs:
+            - create
+            - update
+        # Calico stores some configuration information on the node.
+        - apiGroups: [""]
+          resources:
+            - nodes
+          verbs:
+            - get
+            - list
+            - watch
+        # These permissions are only required for upgrade from v2.6, and can
+        # be removed after upgrade or on fresh installations.
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - bgpconfigurations
+            - bgppeers
+          verbs:
+            - create
+            - update
+        # These permissions are required for Calico CNI to perform IPAM allocations.
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - blockaffinities
+            - ipamblocks
+            - ipamhandles
+          verbs:
+            - get
+            - list
+            - create
+            - update
+            - delete
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - ipamconfigs
+          verbs:
+            - get
+        # Block affinities must also be watchable by confd for route aggregation.
+        - apiGroups: ["crd.projectcalico.org"]
+          resources:
+            - blockaffinities
+          verbs:
+            - watch
+        # The Calico IPAM migration needs to get daemonsets. These permissions can be
+        # removed if not upgrading from an installation using host-local IPAM.
+        - apiGroups: ["apps"]
+          resources:
+            - daemonsets
+          verbs:
+            - get
 
-    {{ if .Kubernetes.Networking.SelfHosting.Typha -}}
-    ---
-    # Source: calico/templates/calico-typha.yaml
-    # This manifest creates a Service, which will be backed by Calico's Typha daemon.
-    # Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: calico-node
+        labels:
+          role.kubernetes.io/networking: "1"
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: calico-node
+      subjects:
+      - kind: ServiceAccount
+        name: calico-node
+        namespace: kube-system
 
-    apiVersion: v1
-    kind: Service
-    metadata:
-      name: calico-typha
-      namespace: kube-system
-      labels:
-        k8s-app: calico-typha
-        role.kubernetes.io/networking: "1"
-    spec:
-      ports:
-        - port: 5473
-          protocol: TCP
-          targetPort: calico-typha
-          name: calico-typha
-      selector:
-        k8s-app: calico-typha
+      {{ if .Kubernetes.Networking.SelfHosting.Typha -}}
+      ---
+      # Source: calico/templates/calico-typha.yaml
+      # This manifest creates a Service, which will be backed by Calico's Typha daemon.
+      # Typha sits in between Felix and the API server, reducing Calico's load on the API server.
 
-    ---
-
-    # This manifest creates a Deployment of Typha to back the above service.
-
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: calico-typha
-      namespace: kube-system
-      labels:
-        k8s-app: calico-typha
-        role.kubernetes.io/networking: "1"
-    spec:
-      # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
-      # typha_service_name variable in the calico-config ConfigMap above.
-      #
-      # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
-      # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
-      # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
-      replicas: 3
-      revisionHistoryLimit: 2
-      selector:
-        matchLabels:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: calico-typha
+        namespace: kube-system
+        labels:
           k8s-app: calico-typha
-      strategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 1
-      template:
-        metadata:
-          labels:
-            k8s-app: calico-typha
-            role.kubernetes.io/networking: "1"
-          annotations:
-            cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
-        spec:
-          nodeSelector:
-            kubernetes.io/os: linux
-            kubernetes.io/role: master
-          hostNetwork: true
-          tolerations:
-            # Mark the pod as a critical add-on for rescheduling.
-            - key: CriticalAddonsOnly
-              operator: Exists
-            - key: "node-role.kubernetes.io/master"
-              effect: NoSchedule
-          # Since Calico can't network a pod until Typha is up, we need to run Typha itself
-          # as a host-networked pod.
-          serviceAccountName: calico-node
-          priorityClassName: system-cluster-critical
-          # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
-          securityContext:
-            fsGroup: 65534
-          containers:
-          - image: calico/typha:v3.13.3
+          role.kubernetes.io/networking: "1"
+      spec:
+        ports:
+          - port: 5473
+            protocol: TCP
+            targetPort: calico-typha
             name: calico-typha
-            ports:
-            - containerPort: 5473
-              name: calico-typha
-              protocol: TCP
-            env:
-              # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
-              - name: TYPHA_LOGSEVERITYSCREEN
-                value: "info"
-              # Disable logging to file and syslog since those don't make sense in Kubernetes.
-              - name: TYPHA_LOGFILEPATH
-                value: "none"
-              - name: TYPHA_LOGSEVERITYSYS
-                value: "none"
-              # Monitor the Kubernetes API to find the number of running instances and rebalance
-              # connections.
-              - name: TYPHA_CONNECTIONREBALANCINGMODE
-                value: "kubernetes"
-              - name: TYPHA_DATASTORETYPE
-                value: "kubernetes"
-              - name: TYPHA_HEALTHENABLED
-                value: "true"
-            livenessProbe:
-              httpGet:
-                path: /liveness
-                port: 9098
-                host: localhost
-              periodSeconds: 30
-              initialDelaySeconds: 30
-            securityContext:
-              runAsNonRoot: true
-              allowPrivilegeEscalation: false
-            readinessProbe:
-              httpGet:
-                path: /readiness
-                port: 9098
-                host: localhost
-              periodSeconds: 10
-
-    ---
-
-    # This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
-
-    apiVersion: policy/v1beta1
-    kind: PodDisruptionBudget
-    metadata:
-      name: calico-typha
-      namespace: kube-system
-      labels:
-        k8s-app: calico-typha
-        role.kubernetes.io/networking: "1"
-    spec:
-      maxUnavailable: 1
-      selector:
-        matchLabels:
+        selector:
           k8s-app: calico-typha
-    {{- end }}
 
-    ---
-    # Source: calico/templates/calico-node.yaml
-    # This manifest installs the calico-node container, as well
-    # as the CNI plugins and network config on
-    # each master and worker node in a Kubernetes cluster.
-    kind: DaemonSet
-    apiVersion: apps/v1
-    metadata:
-      name: calico-node
-      namespace: kube-system
-      labels:
-        k8s-app: calico-node
-        role.kubernetes.io/networking: "1"
-    spec:
-      selector:
-        matchLabels:
-          k8s-app: calico-node
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 1
-      template:
-        metadata:
-          labels:
-            k8s-app: calico-node
-            role.kubernetes.io/networking: "1"
-        spec:
-          nodeSelector:
-            kubernetes.io/os: linux
-          hostNetwork: true
-          tolerations:
-            # Make sure calico-node gets scheduled on all nodes.
-            - effect: NoSchedule
-              operator: Exists
-            # Mark the pod as a critical add-on for rescheduling.
-            - key: CriticalAddonsOnly
-              operator: Exists
-            - effect: NoExecute
-              operator: Exists
-          serviceAccountName: calico-node
-          # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
-          # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
-          terminationGracePeriodSeconds: 0
-          priorityClassName: system-node-critical
-          initContainers:
-            # This container performs upgrade from host-local IPAM to calico-ipam.
-            # It can be deleted if this is a fresh installation, or if you have already
-            # upgraded to use calico-ipam.
-            - name: upgrade-ipam
-              image: calico/cni:v3.13.3
-              command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+      ---
+
+      # This manifest creates a Deployment of Typha to back the above service.
+
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: calico-typha
+        namespace: kube-system
+        labels:
+          k8s-app: calico-typha
+          role.kubernetes.io/networking: "1"
+      spec:
+        # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
+        # typha_service_name variable in the calico-config ConfigMap above.
+        #
+        # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
+        # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
+        # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
+        replicas: 3
+        revisionHistoryLimit: 2
+        selector:
+          matchLabels:
+            k8s-app: calico-typha
+        strategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 1
+        template:
+          metadata:
+            labels:
+              k8s-app: calico-typha
+              role.kubernetes.io/networking: "1"
+            annotations:
+              cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
+          spec:
+            nodeSelector:
+              kubernetes.io/os: linux
+              kubernetes.io/role: master
+            hostNetwork: true
+            tolerations:
+              # Mark the pod as a critical add-on for rescheduling.
+              - key: CriticalAddonsOnly
+                operator: Exists
+              - key: "node-role.kubernetes.io/master"
+                effect: NoSchedule
+            # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+            # as a host-networked pod.
+            serviceAccountName: calico-node
+            priorityClassName: system-cluster-critical
+            # fsGroup allows using projected serviceaccount tokens as described here kubernetes/kubernetes#82573
+            securityContext:
+              fsGroup: 65534
+            containers:
+            - image: calico/typha:v3.13.3
+              name: calico-typha
+              ports:
+              - containerPort: 5473
+                name: calico-typha
+                protocol: TCP
               env:
-                - name: KUBERNETES_NODE_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-                - name: CALICO_NETWORKING_BACKEND
-                  valueFrom:
-                    configMapKeyRef:
-                      name: calico-config
-                      key: calico_backend
-              volumeMounts:
-                - mountPath: /var/lib/cni/networks
-                  name: host-local-net-dir
-                - mountPath: /host/opt/cni/bin
-                  name: cni-bin-dir
-              securityContext:
-                privileged: true
-            # This container installs the CNI binaries
-            # and CNI network config file on each node.
-            - name: install-cni
-              image: calico/cni:v3.13.3
-              command: ["/install-cni.sh"]
-              env:
-                - name: CNI_NET_DIR
-                  value: "/etc/kubernetes/cni/net.d"
-                # Name of the CNI config file to create.
-                - name: CNI_CONF_NAME
-                  value: "10-calico.conflist"
-                # The CNI network config to install on each node.
-                - name: CNI_NETWORK_CONFIG
-                  valueFrom:
-                    configMapKeyRef:
-                      name: calico-config
-                      key: cni_network_config
-                # Set the hostname based on the k8s node name.
-                - name: KUBERNETES_NODE_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-                # CNI MTU Config variable
-                - name: CNI_MTU
-                  valueFrom:
-                    configMapKeyRef:
-                      name: calico-config
-                      key: veth_mtu
-                # Prevents the container from sleeping forever.
-                - name: SLEEP
-                  value: "false"
-              volumeMounts:
-                - mountPath: /host/opt/cni/bin
-                  name: cni-bin-dir
-                - mountPath: /host/etc/cni/net.d
-                  name: cni-net-dir
-              securityContext:
-                privileged: true
-            # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
-            # to communicate with Felix over the Policy Sync API.
-            - name: flexvol-driver
-              image: calico/pod2daemon-flexvol:v3.13.3
-              volumeMounts:
-              - name: flexvol-driver-host
-                mountPath: /host/driver
-              securityContext:
-                privileged: true
-          containers:
-            # Runs calico-node container on each Kubernetes node.  This
-            # container programs network policy and routes on each
-            # host.
-            - name: calico-node
-              image: calico/node:v3.13.3
-              env:
-                # Use Kubernetes API as the backing datastore.
-                - name: DATASTORE_TYPE
-                  value: "kubernetes"
-                {{- if .Kubernetes.Networking.SelfHosting.Typha }}
-                # Typha support: controlled by the ConfigMap.
-                - name: FELIX_TYPHAK8SSERVICENAME
-                  valueFrom:
-                    configMapKeyRef:
-                      name: calico-config
-                      key: typha_service_name
-                {{- end }}
-                # Wait for the datastore.
-                - name: WAIT_FOR_DATASTORE
-                  value: "true"
-                # Set based on the k8s node name.
-                - name: NODENAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: spec.nodeName
-                # Choose the backend to use.
-                - name: CALICO_NETWORKING_BACKEND
-                  valueFrom:
-                    configMapKeyRef:
-                      name: calico-config
-                      key: calico_backend
-                # Cluster type to identify the deployment type
-                - name: CLUSTER_TYPE
-                  value: "kops,bgp"
-                # Auto-detect the BGP IP address.
-                - name: IP
-                  value: "autodetect"
-                - name: IP_AUTODETECTION_METHOD
-                  value: "first-found"
-                - name: IP6_AUTODETECTION_METHOD
-                  value: "first-found"
-                # Enable IPIP
-                - name: CALICO_IPV4POOL_IPIP
-                  value: "Always"
-                # Set MTU for tunnel device used if ipip is enabled
-                - name: FELIX_IPINIPMTU
-                  valueFrom:
-                    configMapKeyRef:
-                      name: calico-config
-                      key: veth_mtu
-                # The default IPv4 pool to create on startup if none exists. Pod IPs will be
-                # chosen from this range. Changing this value after installation will have
-                # no effect. This should fall within `--cluster-cidr`.
-                - name: CALICO_IPV4POOL_CIDR
-                  value: "{{ .PodCIDR }}"
-                # Disable file logging so `kubectl logs` works.
-                - name: CALICO_DISABLE_FILE_LOGGING
-                  value: "true"
-                # Set Felix endpoint to host default action to ACCEPT.
-                - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
-                  value: "ACCEPT"
-                # Disable IPv6 on Kubernetes.
-                - name: FELIX_IPV6SUPPORT
-                  value: "false"
-                # Set Felix logging to "info"
-                - name: FELIX_LOGSEVERITYSCREEN
+                # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
+                - name: TYPHA_LOGSEVERITYSCREEN
                   value: "info"
-                - name: FELIX_HEALTHENABLED
+                # Disable logging to file and syslog since those don't make sense in Kubernetes.
+                - name: TYPHA_LOGFILEPATH
+                  value: "none"
+                - name: TYPHA_LOGSEVERITYSYS
+                  value: "none"
+                # Monitor the Kubernetes API to find the number of running instances and rebalance
+                # connections.
+                - name: TYPHA_CONNECTIONREBALANCINGMODE
+                  value: "kubernetes"
+                - name: TYPHA_DATASTORETYPE
+                  value: "kubernetes"
+                - name: TYPHA_HEALTHENABLED
                   value: "true"
-
-                # kops additions
-                # Set Felix iptables binary variant, Legacy or NFT
-                - name: FELIX_IPTABLESBACKEND
-                  value: "Auto"
-                # Set to enable the experimental Prometheus metrics server
-                - name: FELIX_PROMETHEUSMETRICSENABLED
-                  value: "false"
-                # TCP port that the Prometheus metrics server should bind to
-                - name: FELIX_PROMETHEUSMETRICSPORT
-                  value: "9091"
-                # Enable Prometheus Go runtime metrics collection
-                - name: FELIX_PROMETHEUSGOMETRICSENABLED
-                  value: "true"
-                # Enable Prometheus process metrics collection
-                - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
-                  value: "true"
-              securityContext:
-                privileged: true
-              resources:
-                requests:
-                  cpu: 100m
               livenessProbe:
-                exec:
-                  command:
-                  - /bin/calico-node
-                  - -felix-live
-                  - -bird-live
-                periodSeconds: 10
-                initialDelaySeconds: 10
-                failureThreshold: 6
+                httpGet:
+                  path: /liveness
+                  port: 9098
+                  host: localhost
+                periodSeconds: 30
+                initialDelaySeconds: 30
+              securityContext:
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
               readinessProbe:
-                exec:
-                  command:
-                  - /bin/calico-node
-                  - -felix-ready
-                  - -bird-ready
+                httpGet:
+                  path: /readiness
+                  port: 9098
+                  host: localhost
                 periodSeconds: 10
-              volumeMounts:
-                - mountPath: /lib/modules
-                  name: lib-modules
-                  readOnly: true
-                - mountPath: /run/xtables.lock
-                  name: xtables-lock
-                  readOnly: false
-                - mountPath: /var/run/calico
-                  name: var-run-calico
-                  readOnly: false
-                - mountPath: /var/lib/calico
-                  name: var-lib-calico
-                  readOnly: false
-                - name: policysync
-                  mountPath: /var/run/nodeagent
-          volumes:
-            # Used by calico-node.
-            - name: lib-modules
-              hostPath:
-                path: /lib/modules
-            - name: var-run-calico
-              hostPath:
-                path: /var/run/calico
-            - name: var-lib-calico
-              hostPath:
-                path: /var/lib/calico
-            - name: xtables-lock
-              hostPath:
-                path: /run/xtables.lock
-                type: FileOrCreate
-            # Used to install CNI.
-            - name: cni-bin-dir
-              hostPath:
-                path: /opt/cni/bin
-            - name: cni-net-dir
-              hostPath:
-                path: /etc/kubernetes/cni/net.d
-            # Mount in the directory for host-local IPAM allocations. This is
-            # used when upgrading from host-local to calico-ipam, and can be removed
-            # if not using the upgrade-ipam init container.
-            - name: host-local-net-dir
-              hostPath:
-                path: /var/lib/cni/networks
-            # Used to create per-pod Unix Domain Sockets
-            - name: policysync
-              hostPath:
-                type: DirectoryOrCreate
-                path: /var/run/nodeagent
-            # Used to install Flex Volume Driver
-            - name: flexvol-driver-host
-              hostPath:
-                type: DirectoryOrCreate
-                path: "/var/lib/kubelet/volumeplugins/nodeagent~uds"
-    ---
 
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: calico-node
-      namespace: kube-system
-      labels:
-        role.kubernetes.io/networking: "1"
+      ---
 
-    ---
-    # Source: calico/templates/calico-kube-controllers.yaml
+      # This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
 
-    # See https://github.com/projectcalico/kube-controllers
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: calico-kube-controllers
-      namespace: kube-system
-      labels:
-        k8s-app: calico-kube-controllers
-        role.kubernetes.io/networking: "1"
-    spec:
-      # The controllers can only have a single active instance.
-      replicas: 1
-      selector:
-        matchLabels:
+      apiVersion: policy/v1beta1
+      kind: PodDisruptionBudget
+      metadata:
+        name: calico-typha
+        namespace: kube-system
+        labels:
+          k8s-app: calico-typha
+          role.kubernetes.io/networking: "1"
+      spec:
+        maxUnavailable: 1
+        selector:
+          matchLabels:
+            k8s-app: calico-typha
+      {{- end }}
+
+      ---
+      # Source: calico/templates/calico-node.yaml
+      # This manifest installs the calico-node container, as well
+      # as the CNI plugins and network config on
+      # each master and worker node in a Kubernetes cluster.
+      kind: DaemonSet
+      apiVersion: apps/v1
+      metadata:
+        name: calico-node
+        namespace: kube-system
+        labels:
+          k8s-app: calico-node
+          role.kubernetes.io/networking: "1"
+      spec:
+        selector:
+          matchLabels:
+            k8s-app: calico-node
+        updateStrategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 1
+        template:
+          metadata:
+            labels:
+              k8s-app: calico-node
+              role.kubernetes.io/networking: "1"
+          spec:
+            nodeSelector:
+              kubernetes.io/os: linux
+            hostNetwork: true
+            tolerations:
+              # Make sure calico-node gets scheduled on all nodes.
+              - effect: NoSchedule
+                operator: Exists
+              # Mark the pod as a critical add-on for rescheduling.
+              - key: CriticalAddonsOnly
+                operator: Exists
+              - effect: NoExecute
+                operator: Exists
+            serviceAccountName: calico-node
+            # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+            # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+            terminationGracePeriodSeconds: 0
+            priorityClassName: system-node-critical
+            initContainers:
+              # This container performs upgrade from host-local IPAM to calico-ipam.
+              # It can be deleted if this is a fresh installation, or if you have already
+              # upgraded to use calico-ipam.
+              - name: upgrade-ipam
+                image: calico/cni:v3.13.3
+                command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+                env:
+                  - name: KUBERNETES_NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  - name: CALICO_NETWORKING_BACKEND
+                    valueFrom:
+                      configMapKeyRef:
+                        name: calico-config
+                        key: calico_backend
+                volumeMounts:
+                  - mountPath: /var/lib/cni/networks
+                    name: host-local-net-dir
+                  - mountPath: /host/opt/cni/bin
+                    name: cni-bin-dir
+                securityContext:
+                  privileged: true
+              # This container installs the CNI binaries
+              # and CNI network config file on each node.
+              - name: install-cni
+                image: calico/cni:v3.13.3
+                command: ["/install-cni.sh"]
+                env:
+                  - name: CNI_NET_DIR
+                    value: "/etc/kubernetes/cni/net.d"
+                  # Name of the CNI config file to create.
+                  - name: CNI_CONF_NAME
+                    value: "10-calico.conflist"
+                  # The CNI network config to install on each node.
+                  - name: CNI_NETWORK_CONFIG
+                    valueFrom:
+                      configMapKeyRef:
+                        name: calico-config
+                        key: cni_network_config
+                  # Set the hostname based on the k8s node name.
+                  - name: KUBERNETES_NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  # CNI MTU Config variable
+                  - name: CNI_MTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: calico-config
+                        key: veth_mtu
+                  # Prevents the container from sleeping forever.
+                  - name: SLEEP
+                    value: "false"
+                volumeMounts:
+                  - mountPath: /host/opt/cni/bin
+                    name: cni-bin-dir
+                  - mountPath: /host/etc/cni/net.d
+                    name: cni-net-dir
+                securityContext:
+                  privileged: true
+              # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
+              # to communicate with Felix over the Policy Sync API.
+              - name: flexvol-driver
+                image: calico/pod2daemon-flexvol:v3.13.3
+                volumeMounts:
+                - name: flexvol-driver-host
+                  mountPath: /host/driver
+                securityContext:
+                  privileged: true
+            containers:
+              # Runs calico-node container on each Kubernetes node.  This
+              # container programs network policy and routes on each
+              # host.
+              - name: calico-node
+                image: calico/node:v3.13.3
+                env:
+                  # Use Kubernetes API as the backing datastore.
+                  - name: DATASTORE_TYPE
+                    value: "kubernetes"
+                  {{- if .Kubernetes.Networking.SelfHosting.Typha }}
+                  # Typha support: controlled by the ConfigMap.
+                  - name: FELIX_TYPHAK8SSERVICENAME
+                    valueFrom:
+                      configMapKeyRef:
+                        name: calico-config
+                        key: typha_service_name
+                  {{- end }}
+                  # Wait for the datastore.
+                  - name: WAIT_FOR_DATASTORE
+                    value: "true"
+                  # Set based on the k8s node name.
+                  - name: NODENAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: spec.nodeName
+                  # Choose the backend to use.
+                  - name: CALICO_NETWORKING_BACKEND
+                    valueFrom:
+                      configMapKeyRef:
+                        name: calico-config
+                        key: calico_backend
+                  # Cluster type to identify the deployment type
+                  - name: CLUSTER_TYPE
+                    value: "kops,bgp"
+                  # Auto-detect the BGP IP address.
+                  - name: IP
+                    value: "autodetect"
+                  - name: IP_AUTODETECTION_METHOD
+                    value: "first-found"
+                  - name: IP6_AUTODETECTION_METHOD
+                    value: "first-found"
+                  # Enable IPIP
+                  - name: CALICO_IPV4POOL_IPIP
+                    value: "Always"
+                  # Set MTU for tunnel device used if ipip is enabled
+                  - name: FELIX_IPINIPMTU
+                    valueFrom:
+                      configMapKeyRef:
+                        name: calico-config
+                        key: veth_mtu
+                  # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+                  # chosen from this range. Changing this value after installation will have
+                  # no effect. This should fall within `--cluster-cidr`.
+                  - name: CALICO_IPV4POOL_CIDR
+                    value: "{{ .PodCIDR }}"
+                  # Disable file logging so `kubectl logs` works.
+                  - name: CALICO_DISABLE_FILE_LOGGING
+                    value: "true"
+                  # Set Felix endpoint to host default action to ACCEPT.
+                  - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+                    value: "ACCEPT"
+                  # Disable IPv6 on Kubernetes.
+                  - name: FELIX_IPV6SUPPORT
+                    value: "false"
+                  # Set Felix logging to "info"
+                  - name: FELIX_LOGSEVERITYSCREEN
+                    value: "info"
+                  - name: FELIX_HEALTHENABLED
+                    value: "true"
+
+                  # kops additions
+                  # Set Felix iptables binary variant, Legacy or NFT
+                  - name: FELIX_IPTABLESBACKEND
+                    value: "Auto"
+                  # Set to enable the experimental Prometheus metrics server
+                  - name: FELIX_PROMETHEUSMETRICSENABLED
+                    value: "false"
+                  # TCP port that the Prometheus metrics server should bind to
+                  - name: FELIX_PROMETHEUSMETRICSPORT
+                    value: "9091"
+                  # Enable Prometheus Go runtime metrics collection
+                  - name: FELIX_PROMETHEUSGOMETRICSENABLED
+                    value: "true"
+                  # Enable Prometheus process metrics collection
+                  - name: FELIX_PROMETHEUSPROCESSMETRICSENABLED
+                    value: "true"
+                securityContext:
+                  privileged: true
+                resources:
+                  requests:
+                    cpu: 100m
+                livenessProbe:
+                  exec:
+                    command:
+                    - /bin/calico-node
+                    - -felix-live
+                    - -bird-live
+                  periodSeconds: 10
+                  initialDelaySeconds: 10
+                  failureThreshold: 6
+                readinessProbe:
+                  exec:
+                    command:
+                    - /bin/calico-node
+                    - -felix-ready
+                    - -bird-ready
+                  periodSeconds: 10
+                volumeMounts:
+                  - mountPath: /lib/modules
+                    name: lib-modules
+                    readOnly: true
+                  - mountPath: /run/xtables.lock
+                    name: xtables-lock
+                    readOnly: false
+                  - mountPath: /var/run/calico
+                    name: var-run-calico
+                    readOnly: false
+                  - mountPath: /var/lib/calico
+                    name: var-lib-calico
+                    readOnly: false
+                  - name: policysync
+                    mountPath: /var/run/nodeagent
+            volumes:
+              # Used by calico-node.
+              - name: lib-modules
+                hostPath:
+                  path: /lib/modules
+              - name: var-run-calico
+                hostPath:
+                  path: /var/run/calico
+              - name: var-lib-calico
+                hostPath:
+                  path: /var/lib/calico
+              - name: xtables-lock
+                hostPath:
+                  path: /run/xtables.lock
+                  type: FileOrCreate
+              # Used to install CNI.
+              - name: cni-bin-dir
+                hostPath:
+                  path: /opt/cni/bin
+              - name: cni-net-dir
+                hostPath:
+                  path: /etc/kubernetes/cni/net.d
+              # Mount in the directory for host-local IPAM allocations. This is
+              # used when upgrading from host-local to calico-ipam, and can be removed
+              # if not using the upgrade-ipam init container.
+              - name: host-local-net-dir
+                hostPath:
+                  path: /var/lib/cni/networks
+              # Used to create per-pod Unix Domain Sockets
+              - name: policysync
+                hostPath:
+                  type: DirectoryOrCreate
+                  path: /var/run/nodeagent
+              # Used to install Flex Volume Driver
+              - name: flexvol-driver-host
+                hostPath:
+                  type: DirectoryOrCreate
+                  path: "/var/lib/kubelet/volumeplugins/nodeagent~uds"
+      ---
+
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: calico-node
+        namespace: kube-system
+        labels:
+          role.kubernetes.io/networking: "1"
+
+      ---
+      # Source: calico/templates/calico-kube-controllers.yaml
+
+      # See https://github.com/projectcalico/kube-controllers
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: calico-kube-controllers
+        namespace: kube-system
+        labels:
           k8s-app: calico-kube-controllers
-      strategy:
-        type: Recreate
-      template:
-        metadata:
-          name: calico-kube-controllers
-          namespace: kube-system
-          labels:
+          role.kubernetes.io/networking: "1"
+      spec:
+        # The controllers can only have a single active instance.
+        replicas: 1
+        selector:
+          matchLabels:
             k8s-app: calico-kube-controllers
-            role.kubernetes.io/networking: "1"
-          annotations:
-            scheduler.alpha.kubernetes.io/critical-pod: ''
-        spec:
-          nodeSelector:
-            kubernetes.io/os: linux
-          tolerations:
-            # Mark the pod as a critical add-on for rescheduling.
-            - key: CriticalAddonsOnly
-              operator: Exists
-            - key: node-role.kubernetes.io/master
-              effect: NoSchedule
-          serviceAccountName: calico-kube-controllers
-          priorityClassName: system-cluster-critical
-          containers:
-            - name: calico-kube-controllers
-              image: calico/kube-controllers:v3.13.3
-              env:
-                # Choose which controllers to run.
-                - name: ENABLED_CONTROLLERS
-                  value: node
-                - name: DATASTORE_TYPE
-                  value: kubernetes
-              readinessProbe:
-                exec:
-                  command:
-                  - /usr/bin/check-status
-                  - -r
+        strategy:
+          type: Recreate
+        template:
+          metadata:
+            name: calico-kube-controllers
+            namespace: kube-system
+            labels:
+              k8s-app: calico-kube-controllers
+              role.kubernetes.io/networking: "1"
+            annotations:
+              scheduler.alpha.kubernetes.io/critical-pod: ''
+          spec:
+            nodeSelector:
+              kubernetes.io/os: linux
+            tolerations:
+              # Mark the pod as a critical add-on for rescheduling.
+              - key: CriticalAddonsOnly
+                operator: Exists
+              - key: node-role.kubernetes.io/master
+                effect: NoSchedule
+            serviceAccountName: calico-kube-controllers
+            priorityClassName: system-cluster-critical
+            containers:
+              - name: calico-kube-controllers
+                image: calico/kube-controllers:v3.13.3
+                env:
+                  # Choose which controllers to run.
+                  - name: ENABLED_CONTROLLERS
+                    value: node
+                  - name: DATASTORE_TYPE
+                    value: kubernetes
+                readinessProbe:
+                  exec:
+                    command:
+                    - /usr/bin/check-status
+                    - -r
 
-    ---
+      ---
 
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: calico-kube-controllers
-      namespace: kube-system
-      labels:
-        role.kubernetes.io/networking: "1"
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: calico-kube-controllers
+        namespace: kube-system
+        labels:
+          role.kubernetes.io/networking: "1"
 
   - path: /srv/kubernetes/manifests/canal.yaml
     content: |

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -2181,7 +2181,9 @@ write_files:
                     command:
                     - /bin/calico-node
                     - -felix-live
+                    {{- if not .Kubernetes.Networking.SelfHosting.CalicoConfig.VxlanMode }}
                     - -bird-live
+                    {{- end }}
                   periodSeconds: 10
                   initialDelaySeconds: 10
                   failureThreshold: 6

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1849,10 +1849,14 @@ write_files:
               cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
           spec:
             hostNetwork: true
+            nodeSelector:
+              kubernetes.io/os: linux
             tolerations:
               # Mark the pod as a critical add-on for rescheduling.
               - key: CriticalAddonsOnly
                 operator: Exists
+              - key: node.kubernetes.io/master
+                effect: NoSchedule
             # Since Calico can't network a pod until Typha is up, we need to run Typha itself
             # as a host-networked pod.
             serviceAccountName: calico-node

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -358,7 +358,11 @@ coreos:
         {{- if .Taints }}
         --register-with-taints={{.Taints.String}} \
         {{- end }}
+        {{- if .Experimental.CloudControllerManager.Enabled }}
         --cloud-provider=external \
+        {{- else }}
+        --cloud-provider=aws \
+        {{- end }}
         --cert-dir=/etc/kubernetes/ssl \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- if .Kubelet.Kubeconfig }}
@@ -483,6 +487,23 @@ coreos:
         ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl  --insecure -s -m 20 -f https://127.0.0.1:10250/healthz >/dev/null ; then break ; fi;  done"
         ExecStart=/opt/bin/cfn-signal
 {{end}}
+
+    - name: kubernetes-io-node-label.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Label this kubernetes node with kubernetes.io labels.
+        Wants=kubelet.service
+        After=kubelet.service
+        Before=cfn-signal.service
+
+        [Service]
+        Type=oneshot
+        ExecStop=/bin/true
+        RemainAfterExit=true
+        ExecStart=/opt/bin/kubernetes-io-node-label
 
 {{if .Experimental.AwsNodeLabels.Enabled }}
     - name: kube-node-label.service
@@ -725,6 +746,31 @@ write_files:
 
       rkt rm --uuid-file=/var/run/coreos/set-aws-environment.uuid || :
 {{end}}
+
+  - path: /opt/bin/kubernetes-io-node-label
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash -e
+      set -ue
+
+       # FIXME: Remove dependency on the apiserver insecure port
+       until /usr/bin/curl -s -f http://127.0.0.1:8080/version; do echo waiting until apiserver starts; sleep 1; done
+
+       # FIXME: Remove dependency on the apiserver insecure port
+       /usr/bin/curl \
+         --retry 5 \
+         --request PATCH \
+         -H 'Content-Type: application/strategic-merge-patch+json' \
+         -d '{
+              "metadata": {
+                "labels": {
+                  "kubernetes.io/role": "node",
+                  "node-role.kubernetes.io/node": ""
+                 }
+              }
+            }' \
+         http://localhost:8080/api/v1/nodes/$(hostname)
 
   {{if .Experimental.AwsNodeLabels.Enabled -}}
   - path: /opt/bin/kube-node-label

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -315,6 +315,29 @@ coreos:
         [Service]
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/default/kubelet
+        Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
+        Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
+        Environment="RKT_RUN_ARGS={{.HyperkubeImage.Options}}\
+        --volume dns,kind=host,source=/etc/resolv.conf \
+        --mount volume=dns,target=/etc/resolv.conf \
+        {{ if eq .ContainerRuntime "rkt" -}}
+        --volume rkt,kind=host,source=/opt/bin/host-rkt \
+        --mount volume=rkt,target=/usr/bin/rkt \
+        --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
+        --mount volume=var-lib-rkt,target=/var/lib/rkt \
+        --volume stage,kind=host,source=/tmp \
+        --mount volume=stage,target=/tmp \
+        {{ end -}}
+        --volume var-lib-cni,kind=host,source=/var/lib/cni \
+        --mount volume=var-lib-cni,target=/var/lib/cni \
+        --volume var-run-calico,kind=host,source=/var/run/calico \
+        --mount volume=var-run-calico,target=/var/run/calico \
+        --volume var-lib-calico,kind=host,source=/var/lib/calico \
+        --mount volume=var-lib-calico,target=/var/lib/calico \
+        --volume var-log,kind=host,source=/var/log \
+        --mount volume=var-log,target=/var/log \
+        --volume cni-bin,kind=host,source=/opt/cni/bin \
+        --mount volume=cni-bin,target=/opt/cni/bin"
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
@@ -322,38 +345,10 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
-        ExecStartPre=/usr/bin/mkdir -p /var/lib/docker
-        ExecStartPre=/bin/bash -c "if ! grep -q "/var/lib/kubelet" /proc/mounts; then mount --bind /var/lib/kubelet /var/lib/kubelet && mount --make-shared /var/lib/kubelet; fi"
         ExecStartPre=/bin/sed -e "s/COREOS_PRIVATE_IPV4/${COREOS_PRIVATE_IPV4}/g" -i /etc/kubernetes/config/kubelet.yaml
-        ExecStartPre=-/bin/docker rm -f kubelet
-        ExecStart=/bin/sh -c "docker run --name kubelet --privileged --net=host --pid=host \
-        -v /:/rootfs:ro \
-        -v /sys:/sys:ro \
-        -v /dev:/dev \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -v /etc/resolv.conf:/etc/resolv.conf:ro \
-        -v /var/lib/cni:/var/lib/cni:rw \
-        -v /var/run/calico:/var/run/calico:rw \
-        -v /var/lib/calico:/var/lib/calico:rw \
-        -v /var/log:/var/log:rw \
-        -v /opt/cni/bin:/opt/cni/bin:rw \
-        -v /etc/kubernetes:/etc/kubernetes:rw \
-        -v /var/lib/kubelet:/var/lib/kubelet:rshared \
-        -v /var/lib/docker:/var/lib/docker:rshared \
-        {{ if eq .ContainerRuntime "rkt" -}}
-        -v /opt/bin/host-rkt:/opt/bin/host-rkt:rw \
-        -v /usr/bin/rkt:/usr/bin/rkt:ro \
-        -v /var/lib/rkt:/usr/lib/rkt:rw \
-        -v /tmp:/tmp:rw \
-        {{- end }}
-        {{- if gt (len .Kubelet.Mounts) 0 }}
-          {{- range .Kubelet.Mounts }}
-        {{ .MountDockerRW }} \
-          {{- end }}
-        {{- end }}
-        {{ .HyperkubeImage.RepoWithTag }} /kubelet \
+        ExecStart=/bin/sh -c "exec /usr/lib/coreos/kubelet-wrapper \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
+        {{/* Work-around until https://github.com/kubernetes/kubernetes/issues/43967 is fixed via https://github.com/kubernetes/kubernetes/pull/43995 */ -}}
         --cni-bin-dir=/opt/cni/bin \
         --network-plugin={{.K8sNetworkPlugin}} \
         --container-runtime={{.ContainerRuntime}} \
@@ -363,11 +358,7 @@ coreos:
         {{- if .Taints }}
         --register-with-taints={{.Taints.String}} \
         {{- end }}
-        {{- if .Experimental.CloudControllerManager.Enabled }}
         --cloud-provider=external \
-        {{- else }}
-        --cloud-provider=aws \
-        {{- end }}
         --cert-dir=/etc/kubernetes/ssl \
         --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig/worker-bootstrap.yaml \
         {{- if .Kubelet.Kubeconfig }}
@@ -387,7 +378,8 @@ coreos:
         {{- end }}
         $KUBELET_OPTS"
         Restart=always
-        RestartSec=10
+        RestartSec=10        
+
         [Install]
         WantedBy=multi-user.target
 

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -315,29 +315,6 @@ coreos:
         [Service]
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/default/kubelet
-        Environment=KUBELET_IMAGE_TAG={{.K8sVer}}
-        Environment=KUBELET_IMAGE_URL={{ .HyperkubeImage.RktRepoWithoutTag }}
-        Environment="RKT_RUN_ARGS={{.HyperkubeImage.Options}}\
-        --volume dns,kind=host,source=/etc/resolv.conf \
-        --mount volume=dns,target=/etc/resolv.conf \
-        {{ if eq .ContainerRuntime "rkt" -}}
-        --volume rkt,kind=host,source=/opt/bin/host-rkt \
-        --mount volume=rkt,target=/usr/bin/rkt \
-        --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
-        --mount volume=var-lib-rkt,target=/var/lib/rkt \
-        --volume stage,kind=host,source=/tmp \
-        --mount volume=stage,target=/tmp \
-        {{ end -}}
-        --volume var-lib-cni,kind=host,source=/var/lib/cni \
-        --mount volume=var-lib-cni,target=/var/lib/cni \
-        --volume var-run-calico,kind=host,source=/var/run/calico \
-        --mount volume=var-run-calico,target=/var/run/calico \
-        --volume var-lib-calico,kind=host,source=/var/lib/calico \
-        --mount volume=var-lib-calico,target=/var/lib/calico \
-        --volume var-log,kind=host,source=/var/log \
-        --mount volume=var-log,target=/var/log \
-        --volume cni-bin,kind=host,source=/opt/cni/bin \
-        --mount volume=cni-bin,target=/opt/cni/bin"
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
@@ -345,10 +322,38 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/usr/bin/mkdir -p /var/run/calico
         ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
+        ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet
+        ExecStartPre=/usr/bin/mkdir -p /var/lib/docker
+        ExecStartPre=/bin/bash -c "if ! grep -q "/var/lib/kubelet" /proc/mounts; then mount --bind /var/lib/kubelet /var/lib/kubelet && mount --make-shared /var/lib/kubelet; fi"
         ExecStartPre=/bin/sed -e "s/COREOS_PRIVATE_IPV4/${COREOS_PRIVATE_IPV4}/g" -i /etc/kubernetes/config/kubelet.yaml
-        ExecStart=/bin/sh -c "exec /usr/lib/coreos/kubelet-wrapper \
+        ExecStartPre=-/bin/docker rm -f kubelet
+        ExecStart=/bin/sh -c "docker run --name kubelet --privileged --net=host --pid=host \
+        -v /:/rootfs:ro \
+        -v /sys:/sys:ro \
+        -v /dev:/dev \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /etc/resolv.conf:/etc/resolv.conf:ro \
+        -v /var/lib/cni:/var/lib/cni:rw \
+        -v /var/run/calico:/var/run/calico:rw \
+        -v /var/lib/calico:/var/lib/calico:rw \
+        -v /var/log:/var/log:rw \
+        -v /opt/cni/bin:/opt/cni/bin:rw \
+        -v /etc/kubernetes:/etc/kubernetes:rw \
+        -v /var/lib/kubelet:/var/lib/kubelet:rshared \
+        -v /var/lib/docker:/var/lib/docker:rshared \
+        {{ if eq .ContainerRuntime "rkt" -}}
+        -v /opt/bin/host-rkt:/opt/bin/host-rkt:rw \
+        -v /usr/bin/rkt:/usr/bin/rkt:ro \
+        -v /var/lib/rkt:/usr/lib/rkt:rw \
+        -v /tmp:/tmp:rw \
+        {{- end }}
+        {{- if gt (len .Kubelet.Mounts) 0 }}
+          {{- range .Kubelet.Mounts }}
+        {{ .MountDockerRW }} \
+          {{- end }}
+        {{- end }}
+        {{ .HyperkubeImage.RepoWithTag }} /kubelet \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
-        {{/* Work-around until https://github.com/kubernetes/kubernetes/issues/43967 is fixed via https://github.com/kubernetes/kubernetes/pull/43995 */ -}}
         --cni-bin-dir=/opt/cni/bin \
         --network-plugin={{.K8sNetworkPlugin}} \
         --container-runtime={{.ContainerRuntime}} \
@@ -382,7 +387,7 @@ coreos:
         {{- end }}
         $KUBELET_OPTS"
         Restart=always
-        RestartSec=10        
+        RestartSec=10
 
         [Install]
         WantedBy=multi-user.target

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -303,6 +303,7 @@ coreos:
       command: start
       runtime: true
       content: |
+{{/* START of kubelet [Unit] */}}
         [Unit]
         Wants=rpc-statd.service
         Wants=decrypt-assets.service
@@ -311,7 +312,8 @@ coreos:
         Requires=nvidia-start.service
         After=nvidia-start.service
         {{- end }}
-
+{{/* END of kubelet [Unit] */}}
+{{/* START of kubelet [Service] */}}
         [Service]
         EnvironmentFile=/etc/environment
         EnvironmentFile=-/etc/default/kubelet
@@ -388,9 +390,11 @@ coreos:
         $KUBELET_OPTS"
         Restart=always
         RestartSec=10
-
+{{/* END of kubelet [Service] */}}
+{{/* START of kubelet [Install] */}}
         [Install]
         WantedBy=multi-user.target
+{{/* END of kubelet [Install] */}}
 
     - name: rpc-statd.service
       command: start

--- a/make/test
+++ b/make/test
@@ -19,7 +19,7 @@ default() {
 with-cover() {
   test -z "$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)"
   for d in $(go list ./... | grep -v '/vendor/' | grep -v '/hack'); do
-    go test -timeout 35m -json -v --race -coverprofile=profile.out -covermode=atomic $d | tparse
+    go test -timeout 45m -json -v --race -coverprofile=profile.out -covermode=atomic $d | tparse
     if [ -f profile.out ]; then
       cat profile.out >> coverage.txt
       rm profile.out

--- a/pkg/api/assets.go
+++ b/pkg/api/assets.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"fmt"
-	"github.com/kubernetes-incubator/kube-aws/fingerprint"
 	"strings"
+
+	"github.com/kubernetes-incubator/kube-aws/fingerprint"
 )
 
 type AssetID struct {
@@ -35,7 +36,7 @@ func (l AssetLocation) URL() (string, error) {
 	if (l == AssetLocation{}) {
 		return "", fmt.Errorf("[bug] Empty asset location can't have URL")
 	}
-	return fmt.Sprintf("%s/%s/%s", l.Region.S3Endpoint(), l.Bucket, l.Key), nil
+	return fmt.Sprintf("%s/%s", l.Region.S3Endpoint(l.Bucket), l.Key), nil
 }
 
 func (l AssetLocation) S3URL() (string, error) {

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -790,11 +790,11 @@ func (c Cluster) validate(cpStackName string) error {
 		}
 	}
 
-	if c.Kubernetes.Networking.SelfHosting.Type != "canal" && c.Kubernetes.Networking.SelfHosting.Type != "flannel" {
-		return fmt.Errorf("networkingdaemonsets - style must be either 'canal' or 'flannel'")
+	if c.Kubernetes.Networking.SelfHosting.Type != "canal" && c.Kubernetes.Networking.SelfHosting.Type != "flannel"  && c.Kubernetes.Networking.SelfHosting.Type != "calico" {
+		return fmt.Errorf("networkingdaemonsets - style must be either 'canal' or 'flannel' or 'calico'")
 	}
-	if c.Kubernetes.Networking.SelfHosting.Typha && c.Kubernetes.Networking.SelfHosting.Type != "canal" {
-		return fmt.Errorf("networkingdaemonsets - you can only enable typha when deploying type 'canal'")
+	if c.Kubernetes.Networking.SelfHosting.Typha && c.Kubernetes.Networking.SelfHosting.Type != "canal" && c.Kubernetes.Networking.SelfHosting.Type != "calico" {
+		return fmt.Errorf("networkingdaemonsets - you can only enable typha when deploying type 'canal' or 'calico'")
 	}
 
 	return nil

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -240,6 +240,7 @@ func NewDefaultCluster() *Cluster {
 						FlannelCniImage: Image{Repo: "quay.io/coreos/flannel-cni", Tag: kubeNetworkingSelfHostingDefaultFlannelCniImageTag, RktPullDocker: false},
 						TyphaImage:      Image{Repo: "calico/typha", Tag: kubeNetworkingSelfHostingDefaultTyphaImageTag, RktPullDocker: false},
 						FlannelConfig:   FlannelConfig{SubnetLen: int32(0)},
+						CalicoConfig:    CalicoConfig{VxlanMode: true},
 					},
 				},
 			},

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -20,11 +20,11 @@ var KUBERNETES_VERSION = "v99.99"
 
 const (
 	// Experimental SelfHosting feature default images.
-	kubeNetworkingSelfHostingDefaultCalicoNodeImageTag = "v3.11.1"
-	kubeNetworkingSelfHostingDefaultCalicoCniImageTag  = "v3.11.1"
+	kubeNetworkingSelfHostingDefaultCalicoNodeImageTag = "v3.13.3"
+	kubeNetworkingSelfHostingDefaultCalicoCniImageTag  = "v3.13.3"
 	kubeNetworkingSelfHostingDefaultFlannelImageTag    = "v0.11.0"
 	kubeNetworkingSelfHostingDefaultFlannelCniImageTag = "v0.3.0"
-	kubeNetworkingSelfHostingDefaultTyphaImageTag      = "v3.11.1"
+	kubeNetworkingSelfHostingDefaultTyphaImageTag      = "v3.13.3"
 
 	// Experimental CSI support default image tags...
 	CSIDefaultProvisionerImageTag     = "v1.3.1"
@@ -234,11 +234,11 @@ func NewDefaultCluster() *Cluster {
 								Memory: "200Mi",
 							},
 						},
-						CalicoNodeImage: Image{Repo: "quay.io/calico/node", Tag: kubeNetworkingSelfHostingDefaultCalicoNodeImageTag, RktPullDocker: false},
-						CalicoCniImage:  Image{Repo: "quay.io/calico/cni", Tag: kubeNetworkingSelfHostingDefaultCalicoCniImageTag, RktPullDocker: false},
+						CalicoNodeImage: Image{Repo: "calico/node", Tag: kubeNetworkingSelfHostingDefaultCalicoNodeImageTag, RktPullDocker: false},
+						CalicoCniImage:  Image{Repo: "calico/cni", Tag: kubeNetworkingSelfHostingDefaultCalicoCniImageTag, RktPullDocker: false},
 						FlannelImage:    Image{Repo: "quay.io/coreos/flannel", Tag: kubeNetworkingSelfHostingDefaultFlannelImageTag, RktPullDocker: false},
 						FlannelCniImage: Image{Repo: "quay.io/coreos/flannel-cni", Tag: kubeNetworkingSelfHostingDefaultFlannelCniImageTag, RktPullDocker: false},
-						TyphaImage:      Image{Repo: "quay.io/calico/typha", Tag: kubeNetworkingSelfHostingDefaultTyphaImageTag, RktPullDocker: false},
+						TyphaImage:      Image{Repo: "calico/typha", Tag: kubeNetworkingSelfHostingDefaultTyphaImageTag, RktPullDocker: false},
 						FlannelConfig:   FlannelConfig{SubnetLen: int32(0)},
 					},
 				},
@@ -790,7 +790,7 @@ func (c Cluster) validate(cpStackName string) error {
 		}
 	}
 
-	if c.Kubernetes.Networking.SelfHosting.Type != "canal" && c.Kubernetes.Networking.SelfHosting.Type != "flannel"  && c.Kubernetes.Networking.SelfHosting.Type != "calico" {
+	if c.Kubernetes.Networking.SelfHosting.Type != "canal" && c.Kubernetes.Networking.SelfHosting.Type != "flannel" && c.Kubernetes.Networking.SelfHosting.Type != "calico" {
 		return fmt.Errorf("networkingdaemonsets - style must be either 'canal' or 'flannel' or 'calico'")
 	}
 	if c.Kubernetes.Networking.SelfHosting.Typha && c.Kubernetes.Networking.SelfHosting.Type != "canal" && c.Kubernetes.Networking.SelfHosting.Type != "calico" {

--- a/pkg/api/networking.go
+++ b/pkg/api/networking.go
@@ -15,8 +15,13 @@ type SelfHosting struct {
 	FlannelCniImage Image            `yaml:"flannelCniImage"`
 	TyphaImage      Image            `yaml:"typhaImage"`
 	FlannelConfig   FlannelConfig    `yaml:"flannelConfig"`
+	CalicoConfig    CalicoConfig     `yaml:"calicoConfig"`
 }
 
 type FlannelConfig struct {
 	SubnetLen int32 `yaml:"subnetLen"`
+}
+
+type CalicoConfig struct {
+	VxlanMode bool `yaml:"vxlanMode"`
 }

--- a/pkg/api/region.go
+++ b/pkg/api/region.go
@@ -42,14 +42,15 @@ func (r Region) String() string {
 	return r.Name
 }
 
-func (r Region) S3Endpoint() string {
+func (r Region) S3Endpoint(bucket string) string {
+	domain := "s3"
 	if r.IsChina() {
-		return fmt.Sprintf("https://s3.%s.amazonaws.com.cn", r.Name)
+		domain = fmt.Sprintf("s3.%s", r.Name)
 	}
 	if r.IsGovcloud() {
-		return fmt.Sprintf("https://s3-%s.amazonaws.com", r.Name)
+		domain = fmt.Sprintf("s3-%s", r.Name)
 	}
-	return "https://s3.amazonaws.com"
+	return fmt.Sprintf("https://%s.%s.%s", bucket, domain, r.PublicDomainName())
 }
 
 func (r Region) Partition() string {


### PR DESCRIPTION
## Changes

- Canal is EOL, and the only other option we offered was AWS CNI. This borrows (steals) the Calico configuration for kops, and dumps it into kube-aws so that we can use that as an option too.
- This PR also fixes node labelling issues that changed between v1.15.x and v1.16.x, as we can no longer use `kubelet` to self label `kubernetes.io` tags, making nodes difficult to differentiate.
- This PR also removes quay.io as the core provider for calico networking images because they keep falling over.
- This PR also opens ports 4789 to allow for vxlan networking between ports, and opens communication between workers & controllers for IPnIP tunnelling used by Calico's BGP (also requiring port 179) setup.