### PR TITLE
Migrate to new s3 URL method

### DIFF
--- a/pkg/api/assets.go
+++ b/pkg/api/assets.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"fmt"
-	"github.com/kubernetes-incubator/kube-aws/fingerprint"
 	"strings"
+
+	"github.com/kubernetes-incubator/kube-aws/fingerprint"
 )
 
 type AssetID struct {
@@ -35,7 +36,7 @@ func (l AssetLocation) URL() (string, error) {
 	if (l == AssetLocation{}) {
 		return "", fmt.Errorf("[bug] Empty asset location can't have URL")
 	}
-	return fmt.Sprintf("%s/%s/%s", l.Region.S3Endpoint(), l.Bucket, l.Key), nil
+	return fmt.Sprintf("%s/%s", l.Region.S3Endpoint(l.Bucket), l.Key), nil
 }
 
 func (l AssetLocation) S3URL() (string, error) {

--- a/pkg/api/region.go
+++ b/pkg/api/region.go
@@ -42,14 +42,15 @@ func (r Region) String() string {
 	return r.Name
 }
 
-func (r Region) S3Endpoint() string {
+func (r Region) S3Endpoint(bucket string) string {
+	domain := "s3"
 	if r.IsChina() {
-		return fmt.Sprintf("https://s3.%s.amazonaws.com.cn", r.Name)
+		domain = fmt.Sprintf("s3.%s", r.Name)
 	}
 	if r.IsGovcloud() {
-		return fmt.Sprintf("https://s3-%s.amazonaws.com", r.Name)
+		domain = fmt.Sprintf("s3-%s", r.Name)
 	}
-	return "https://s3.amazonaws.com"
+	return fmt.Sprintf("https://%s.%s.%s", bucket, domain, r.PublicDomainName())
 }
 
 func (r Region) Partition() string {


### PR DESCRIPTION
Path based access has been deprecated and now returns a redirect error to bucketname.s3.amazonaws.com
as explained in this post:
https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/

This makes cloudformation to fail as it refers to the now redirected s3
bucket path, and raises the message:
S3 error: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint. For more information check http://docs.aws.amazon.com/AmazonS3/la

There is no strong documentation about what are the updates in China and
Gov regions, consider it follows the same logic.