### PR TITLE
Allow injection of CoreDNS configuration for non-root zones

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1208,7 +1208,7 @@ kubernetes:
     selfHosting:
       type: canal      # either "canal" or "flannel"
       typha: false     # enable for type 'canal' for 50+ node clusters
-#      typhaResources:  # control k8s resources assigned to Typha pods 
+#      typhaResources:  # control k8s resources assigned to Typha pods
 #        requests:
 #          cpu: "100m"
 #          memory: "100Mi"
@@ -1338,7 +1338,7 @@ kubernetesDashboard:
 kubeDns:
   # Define which DNS provider to use (kube-dns or coredns), default coredns.
   provider: coredns
-  
+
   # Defines resources for the CoreDNS Deployment. Ignored if using kubedns.
   # dnsDeploymentResources:
   #   requests:
@@ -1371,9 +1371,17 @@ kubeDns:
     coresPerReplica: 256
     nodesPerReplica: 16
     min: 2
-  # Allows to add extra configuration into CoreDNS config map
+  # Allows addition of extra configuration into CoreDNS config map's root zone.
   # extraCoreDNSConfig: |
   #   rewrite name substring demo.app.org app.default.svc.cluster.local
+  # This configuration is injected into the CoreDNS config map after the root
+  # zone (".") and can be used to add configuration for additional zones.
+  # additionalZoneCoreDNSConfig: |
+  #  global:53 {
+  #      errors
+  #      cache 30
+  #      forward . 1.2.3.4:53
+  #  }
 
 kubeProxy:
   # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.9.0+ to work reliably)

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3856,6 +3856,9 @@ write_files:
                 reload
                 loadbalance
             }
+            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+            {{ .KubeDns.AdditionalZoneCoreDNSConfig }}
+            {{- end }}
 {{- else }}
   - path: /srv/kubernetes/manifests/kube-dns-sa.yaml
     content: |

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -181,7 +181,8 @@ func NewDefaultCluster() *Cluster {
 						Cpu:    "200m",
 					},
 				},
-				ExtraCoreDNSConfig: "",
+				ExtraCoreDNSConfig:          "",
+				AdditionalZoneCoreDNSConfig: "",
 			},
 			KubeSystemNamespaceLabels: make(map[string]string),
 			KubernetesDashboard: KubernetesDashboard{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -220,6 +220,7 @@ type KubeDns struct {
 	Autoscaler                   KubeDnsAutoscaler `yaml:"autoscaler"`
 	DnsDeploymentResources       ComputeResources  `yaml:"dnsDeploymentResources,omitempty"`
 	ExtraCoreDNSConfig           string            `yaml:"extraCoreDNSConfig"`
+	AdditionalZoneCoreDNSConfig  string            `yaml:"additionalZoneCoreDNSConfig"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1382,6 +1382,36 @@ kubeDns:
 				ExtraCoreDNSConfig: "rewrite name substring demo.app.org app.default.svc.cluster.local",
 			},
 		},
+		{
+			conf: `
+kubeDns:
+  provider: coredns
+  additionalZoneCoreDNSConfig: global:53 { forward . 1.2.3.4 }
+`,
+			kubeDns: api.KubeDns{
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
+				Autoscaler: api.KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+				DnsDeploymentResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
+				AdditionalZoneCoreDNSConfig: "global:53 { forward . 1.2.3.4 }",
+			},
+		},
 	}
 
 	for _, conf := range validConfigs {


### PR DESCRIPTION
The existing `kubeDns.autoscaler.extraCoreDNSConfig`  allows the user to
inject additional values into the coredns configmap's root zone (".").
This commit allows the user to additionally specify a string to
`kubeDns.autoscaler.additionalZoneCoreDNSConfig` which will be injected
into the configmap after the root zone to allow the user to specify
configuration for additional zones. As an example, this might be used
to forward traffic for the .global zone to the istiocoredns service.