### PR TITLE
Upgrade aws auth, fix CF template bug

### DIFF
--- a/builtin/files/plugins/aws-iam-authenticator/files/authentication-token-webhook-config.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/files/authentication-token-webhook-config.yaml
@@ -13,5 +13,5 @@ current-context: webhook
 contexts:
 - name: webhook
   context:
-    cluster: aws-iam-authenticator
+    cluster: {{.Config.AWSIAMAuthenticatorClusterIDRef}}
     user: apiserver

--- a/builtin/files/plugins/aws-iam-authenticator/files/controller-kubeconfig.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/files/controller-kubeconfig.yaml
@@ -15,10 +15,10 @@ preferences: {}
 users:
 - name: aws
   user:
-  exec:
-    apiVersion: client.authentication.k8s.io/v1alpha1
-    command: /opt/bin/aws-iam-authenticator
-    args:
-    - token
-    - -i
-    - {{.Config.AWSIAMAuthenticatorClusterIDRef}}
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      command: /opt/bin/aws-iam-authenticator
+      args:
+      - token
+      - -i
+      - {{.Config.AWSIAMAuthenticatorClusterIDRef}}

--- a/builtin/files/plugins/aws-iam-authenticator/files/worker-kubeconfig.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/files/worker-kubeconfig.yaml
@@ -15,10 +15,10 @@ preferences: {}
 users:
 - name: aws
   user:
-  exec:
-    apiVersion: client.authentication.k8s.io/v1alpha1
-    command: /opt/bin/aws-iam-authenticator
-    args:
-    - token
-    - -i
-    - {{.Config.AWSIAMAuthenticatorClusterIDRef}}
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      command: /opt/bin/aws-iam-authenticator
+      args:
+      - token
+      - -i
+      - {{.Config.AWSIAMAuthenticatorClusterIDRef}}

--- a/builtin/files/plugins/aws-iam-authenticator/manifests/aws-auth-cm.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/manifests/aws-auth-cm.yaml
@@ -12,6 +12,6 @@ data:
         - rolearn: {{$role}}
           username: system:node:{{`{{EC2PrivateDNSName}}`}}
           groups:
-          - system:bootstrappers
-          - system:nodes
+            - system:bootstrappers
+            - system:nodes
         {{ end -}}

--- a/builtin/files/plugins/aws-iam-authenticator/manifests/clusterrole.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/manifests/clusterrole.yaml
@@ -1,0 +1,29 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: aws-iam-authenticator
+rules:
+  - apiGroups:
+      - iamauthenticator.k8s.aws
+    resources:
+      - iamidentitymappings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - iamauthenticator.k8s.aws
+    resources:
+      - iamidentitymappings/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - update
+      - patch

--- a/builtin/files/plugins/aws-iam-authenticator/manifests/clusterrolebinding.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/manifests/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: aws-iam-authenticator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-iam-authenticator
+subjects:
+  - kind: ServiceAccount
+    name: aws-iam-authenticator
+    namespace: kube-system

--- a/builtin/files/plugins/aws-iam-authenticator/manifests/daemonset.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/manifests/daemonset.yaml
@@ -1,12 +1,15 @@
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   namespace: kube-system
   name: aws-iam-authenticator
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
   labels:
     k8s-app: aws-iam-authenticator
 spec:
+  revisionHistoryLimit: 10
   updateStrategy:
     type: RollingUpdate
   selector:
@@ -14,38 +17,40 @@ spec:
       k8s-app: aws-iam-authenticator
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: aws-iam-authenticator
     spec:
+      # use service account with access to
+      serviceAccountName: aws-iam-authenticator
+
       # run on the host network (don't depend on CNI)
       hostNetwork: true
+
       # run on each master node
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
         - effect: NoSchedule
-          key: node.alpha.kubernetes.io/role
-          value: master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
         - key: CriticalAddonsOnly
           operator: Exists
+
+      priorityClassName: system-cluster-critical
+
       # run `aws-iam-authenticator server` with three volumes
       # - config (mounted from the ConfigMap at /etc/aws-iam-authenticator/config.yaml)
       # - state (persisted TLS certificate and keys, mounted from the host)
       # - output (output kubeconfig to plug into your apiserver configuration, mounted from the host)
       containers:
         - name: aws-iam-authenticator
-          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.0-alpine-3.7
+          image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.1-alpine-3.7
           args:
             - server
             - --config=/etc/aws-iam-authenticator/config.yaml
             - --state-dir=/var/aws-iam-authenticator
             - --kubeconfig-pregenerated=true
-            # NOTE required for 0.5.0 to work, resolved in >= 0.5.1
-            - --backend-mode=ConfigMap,File
           resources:
             requests:
               memory: 20Mi

--- a/builtin/files/plugins/aws-iam-authenticator/manifests/daemonset.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/manifests/daemonset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   namespace: kube-system
@@ -28,12 +28,12 @@ spec:
 
       # run on each master node
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node.kubernetes.io/role: master
       tolerations:
         - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
+          key: node.kubernetes.io/role
+          operator: Equal
+          value: master
         - key: CriticalAddonsOnly
           operator: Exists
 

