### PR TITLE
Keep newline, so apiserver starts

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -346,7 +346,7 @@ coreos:
         {{ range $i, $m := .Kubelet.Mounts -}}
         {{ range $j, $a := $m.ToRktRunArgs -}}
         {{ $a }} \
-        {{- end }}
+        {{ end }}
         {{- end }}
         {{- end }}
         --mount volume=var-log,target=/var/log \


### PR DESCRIPTION
* With WS stripping character in place configs would be malformed, ie
    * `--volume opt-bin,kind=host,source=/opt/bin \--mount volume=var-log,target=/var/log \`
* This code has been refactored in 0.16.x and master. As far as I'm aware, this is the only branch with this bug.
* Now there's an extra newline, but this function is only called once  and the the sh environment formatting is more forgiving, ie

```sh
--volume opt-bin,kind=host,source=/opt/bin \

--mount volume=var-log,target=/var/log \
```
