### PR TITLE
Allow injection of CoreDNS configuration for non-root zones

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1341,9 +1341,18 @@ kubeDns:
     nodesPerReplica: 16
     min: 2
 
-  # Allows to add extra configuration into CoreDNS config map
+  # Allows addition of extra configuration into CoreDNS config map's root zone.
   # extraCoreDNSConfig: |
   #   rewrite name substring demo.app.org app.default.svc.cluster.local
+  #
+  # This configuration is injected into the CoreDNS config map after the root
+  # zone (".") and can be used to add configuration for additional zones.
+  # additionalZoneCoreDNSConfig: |
+  #  global:53 {
+  #      errors
+  #      cache 30
+  #      forward . 1.2.3.4:53
+  #  }
 
 kubeProxy:
   # Use IPVS kube-proxy mode instead of [default] iptables one (requires Kubernetes 1.9.0+ to work reliably)

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1572,7 +1572,7 @@ write_files:
                     value: "kubernetes"
                   # Configure route aggregation based on pod CIDR.
                   - name: USE_POD_CIDR
-                    value: "true"                    
+                    value: "true"
                   # Enable felix logging.
                   - name: FELIX_LOGSEVERITYSYS
                     value: "Warning"
@@ -1605,7 +1605,7 @@ write_files:
                     valueFrom:
                       configMapKeyRef:
                         name: canal-config
-                        key: veth_mtu                    
+                        key: veth_mtu
                   - name: NODENAME
                     valueFrom:
                       fieldRef:
@@ -1660,7 +1660,7 @@ write_files:
                   privileged: true
                 env:
                   - name: FLANNELD_IPTABLES_FORWARD_RULES
-                    value: "false"                
+                    value: "false"
                   - name: POD_NAME
                     valueFrom:
                       fieldRef:
@@ -3387,7 +3387,7 @@ write_files:
           - --endpoint-reconciler-type=lease
           {{- else }}
           - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .Controller.Count }}{{end}}
-          {{- end }}        
+          {{- end }}
           - --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,RuntimeClass,ResourceQuota,ExtendedResourceToleration,NodeRestriction,PodSecurityPolicy{{if .Experimental.Admission.AlwaysPullImages.Enabled}},AlwaysPullImages{{ end }}{{ if .Experimental.Admission.EventRateLimit.Enabled }},EventRateLimit{{end}}
           {{ if .Experimental.Admission.EventRateLimit.Enabled -}}
           - --admission-control-config-file=/etc/kubernetes/auth/admission-control-config.yaml
@@ -4365,6 +4365,9 @@ write_files:
               reload
               loadbalance
           }
+          {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 10 }}
+          {{- end }}
 {{- else }}
   - path: /srv/kubernetes/manifests/kube-dns-sa.yaml
     content: |

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -204,7 +204,8 @@ func NewDefaultCluster() *Cluster {
 						Cpu:    "200m",
 					},
 				},
-				ExtraCoreDNSConfig: "",
+				ExtraCoreDNSConfig:          "",
+				AdditionalZoneCoreDNSConfig: "",
 			},
 			KubeSystemNamespaceLabels: make(map[string]string),
 			Kubernetes: Kubernetes{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -210,6 +210,7 @@ type KubeDns struct {
 	Autoscaler                   KubeDnsAutoscaler `yaml:"autoscaler"`
 	DnsDeploymentResources       ComputeResources  `yaml:"dnsDeploymentResources,omitempty"`
 	ExtraCoreDNSConfig           string            `yaml:"extraCoreDNSConfig"`
+	AdditionalZoneCoreDNSConfig  string            `yaml:"additionalZoneCoreDNSConfig"`
 }
 
 func (c *KubeDns) MergeIfEmpty(other KubeDns) {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1449,6 +1449,36 @@ kubeDns:
 				ExtraCoreDNSConfig: "rewrite name substring demo.app.org app.default.svc.cluster.local",
 			},
 		},
+		{
+			conf: `
+kubeDns:
+  provider: coredns
+  additionalZoneCoreDNSConfig: global:53 { forward . 1.2.3.4 }
+`,
+			kubeDns: api.KubeDns{
+				Provider:                     "coredns",
+				NodeLocalResolver:            false,
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
+				Autoscaler: api.KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+				DnsDeploymentResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
+				AdditionalZoneCoreDNSConfig: "global:53 { forward . 1.2.3.4 }",
+			},
+		},
 	}
 
 	for _, conf := range validConfigs {


### PR DESCRIPTION
The existing `kubeDns.extraCoreDNSConfig`  allows the user to
inject additional values into the coredns configmap's root zone (".").
This commit allows the user to additionally specify a string to
`kubeDns.additionalZoneCoreDNSConfig` which will be injected
into the configmap after the root zone to allow the user to specify
configuration for additional zones. As an example, this might be used
to forward traffic for the .global zone to the istiocoredns service.