--- a/builtin/files/plugins/aws-iam-authenticator/manifests/serviceaccount.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/manifests/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-iam-authenticator
+  namespace: kube-system
+

--- a/builtin/files/plugins/aws-iam-authenticator/plugin.yaml
+++ b/builtin/files/plugins/aws-iam-authenticator/plugin.yaml
@@ -1,6 +1,6 @@
 metadata:
   name: aws-iam-authenticator
-  version: 0.2
+  version: 0.3
 spec:
   cluster:
     pki:
@@ -21,6 +21,12 @@ spec:
           path: manifests/aws-auth-cm.yaml
       - source:
           path: manifests/daemonset.yaml
+      - source:
+          path: manifests/clusterrole.yaml
+      - source:
+          path: manifests/clusterrolebinding.yaml
+      - source:
+          path: manifests/serviceaccount.yaml
       apiserver:
         flags:
         - name: authentication-token-webhook-config-file
@@ -44,7 +50,7 @@ spec:
             type: binary
             source:
               path: "files/aws-iam-auth/opt/bin/aws-iam-authenticator"
-              url: "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.0/aws-iam-authenticator_0.5.0_linux_amd64"
+              url: "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.1/aws-iam-authenticator_0.5.1_linux_amd64"
           - path: /etc/kubernetes/kubeconfig/aws-iam-auth.yaml
             permissions: 0644
             source:
@@ -72,7 +78,7 @@ spec:
             type: binary
             source:
               path: "files/aws-iam-auth/opt/bin/aws-iam-authenticator"
-              url: "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.0/aws-iam-authenticator_0.5.0_linux_amd64"
+              url: "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.1/aws-iam-authenticator_0.5.1_linux_amd64"
           - path: /etc/kubernetes/kubeconfig/aws-iam-auth.yaml
             permissions: 0644
             source:

--- a/builtin/files/stack-templates/control-plane.json.tmpl
+++ b/builtin/files/stack-templates/control-plane.json.tmpl
@@ -217,9 +217,11 @@
             "FromPort": -1,
             "IpProtocol": "icmp",
             "ToPort": -1
-          },
+          }
           {{end -}}
