### PR TITLE
[v0.16.x] Allow injection of CoreDNS configuration for non-root zones

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1345,9 +1345,18 @@ kubeDns:
     nodesPerReplica: 16
     min: 2
 
-  # Allows to add extra configuration into CoreDNS config map
+  # Allows addition of extra configuration into CoreDNS config map's root zone.
   # extraCoreDNSConfig: |
   #   rewrite name substring demo.app.org app.default.svc.cluster.local
+  #
+  # This configuration is injected into the CoreDNS config map after the root
+  # zone (".") and can be used to add configuration for additional zones.
+  # additionalZoneCoreDNSConfig: |
+  #  global:53 {
+  #      errors
+  #      cache 30
+  #      forward . 1.2.3.4:53
+  #  }
 
 kubeProxy:
   # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.9.0+ to work reliably)

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -11,7 +11,7 @@ s3URI: {{.S3URI}}
 #releaseChannel: stable
 
 # To update this to the latest AMI run the following command with the appropriate region and channel then place the resulting ID here
-#   REGION=eu-west-1 CHANNEL=stable curl -s https://$CHANNEL.release.flatcar-linux.net/amd64-usr/current/flatcar_production_ami_all.json | jq  -r ".amis[] | select(.name==\"$REGION\") .hvm
+#  REGION=eu-west-1 CHANNEL=stable curl -s https://$CHANNEL.release.flatcar-linux.net/amd64-usr/current/flatcar_production_ami_all.json | jq  -r ".amis[] | select(.name==\"$REGION\") .hvm
 amiId: "{{.AmiId}}"
 
 # Flatcar has automatic updates https://docs.flatcar-linux.org/os/update-strategies/#disable-automatic-updates-daemon. This can be a risk in certain situations and this is why is disabled by default and you can enable it by setting this param to false.

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1340,7 +1340,7 @@ write_files:
       data:
         # You must set a non-zero value for Typha replicas below.
         typha_service_name: "{{- if .Kubernetes.Networking.SelfHosting.Typha }}calico-typha{{- else -}}none{{- end -}}"
-        
+
         # Configure the backend to use.
         calico_backend: "{{- if .Kubernetes.Networking.SelfHosting.CalicoConfig.VxlanMode }}vxlan{{- else -}}bird{{- end -}}"
 
@@ -4394,7 +4394,7 @@ write_files:
           - --endpoint-reconciler-type=lease
           {{- else }}
           - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .Controller.Count }}{{end}}
-          {{- end }}        
+          {{- end }}
           - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,RuntimeClass,ResourceQuota,ExtendedResourceToleration,NodeRestriction,PodSecurityPolicy{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{ if .Experimental.Admission.EventRateLimit.Enabled }},EventRateLimit{{end}}
           {{ if .Experimental.Admission.EventRateLimit.Enabled -}}
           - --admission-control-config-file=/etc/kubernetes/auth/admission-control-config.yaml
@@ -5372,6 +5372,9 @@ write_files:
               reload
               loadbalance
           }
+          {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 10 }}
+          {{- end }}
 {{- else }}
   - path: /srv/kubernetes/manifests/kube-dns-sa.yaml
     content: |

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -204,7 +204,8 @@ func NewDefaultCluster() *Cluster {
 						Cpu:    "200m",
 					},
 				},
-				ExtraCoreDNSConfig: "",
+				ExtraCoreDNSConfig:          "",
+				AdditionalZoneCoreDNSConfig: "",
 			},
 			KubeSystemNamespaceLabels: make(map[string]string),
 			Kubernetes: Kubernetes{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -210,6 +210,7 @@ type KubeDns struct {
 	Autoscaler                   KubeDnsAutoscaler `yaml:"autoscaler"`
 	DnsDeploymentResources       ComputeResources  `yaml:"dnsDeploymentResources,omitempty"`
 	ExtraCoreDNSConfig           string            `yaml:"extraCoreDNSConfig"`
+	AdditionalZoneCoreDNSConfig  string            `yaml:"additionalZoneCoreDNSConfig"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1449,6 +1449,36 @@ kubeDns:
 				ExtraCoreDNSConfig: "rewrite name substring demo.app.org app.default.svc.cluster.local",
 			},
 		},
+		{
+			conf: `
+kubeDns:
+  provider: coredns
+  additionalZoneCoreDNSConfig: global:53 { forward . 1.2.3.4 }
+`,
+			kubeDns: api.KubeDns{
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
+				Autoscaler: api.KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+				DnsDeploymentResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
+				AdditionalZoneCoreDNSConfig: "global:53 { forward . 1.2.3.4 }",
+			},
+		},
 	}
 
 	for _, conf := range validConfigs {


### PR DESCRIPTION
The existing `kubeDns.extraCoreDNSConfig`  allows the user to
inject additional values into the coredns configmap's root zone (".").
This commit allows the user to additionally specify a string to
`kubeDns.additionalZoneCoreDNSConfig` which will be injected
into the configmap after the root zone to allow the user to specify
configuration for additional zones. As an example, this might be used
to forward traffic for the .global zone to the istiocoredns service.