### PR TITLE
Add proper indentation to additional zone CoreDNS config

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1378,6 +1378,7 @@ kubeDns:
   # Allows addition of extra configuration into CoreDNS config map's root zone.
   # extraCoreDNSConfig: |
   #   rewrite name substring demo.app.org app.default.svc.cluster.local
+  #
   # This configuration is injected into the CoreDNS config map after the root
   # zone (".") and can be used to add configuration for additional zones.
   # additionalZoneCoreDNSConfig: |

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3905,7 +3905,7 @@ write_files:
                 loadbalance
             }
             {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
-            {{ .KubeDns.AdditionalZoneCoreDNSConfig }}
+{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
             {{- end }}
 {{- else }}
   - path: /srv/kubernetes/manifests/kube-dns-sa.yaml


### PR DESCRIPTION
This PR adds proper indentation to the additional zone CoreDNS change introduced with https://github.com/kubernetes-incubator/kube-aws/pull/1875.