-          {{ range $_, $r := $.SSHAccessAllowedSourceCIDRs -}}
+          {{ $icmp := eq .OpenICMP true -}}
+          {{ range $i, $r := $.SSHAccessAllowedSourceCIDRs -}}
+          {{ if or (gt $i 0) $icmp }},{{end}}
           {
             "CidrIp": "{{$r}}",
             "FromPort": 22,

--- a/docs/getting-started/step-6-configure-add-ons.md
+++ b/docs/getting-started/step-6-configure-add-ons.md
@@ -126,7 +126,6 @@ Resources:
 ### Enable aws-iam-authenticator
 
 1. Merge these settings into your cluster.yaml
-
 ```yaml
 controller:
   iam:
@@ -137,13 +136,8 @@ kubeAwsPlugins:
   awsIamAuthenticator:
     enabled: true
 ```
-
-By controlling the name of the role associated with the controller you will find it easier to grant the necessary permissions. The name of the role will become CLUSTER_NAME-REGION-IAM_ROLE_NAME.
-
-**NOTE** Applying this update will delete the existing role for the controller, replacing it with a new one.
-
+By controlling the name of the role associated with the controller you will find it easier to grant the necessary permissions. The name of the role will become CLUSTER_NAME-REGION-IAM_ROLE_NAME.<br>**NOTE** Applying this update will delete the existing role for the controller, replacing it with a new one.
 1. The IAM role associated with controller nodes requires an IAM policy:
- 
   ```json
   {
     "Action": "sts:AssumeRole",
@@ -151,11 +145,10 @@ By controlling the name of the role associated with the controller you will find
     "Effect": "Allow"
   }
   ```
-
 1. `kube-aws render credentials`
     * The resulting cert and key will be signed by the default CA
 1. `kube-aws render stack`
-1. Consult the [aws-iam-aithentication docs](https://github.com/kubernetes-sigs/aws-iam-authenticator/#4-create-iam-roleuser-to-kubernetes-usergroup-mappings), to configure roles and the config map.
+1. Consult the [aws-iam-authenticator docs](https://github.com/kubernetes-sigs/aws-iam-authenticator/#4-create-iam-roleuser-to-kubernetes-usergroup-mappings), to configure roles and the config map.
     * the config map is in `plugins/aws-iam-authenticator/manifest/aws-auth-cm.yaml`
     * server command line arguments are in `plugins/aws-iam-authenticator/manifest/daemonset.yaml`
     * don't forget to update kubeconfig

--- a/docs/getting-started/step-6-configure-add-ons.md
+++ b/docs/getting-started/step-6-configure-add-ons.md
@@ -119,6 +119,78 @@ Resources:
       ...
 ```
 
+## aws-iam-authenticator
+
+[aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) is an add-on which permits users, roles, nodes, etc. to access the cluster using IAM credentials. This plugin cannot be enabled when a cluster is initially created. To successfully enable it, you must update an existing stack.
+
+### Enable aws-iam-authenticator
+
+1. Merge these settings into your cluster.yaml
+
+```yaml
+controller:
+  iam:
+    role:
+      name: controller
+
+kubeAwsPlugins:
+  awsIamAuthenticator:
+    enabled: true
+```
+
+By controlling the name of the role associated with the controller you will find it easier to grant the necessary permissions. The name of the role will become CLUSTER_NAME-REGION-IAM_ROLE_NAME.
+
+**NOTE** Applying this update will delete the existing role for the controller, replacing it with a new one.
+
+1. The IAM role associated with controller nodes requires an IAM policy:
+ 
+  ```json
+  {
+    "Action": "sts:AssumeRole",
+    "Resource": "*",
+    "Effect": "Allow"
+  }
+  ```
+
+1. `kube-aws render credentials`
+    * The resulting cert and key will be signed by the default CA
+1. `kube-aws render stack`
+1. Consult the [aws-iam-aithentication docs](https://github.com/kubernetes-sigs/aws-iam-authenticator/#4-create-iam-roleuser-to-kubernetes-usergroup-mappings), to configure roles and the config map.
+    * the config map is in `plugins/aws-iam-authenticator/manifest/aws-auth-cm.yaml`
+    * server command line arguments are in `plugins/aws-iam-authenticator/manifest/daemonset.yaml`
+    * don't forget to update kubeconfig
+1. The aws-iam-authenticator docker image is only available from ECR. If you are not regularly authenticating to ECR in us-west-2, you will probably need to copy the image to your own docker registry. 
+    1. Login to ECR
+        * `aws --region us-west-2 ecr get-login-password | docker login --username AWS --password-stdin 602401143452.dkr.ecr.us-west-2.amazonaws.com`
+    1. Choose your preferred image to [pull](https://github.com/kubernetes-sigs/aws-iam-authenticator/releases), ie
+        * `docker pull 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.1-alpine-3.7`
+    1. Re-tag the image
+        * `docker tag 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-iam-authenticator:v0.5.1-alpine-3.7 YOUR_ORG/aws-iam-authenticator:v0.5.1-alpine-3.7`
+    1. Push the new tag
+        * `docker push YOUR_ORG/aws-iam-authenticator:v0.5.1-alpine-3.7`
+    1. Update the `image` key in `plugins/aws-iam-authenticator/manifest/daemonset.yaml`
+1. `kube-aws apply`
+
+### Delete an aws-iam-authenticator enabled cluster
+
+To successfully delete a cluster with aws-iam-authenticator enabled you must
+work around a quirk in cloud formation. You have two options.
+
+#### Delete the control plane stack manually and then delete the cluster
+
+1.  https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks?filteringText=&filteringStatus=active&viewNested=true&hideStacks=false
+    1. Navigate to the control plane stack of the cluster you'd like to delete
+    1. Click the delete button
+        1. Choose to delete the sub stack
+        1. Type in the confirmation
+1. Follow the rest of the instructions to [destroy your cluster][getting-started-step-7] 
+
+#### Disable aws-iam-authenticator and then delete the cluster
+
+1. Set `kubeAwsPlugins.awsIamAuthenticator.enabled` to `false`
+1. `kube-aws apply`
+1. Follow the rest of the instructions to [destroy your cluster][getting-started-step-7] 
+
 When you are done with your cluster, [destroy your cluster][getting-started-step-7]
 
 [getting-started-step-1]: step-1-configure.md

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -211,7 +211,7 @@ func NewDefaultCluster() *Cluster {
 				Authentication: KubernetesAuthentication{
 					AWSIAM: AWSIAM{
 						Enabled:           false,
-						BinaryDownloadURL: `https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.0/aws-iam-authenticator_0.5.0_linux_amd64`,
+						BinaryDownloadURL: `https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.1/aws-iam-authenticator_0.5.1_linux_amd64`,
 					},
 				},
 				EncryptionAtRest: EncryptionAtRest{


### PR DESCRIPTION
## Description 

* Fix bug in stack-template for controller, around `OpenICMP` and ssh security groups
* Upgrade to aws-iam-authenticator 0.5.1
* Resolve issue introduced in 941fd29, where the context cluster name didn't match
* Fix formatting issue with controller and worker kubeconfig files
* Add clusterrole, binding, and service account
* Allow aws-iam-auth to be scheduled on k8s 1.15 and 1.16

## Versions

* I have successfully created a new stack, on master
* I have not tested this on v0.16.x
* I have successfully created a new stack, on v0.15.x
    * This can be safely merged into v0.15.x after #1874 and #1886

## Installing the aws-iam-authenticator

AWS authenticator expects IAM roles for controllers and workers already exist. As it is currently configured, the aws-iam-authenticator must be enabled *after* the initial `kube-aws apply`. This is because the exports on the root stack, for workers, are not available to the control plane stack during creation, ie 

`+00:06:18       CREATE_FAILED                           test-Controlplane-13Y4STRG1AGDV        "No export named test-NodePoolPool1eWorkerIAMRoleArn found"`
