### PR TITLE
[v0.14.x] Allow dnsmasq to be backed by a local copy of CoreDNS

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1359,6 +1359,9 @@ kubeDns:
   # nodeLocalResolverOptions:
   # - --neg-ttl=10
   # - --no-ping
+  # When enabled, this will run a copy of CoreDNS within each DNS-masq pod and
+  # configure the utility to use it for resolution.
+  # coreDNSLocal: false
 
   # When enabled, will modify the TTL of the coredns service.
   # ttl: 30
@@ -1381,6 +1384,8 @@ kubeDns:
   #
   # This configuration is injected into the CoreDNS config map after the root
   # zone (".") and can be used to add configuration for additional zones.
+  # If corednsLocal has been enabled, this configuration will additionally be injected
+  # into its ConfigMap.
   # additionalZoneCoreDNSConfig: |
   #  global:53 {
   #      errors

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1359,9 +1359,13 @@ kubeDns:
   # nodeLocalResolverOptions:
   # - --neg-ttl=10
   # - --no-ping
-  # When enabled, this will run a copy of CoreDNS within each DNS-masq pod and
-  # configure the utility to use it for resolution.
-  # coreDNSLocal: false
+
+  # Settings for the dnsmasq-node DaemonSet which must be enabled by setting
+  # `kubeDns.nodeLocalResolver` to true.
+  dnsmasq:
+    # When enabled, this will run a copy of CoreDNS within each DNS-masq pod and
+    # configure the utility to use it for resolution.
+    coreDNSLocal: false
 
   # When enabled, will modify the TTL of the coredns service.
   # ttl: 30

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1363,9 +1363,16 @@ kubeDns:
   # Settings for the dnsmasq-node DaemonSet which must be enabled by setting
   # `kubeDns.nodeLocalResolver` to true.
   dnsmasq:
-    # When enabled, this will run a copy of CoreDNS within each DNS-masq pod and
-    # configure the utility to use it for resolution.
-    enableCoreDNSLocal: false
+    coreDNSLocal:
+      # When enabled, this will run a copy of CoreDNS within each DNS-masq pod and
+      # configure the utility to use it for resolution.
+      enabled: false
+
+      # Defines the resource limits for the coredns-local container. Either limit
+      # can be disabled by setting it to an empty string.
+      limits:
+        cpu: 50m
+        memory: 100Mi
 
     # The size of dnsmasq's cache.
     cacheSize: 50000

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1368,11 +1368,16 @@ kubeDns:
       # configure the utility to use it for resolution.
       enabled: false
 
-      # Defines the resource limits for the coredns-local container. Either limit
-      # can be disabled by setting it to an empty string.
-      limits:
-        cpu: 50m
-        memory: 100Mi
+      # Defines the resource requests/limits for the coredns-local container.
+      # cpu and/or memory constraints can be removed by setting the appropriate value(s)
+      # to an empty string.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 100Mi
+        limits:
+          cpu: 50m
+          memory: 100Mi
 
     # The size of dnsmasq's cache.
     cacheSize: 50000

--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1365,7 +1365,17 @@ kubeDns:
   dnsmasq:
     # When enabled, this will run a copy of CoreDNS within each DNS-masq pod and
     # configure the utility to use it for resolution.
-    coreDNSLocal: false
+    enableCoreDNSLocal: false
+
+    # The size of dnsmasq's cache.
+    cacheSize: 50000
+
+    # The maximum number of concurrent DNS queries.
+    dnsForwardMax: 500
+
+    # This option gives a default value for time-to-live (in seconds) which dnsmasq
+    # uses to cache negative replies even in the absence of an SOA record.
+    # negTTL: 60
 
   # When enabled, will modify the TTL of the coredns service.
   # ttl: 30

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4214,13 +4214,19 @@ write_files:
                 resources:
                   requests:
                     ephemeral-storage: 256Mi
-                  {{ if or .KubeDns.DNSMasq.CoreDNSLocal.Limits.CPU .KubeDns.DNSMasq.CoreDNSLocal.Limits.Memory }}
-                  limits:
-                    {{ if .KubeDns.DNSMasq.CoreDNSLocal.Limits.CPU }}
-                    cpu: {{ .KubeDns.DNSMasq.CoreDNSLocal.Limits.CPU }}
+                    {{ if .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Requests.Cpu }}
+                    cpu: {{ .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Requests.Cpu }}
                     {{ end }}
-                    {{ if .KubeDns.DNSMasq.CoreDNSLocal.Limits.Memory }}
-                    memory: {{ .KubeDns.DNSMasq.CoreDNSLocal.Limits.Memory }}
+                    {{ if .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Requests.Memory }}
+                    memory: {{ .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Requests.Memory }}
+                    {{ end }}
+                  {{ if or .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Cpu .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Memory }}
+                  limits:
+                    {{ if .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Cpu }}
+                    cpu: {{ .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Cpu }}
+                    {{ end }}
+                    {{ if .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Memory }}
+                    memory: {{ .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Memory }}
                     {{ end }}
                   {{ end }}
               {{ end }}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3969,6 +3969,85 @@ write_files:
                   - --v=2
                   - --logtostderr
 
+{{ if and .KubeDns.NodeLocalResolver .KubeDns.CoreDNSLocal }}
+  - path: /srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml
+    content: |
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: dnsmasq
+          namespace: kube-system
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: dnsmasq
+        rules:
+          - apiGroups: [""]
+            resources: ["endpoints", "services", "pods", "namespaces"]
+            verbs: ["list", "watch"]
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: dnsmasq
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: dnsmasq
+        subjects:
+          - kind: ServiceAccount
+            name: dnsmasq
+            namespace: kube-system
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: dnsmasq-privileged-psp
+          namespace: kube-system
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: privileged-psp
+        subjects:
+          - kind: ServiceAccount
+            name: dnsmasq
+            namespace: kube-system
+        ---
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: coredns-local
+          namespace: kube-system
+          labels:
+            application: coredns
+        data:
+          Corefile: |
+            cluster.local:9254 {{ .PodCIDR }}:9254 {{ .ServiceCIDR }}:9254 {
+                errors
+                kubernetes {
+                    pods insecure
+                }
+                cache 30
+                log svc.svc.cluster.local.
+                prometheus :9153
+            }
+
+            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
+            {{- end }}
+
+            .:9254 {
+                errors
+                health :9154 # this is global for all servers
+                prometheus :9153
+                forward . /etc/resolv.conf
+                pprof 127.0.0.1:9156
+                cache 30
+                reload
+            }
+{{ end }}
+
 {{ if .KubeDns.NodeLocalResolver }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-ds.yaml
     content: |
@@ -3980,9 +4059,12 @@ write_files:
           labels:
             k8s-app: dnsmasq-node
         spec:
+          selector:
+            matchLabels:
+              k8s-app: dnsmasq-node
           updateStrategy:
             rollingUpdate:
-              maxUnavailable: 100%
+              maxUnavailable: 10%
             type: RollingUpdate
           template:
             metadata:
@@ -3997,22 +4079,29 @@ write_files:
                 effect: NoSchedule
               - operator: Exists
                 effect: NoExecute
-              - operator: Exists
-                key: CriticalAddonsOnly
               volumes:
               - name: kube-dns-config
                 configMap:
                   name: kube-dns
                   optional: true
+              {{ if .KubeDns.CoreDNSLocal }}
+              - name: coredns-local-config
+                configMap:
+                  name: coredns-local
+                  items:
+                    - key: Corefile
+                      path: Corefile
+              {{ end }}
               containers:
               - name: dnsmasq
                 image: {{ .KubeDnsMasqImage.RepoWithTag }}
                 livenessProbe:
                   httpGet:
                     path: /healthcheck/dnsmasq
-                    port: 10054
+                    port: 9054
                     scheme: HTTP
                   initialDelaySeconds: 60
+                  periodSeconds: 10
                   timeoutSeconds: 5
                   successThreshold: 1
                   failureThreshold: 5
@@ -4023,13 +4112,24 @@ write_files:
                 - -restartDnsmasq=true
                 - --
                 - -k
-                - --min-port=1024
-                - --cache-size=1000
+                - --cache-size=50000
+                - --dns-forward-max=500
+                - --log-facility=-
+                {{ if .KubeDns.CoreDNSLocal }}
+                - --no-resolv
+                - --keep-in-foreground
+                - --neg-ttl=60
+                # Send requests to the last server (coredns-local) first and only
+                # fallback to the previous one (global coredns) if it's unreachable.
+                - --strict-order
+                - --server={{.DNSServiceIP}}#53
+                - --server=127.0.0.1#9254
+                {{ else }}
                 - --server=//{{.DNSServiceIP}}
                 - --server=/cluster.local/{{.DNSServiceIP}}
                 - --server=/in-addr.arpa/{{.DNSServiceIP}}
                 - --server=/ip6.arpa/{{.DNSServiceIP}}
-                - --log-facility=-
+                {{ end }}
                 {{- if ne (len .KubeDns.NodeLocalResolverOptions) 0 }}
                   {{- range .KubeDns.NodeLocalResolverOptions }}
                 - {{.}}
@@ -4044,9 +4144,11 @@ write_files:
                   protocol: TCP
                 # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
                 resources:
+                  limits:
+                    cpu: 100m
+                    memory: 50Mi
                   requests:
-                    cpu: 150m
-                    memory: 20Mi
+                    ephemeral-storage: 256Mi
                 volumeMounts:
                 - name: kube-dns-config
                   mountPath: /etc/k8s/dns/dnsmasq-nanny
@@ -4055,7 +4157,7 @@ write_files:
                 livenessProbe:
                   httpGet:
                     path: /metrics
-                    port: 10054
+                    port: 9054
                     scheme: HTTP
                   initialDelaySeconds: 60
                   timeoutSeconds: 5
@@ -4064,17 +4166,58 @@ write_files:
                 args:
                 - --v=2
                 - --logtostderr
+                {{ if .KubeDns.CoreDNSLocal }}
+                - --probe=dnsmasq,127.0.0.1:9254,ec2.amazonaws.com,5,A
+                {{ else }}
                 - --probe=dnsmasq,127.0.0.1:53,ec2.amazonaws.com,5,A
+                {{ end }}
+                - --prometheus-port=9054
                 ports:
-                - containerPort: 10054
+                - containerPort: 9054
                   name: metrics
                   protocol: TCP
                 resources:
                   requests:
-                    memory: 20Mi
+                    ephemeral-storage: 256Mi
+                  limits:
+                    cpu: 10m
+                    memory: 45Mi
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              {{ if .KubeDns.CoreDNSLocal }}
+              - name: coredns
+                image: {{ .CoreDnsImage.RepoWithTag }}
+                args: ["-conf", "/etc/coredns/Corefile"]
+                volumeMounts:
+                  - name: coredns-local-config
+                    mountPath: /etc/coredns
+                ports:
+                  - containerPort: 9254
+                    name: dns
+                    protocol: UDP
+                  - containerPort: 9254
+                    name: dns-tcp
+                    protocol: TCP
+                livenessProbe:
+                  httpGet:
+                    path: /health
+                    port: 9154
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                  timeoutSeconds: 5
+                  successThreshold: 1
+                  failureThreshold: 5
+                resources:
+                  requests:
+                    ephemeral-storage: 256Mi
+                  limits:
+                    cpu: 50m
+                    memory: 100Mi
+              {{ end }}
               hostNetwork: true
               dnsPolicy: Default
-              automountServiceAccountToken: false
+              automountServiceAccountToken: true
+              serviceAccountName: dnsmasq
 {{ end }}
 
 {{- if eq .KubeDns.Provider "coredns" }}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1058,6 +1058,9 @@ write_files:
         "${mfdir}/kube-dns-de.yaml"
       {{- end }}
       {{ if .KubeDns.NodeLocalResolver -}}
+      {{ if .KubeDns.dnsmasq.EnableCoreDNSLocal -}}
+      deploy "${mfdir}/dnsmasq-node-coredns-local.yaml"
+      {{ end -}}
       deploy "${mfdir}/dnsmasq-node-ds.yaml"
       {{ end -}}
       forceapply "${mfdir}/kube-dns-pdb.yaml"

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3882,6 +3882,10 @@ write_files:
           namespace: kube-system
         data:
           Corefile: |
+            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
+            {{- end }}
+
             .:53 {
                 errors
                 health
@@ -3904,9 +3908,6 @@ write_files:
                 reload
                 loadbalance
             }
-            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
-{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
-            {{- end }}
 {{- else }}
   - path: /srv/kubernetes/manifests/kube-dns-sa.yaml
     content: |
@@ -4023,6 +4024,10 @@ write_files:
             application: coredns
         data:
           Corefile: |
+            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
+            {{- end }}
+
             cluster.local:9254 {{ .PodCIDR }}:9254 {{ .ServiceCIDR }}:9254 {
                 errors
                 kubernetes {
@@ -4032,10 +4037,6 @@ write_files:
                 log svc.svc.cluster.local.
                 prometheus :9153
             }
-
-            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
-{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
-            {{- end }}
 
             .:9254 {
                 errors

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3970,7 +3970,7 @@ write_files:
                   - --v=2
                   - --logtostderr
 
-{{ if and .KubeDns.NodeLocalResolver .KubeDns.DNSMasq.CoreDNSLocal }}
+{{ if and .KubeDns.NodeLocalResolver .KubeDns.DNSMasq.EnableCoreDNSLocal }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml
     content: |
         apiVersion: v1
@@ -4085,7 +4085,7 @@ write_files:
                 configMap:
                   name: kube-dns
                   optional: true
-              {{ if .KubeDns.DNSMasq.CoreDNSLocal }}
+              {{ if .KubeDns.DNSMasq.EnableCoreDNSLocal }}
               - name: coredns-local-config
                 configMap:
                   name: coredns-local
@@ -4113,13 +4113,13 @@ write_files:
                 - -restartDnsmasq=true
                 - --
                 - -k
-                - --cache-size=50000
-                - --dns-forward-max=500
+                - --cache-size={{ .KubeDns.DNSMasq.CacheSize }}
+                - --dns-forward-max={{ .KubeDns.DNSMasq.DNSForwardMax }}
                 - --log-facility=-
-                {{ if .KubeDns.DNSMasq.CoreDNSLocal }}
+                {{ if .KubeDns.DNSMasq.EnableCoreDNSLocal }}
                 - --no-resolv
                 - --keep-in-foreground
-                - --neg-ttl=60
+                - --neg-ttl={{ .KubeDns.DNSMasq.NegTTL }}
                 # Send requests to the last server (coredns-local) first and only
                 # fallback to the previous one (global coredns) if it's unreachable.
                 - --strict-order
@@ -4167,7 +4167,7 @@ write_files:
                 args:
                 - --v=2
                 - --logtostderr
-                {{ if .KubeDns.DNSMasq.CoreDNSLocal }}
+                {{ if .KubeDns.DNSMasq.EnableCoreDNSLocal }}
                 - --probe=dnsmasq,127.0.0.1:9254,ec2.amazonaws.com,5,A
                 {{ else }}
                 - --probe=dnsmasq,127.0.0.1:53,ec2.amazonaws.com,5,A
@@ -4185,7 +4185,7 @@ write_files:
                     memory: 45Mi
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
-              {{ if .KubeDns.DNSMasq.CoreDNSLocal }}
+              {{ if .KubeDns.DNSMasq.EnableCoreDNSLocal }}
               - name: coredns
                 image: {{ .CoreDnsImage.RepoWithTag }}
                 args: ["-conf", "/etc/coredns/Corefile"]

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3970,7 +3970,7 @@ write_files:
                   - --v=2
                   - --logtostderr
 
-{{ if and .KubeDns.NodeLocalResolver .KubeDns.CoreDNSLocal }}
+{{ if and .KubeDns.NodeLocalResolver .KubeDns.DNSMasq.CoreDNSLocal }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml
     content: |
         apiVersion: v1
@@ -4085,7 +4085,7 @@ write_files:
                 configMap:
                   name: kube-dns
                   optional: true
-              {{ if .KubeDns.CoreDNSLocal }}
+              {{ if .KubeDns.DNSMasq.CoreDNSLocal }}
               - name: coredns-local-config
                 configMap:
                   name: coredns-local
@@ -4116,7 +4116,7 @@ write_files:
                 - --cache-size=50000
                 - --dns-forward-max=500
                 - --log-facility=-
-                {{ if .KubeDns.CoreDNSLocal }}
+                {{ if .KubeDns.DNSMasq.CoreDNSLocal }}
                 - --no-resolv
                 - --keep-in-foreground
                 - --neg-ttl=60
@@ -4167,7 +4167,7 @@ write_files:
                 args:
                 - --v=2
                 - --logtostderr
-                {{ if .KubeDns.CoreDNSLocal }}
+                {{ if .KubeDns.DNSMasq.CoreDNSLocal }}
                 - --probe=dnsmasq,127.0.0.1:9254,ec2.amazonaws.com,5,A
                 {{ else }}
                 - --probe=dnsmasq,127.0.0.1:53,ec2.amazonaws.com,5,A
@@ -4185,7 +4185,7 @@ write_files:
                     memory: 45Mi
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
-              {{ if .KubeDns.CoreDNSLocal }}
+              {{ if .KubeDns.DNSMasq.CoreDNSLocal }}
               - name: coredns
                 image: {{ .CoreDnsImage.RepoWithTag }}
                 args: ["-conf", "/etc/coredns/Corefile"]

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1060,6 +1060,8 @@ write_files:
       {{ if .KubeDns.NodeLocalResolver -}}
       {{ if .KubeDns.dnsmasq.CoreDNSLocal.Enabled -}}
       deploy "${mfdir}/dnsmasq-node-coredns-local.yaml"
+      {{- else }}
+      remove "${mfdir}/dnsmasq-node-coredns-local.yaml"
       {{ end -}}
       deploy "${mfdir}/dnsmasq-node-ds.yaml"
       {{ end -}}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1058,7 +1058,7 @@ write_files:
         "${mfdir}/kube-dns-de.yaml"
       {{- end }}
       {{ if .KubeDns.NodeLocalResolver -}}
-      {{ if .KubeDns.dnsmasq.EnableCoreDNSLocal -}}
+      {{ if .KubeDns.dnsmasq.CoreDNSLocal.Enabled -}}
       deploy "${mfdir}/dnsmasq-node-coredns-local.yaml"
       {{ end -}}
       deploy "${mfdir}/dnsmasq-node-ds.yaml"
@@ -3973,7 +3973,7 @@ write_files:
                   - --v=2
                   - --logtostderr
 
-{{ if and .KubeDns.NodeLocalResolver .KubeDns.DNSMasq.EnableCoreDNSLocal }}
+{{ if and .KubeDns.NodeLocalResolver .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml
     content: |
         apiVersion: v1
@@ -4088,7 +4088,7 @@ write_files:
                 configMap:
                   name: kube-dns
                   optional: true
-              {{ if .KubeDns.DNSMasq.EnableCoreDNSLocal }}
+              {{ if .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
               - name: coredns-local-config
                 configMap:
                   name: coredns-local
@@ -4119,7 +4119,7 @@ write_files:
                 - --cache-size={{ .KubeDns.DNSMasq.CacheSize }}
                 - --dns-forward-max={{ .KubeDns.DNSMasq.DNSForwardMax }}
                 - --log-facility=-
-                {{ if .KubeDns.DNSMasq.EnableCoreDNSLocal }}
+                {{ if .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
                 - --no-resolv
                 - --keep-in-foreground
                 - --neg-ttl={{ .KubeDns.DNSMasq.NegTTL }}
@@ -4170,7 +4170,7 @@ write_files:
                 args:
                 - --v=2
                 - --logtostderr
-                {{ if .KubeDns.DNSMasq.EnableCoreDNSLocal }}
+                {{ if .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
                 - --probe=dnsmasq,127.0.0.1:9254,ec2.amazonaws.com,5,A
                 {{ else }}
                 - --probe=dnsmasq,127.0.0.1:53,ec2.amazonaws.com,5,A
@@ -4188,7 +4188,7 @@ write_files:
                     memory: 45Mi
                 terminationMessagePath: /dev/termination-log
                 terminationMessagePolicy: File
-              {{ if .KubeDns.DNSMasq.EnableCoreDNSLocal }}
+              {{ if .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
               - name: coredns
                 image: {{ .CoreDnsImage.RepoWithTag }}
                 args: ["-conf", "/etc/coredns/Corefile"]
@@ -4214,9 +4214,15 @@ write_files:
                 resources:
                   requests:
                     ephemeral-storage: 256Mi
+                  {{ if or .KubeDns.DNSMasq.CoreDNSLocal.Limits.CPU .KubeDns.DNSMasq.CoreDNSLocal.Limits.Memory }}
                   limits:
-                    cpu: 50m
-                    memory: 100Mi
+                    {{ if .KubeDns.DNSMasq.CoreDNSLocal.Limits.CPU }}
+                    cpu: {{ .KubeDns.DNSMasq.CoreDNSLocal.Limits.CPU }}
+                    {{ end }}
+                    {{ if .KubeDns.DNSMasq.CoreDNSLocal.Limits.Memory }}
+                    memory: {{ .KubeDns.DNSMasq.CoreDNSLocal.Limits.Memory }}
+                    {{ end }}
+                  {{ end }}
               {{ end }}
               hostNetwork: true
               dnsPolicy: Default

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -161,9 +161,11 @@ func NewDefaultCluster() *Cluster {
 				IPVSMode: ipvsMode,
 			},
 			KubeDns: KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
-				CoreDNSLocal:                 false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: DNSMasq{
+					CoreDNSLocal: false,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -163,6 +163,7 @@ func NewDefaultCluster() *Cluster {
 			KubeDns: KubeDns{
 				Provider:                     "coredns",
 				NodeLocalResolver:            false,
+				CoreDNSLocal:                 false,
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -164,10 +164,16 @@ func NewDefaultCluster() *Cluster {
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: CoreDNSLocal{
+						Enabled: false,
+						Limits: CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -166,9 +166,15 @@ func NewDefaultCluster() *Cluster {
 				DNSMasq: DNSMasq{
 					CoreDNSLocal: CoreDNSLocal{
 						Enabled: false,
-						Limits: CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: ComputeResources{
+							Requests: ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -164,7 +164,10 @@ func NewDefaultCluster() *Cluster {
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: DNSMasq{
-					CoreDNSLocal: false,
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -209,14 +209,9 @@ type IPVSMode struct {
 	MinSyncPeriod string `yaml:"minSyncPeriod"`
 }
 
-type CoreDNSLocalLimits struct {
-	CPU    string `yaml:"cpu"`
-	Memory string `yaml:"memory"`
-}
-
 type CoreDNSLocal struct {
-	Enabled bool               `yaml:"enabled"`
-	Limits  CoreDNSLocalLimits `yaml:"limits"`
+	Enabled          bool             `yaml:"enabled"`
+	ComputeResources ComputeResources `yaml:"resources,omitempty"`
 }
 
 type DNSMasq struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -219,6 +219,7 @@ type KubeDns struct {
 	Provider                     string            `yaml:"provider"`
 	NodeLocalResolver            bool              `yaml:"nodeLocalResolver"`
 	NodeLocalResolverOptions     []string          `yaml:"nodeLocalResolverOptions"`
+	CoreDNSLocal                 bool              `yaml:"coreDNSLocal"`
 	DeployToControllers          bool              `yaml:"deployToControllers"`
 	AntiAffinityAvailabilityZone bool              `yaml:"antiAffinityAvailabilityZone"`
 	TTL                          int               `yaml:"ttl"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -209,6 +209,10 @@ type IPVSMode struct {
 	MinSyncPeriod string `yaml:"minSyncPeriod"`
 }
 
+type DnsMasq struct {
+	CoreDNSLocal bool `yaml:"coreDNSLocal"`
+}
+
 type KubeDnsAutoscaler struct {
 	CoresPerReplica int `yaml:"coresPerReplica"`
 	NodesPerReplica int `yaml:"nodesPerReplica"`
@@ -219,7 +223,7 @@ type KubeDns struct {
 	Provider                     string            `yaml:"provider"`
 	NodeLocalResolver            bool              `yaml:"nodeLocalResolver"`
 	NodeLocalResolverOptions     []string          `yaml:"nodeLocalResolverOptions"`
-	CoreDNSLocal                 bool              `yaml:"coreDNSLocal"`
+	DNSMasq                      DNSMasq           `yaml:"dnsmasq"`
 	DeployToControllers          bool              `yaml:"deployToControllers"`
 	AntiAffinityAvailabilityZone bool              `yaml:"antiAffinityAvailabilityZone"`
 	TTL                          int               `yaml:"ttl"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -209,8 +209,11 @@ type IPVSMode struct {
 	MinSyncPeriod string `yaml:"minSyncPeriod"`
 }
 
-type DnsMasq struct {
-	CoreDNSLocal bool `yaml:"coreDNSLocal"`
+type DNSMasq struct {
+	EnableCoreDNSLocal bool `yaml:"enableCoreDNSLocal"`
+	CacheSize          int  `yaml:"cacheSize"`
+	DNSForwardMax      int  `yaml:"dnsForwardMax"`
+	NegTTL             int  `yaml:"negTTL"`
 }
 
 type KubeDnsAutoscaler struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -209,11 +209,21 @@ type IPVSMode struct {
 	MinSyncPeriod string `yaml:"minSyncPeriod"`
 }
 
+type CoreDNSLocalLimits struct {
+	CPU    string `yaml:"cpu"`
+	Memory string `yaml:"memory"`
+}
+
+type CoreDNSLocal struct {
+	Enabled bool               `yaml:"enabled"`
+	Limits  CoreDNSLocalLimits `yaml:"limits"`
+}
+
 type DNSMasq struct {
-	EnableCoreDNSLocal bool `yaml:"enableCoreDNSLocal"`
-	CacheSize          int  `yaml:"cacheSize"`
-	DNSForwardMax      int  `yaml:"dnsForwardMax"`
-	NegTTL             int  `yaml:"negTTL"`
+	CoreDNSLocal  CoreDNSLocal `yaml:"coreDNSLocal"`
+	CacheSize     int          `yaml:"cacheSize"`
+	DNSForwardMax int          `yaml:"dnsForwardMax"`
+	NegTTL        int          `yaml:"negTTL"`
 }
 
 type KubeDnsAutoscaler struct {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1124,9 +1124,15 @@ func TestKubeDns(t *testing.T) {
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,
@@ -1165,9 +1171,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,
@@ -1206,9 +1218,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,
@@ -1247,9 +1265,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,
@@ -1292,9 +1316,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,
@@ -1328,9 +1358,13 @@ kubeDns:
   dnsmasq:
     coreDNSLocal:
       enabled: true
-      limits:
-        cpu: ""
-        memory: ""
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "2000Mi"
+        limits:
+          cpu: ""
+          memory: ""
     cacheSize: 500
     dnsForwardMax: 100
     negTTL: 10
@@ -1341,9 +1375,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: true,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "",
-							Memory: "",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "100m",
+								Memory: "2000Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "",
+								Memory: "",
+							},
 						},
 					},
 					CacheSize:     500,
@@ -1381,9 +1421,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,
@@ -1428,9 +1474,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,
@@ -1468,9 +1520,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,
@@ -1509,9 +1567,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,
@@ -1551,9 +1615,15 @@ kubeDns:
 				DNSMasq: api.DNSMasq{
 					CoreDNSLocal: api.CoreDNSLocal{
 						Enabled: false,
-						Limits: api.CoreDNSLocalLimits{
-							CPU:    "50m",
-							Memory: "100Mi",
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
 						},
 					},
 					CacheSize:     50000,

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1121,6 +1121,7 @@ func TestKubeDns(t *testing.T) {
 			kubeDns: api.KubeDns{
 				Provider:                     "coredns",
 				NodeLocalResolver:            false,
+				CoreDNSLocal:                 false,
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1145,11 +1146,13 @@ func TestKubeDns(t *testing.T) {
 			conf: `
 kubeDns:
   nodeLocalResolver: false
+  coreDNSLocall: false
   deployToControllers: false
 `,
 			kubeDns: api.KubeDns{
 				Provider:                     "coredns",
 				NodeLocalResolver:            false,
+				CoreDNSLocal:                 false,
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1259,6 +1262,18 @@ kubeDns:
 						Cpu:    "200m",
 					},
 				},
+			},
+		},
+		{
+			conf: `
+kubeDns:
+  nodeLocalResolver: true
+  coreDNSLocal: true
+`,
+			kubeDns: api.KubeDns{
+				Provider:          "coredns",
+				NodeLocalResolver: true,
+				CoreDNSLocal:      true,
 			},
 		},
 		{

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1119,9 +1119,11 @@ func TestKubeDns(t *testing.T) {
 			conf: `
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
-				CoreDNSLocal:                 false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSmasq{
+					CoreDNSLocal: false,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1146,13 +1148,16 @@ func TestKubeDns(t *testing.T) {
 			conf: `
 kubeDns:
   nodeLocalResolver: false
-  coreDNSLocall: false
+  dnsmasq:
+	coreDNSLocall: false
   deployToControllers: false
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
-				CoreDNSLocal:                 false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: false,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1268,12 +1273,15 @@ kubeDns:
 			conf: `
 kubeDns:
   nodeLocalResolver: true
-  coreDNSLocal: true
+  dnsmasq:
+	coreDNSLocal: true
 `,
 			kubeDns: api.KubeDns{
 				Provider:          "coredns",
 				NodeLocalResolver: true,
-				CoreDNSLocal:      true,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: true,
+				},
 			},
 		},
 		{

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1121,8 +1121,11 @@ func TestKubeDns(t *testing.T) {
 			kubeDns: api.KubeDns{
 				Provider:          "coredns",
 				NodeLocalResolver: false,
-				DNSMasq: api.DNSmasq{
-					CoreDNSLocal: false,
+				DNSMasq: api.DNSMasq{
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
@@ -1148,15 +1151,16 @@ func TestKubeDns(t *testing.T) {
 			conf: `
 kubeDns:
   nodeLocalResolver: false
-  dnsmasq:
-	coreDNSLocall: false
   deployToControllers: false
 `,
 			kubeDns: api.KubeDns{
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					CoreDNSLocal: false,
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
@@ -1185,8 +1189,14 @@ kubeDns:
   antiAffinityAvailabilityZone: true
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: true,
 				TTL:                          30,
@@ -1214,8 +1224,14 @@ kubeDns:
   antiAffinityAvailabilityZone: true
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
+				},
 				DeployToControllers:          true,
 				AntiAffinityAvailabilityZone: true,
 				TTL:                          30,
@@ -1247,8 +1263,14 @@ kubeDns:
     min: 15
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            true,
+				Provider:          "coredns",
+				NodeLocalResolver: true,
+				DNSMasq: api.DNSMasq{
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
+				},
 				DeployToControllers:          true,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1274,13 +1296,37 @@ kubeDns:
 kubeDns:
   nodeLocalResolver: true
   dnsmasq:
-	coreDNSLocal: true
+    enableCoreDNSLocal: true
+    cacheSize: 500
+    dnsForwardMax: 100
+    negTTL: 10
 `,
 			kubeDns: api.KubeDns{
 				Provider:          "coredns",
 				NodeLocalResolver: true,
 				DNSMasq: api.DNSMasq{
-					CoreDNSLocal: true,
+					EnableCoreDNSLocal: true,
+					CacheSize:          500,
+					DNSForwardMax:      100,
+					NegTTL:             10,
+				},
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
+				Autoscaler: api.KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+				DnsDeploymentResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
 				},
 			},
 		},
@@ -1290,8 +1336,14 @@ kubeDns:
   provider: coredns
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1325,8 +1377,14 @@ kubeDns:
       memory: "250Mi"
 `,
 			kubeDns: api.KubeDns{
-				Provider:            "coredns",
-				NodeLocalResolver:   false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
+				},
 				DeployToControllers: false,
 				TTL:                 30,
 				Autoscaler: api.KubeDnsAutoscaler{
@@ -1353,8 +1411,14 @@ kubeDns:
   ttl: 5
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          5,
@@ -1382,8 +1446,14 @@ kubeDns:
   extraCoreDNSConfig: rewrite name substring demo.app.org app.default.svc.cluster.local
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1412,8 +1482,14 @@ kubeDns:
   additionalZoneCoreDNSConfig: global:53 { forward . 1.2.3.4 }
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					EnableCoreDNSLocal: false,
+					CacheSize:          50000,
+					DNSForwardMax:      500,
+					NegTTL:             60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1122,10 +1122,16 @@ func TestKubeDns(t *testing.T) {
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
@@ -1157,10 +1163,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
@@ -1192,10 +1204,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: true,
@@ -1227,10 +1245,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          true,
 				AntiAffinityAvailabilityZone: true,
@@ -1266,10 +1290,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: true,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          true,
 				AntiAffinityAvailabilityZone: false,
@@ -1296,7 +1326,11 @@ kubeDns:
 kubeDns:
   nodeLocalResolver: true
   dnsmasq:
-    enableCoreDNSLocal: true
+    coreDNSLocal:
+      enabled: true
+      limits:
+        cpu: ""
+        memory: ""
     cacheSize: 500
     dnsForwardMax: 100
     negTTL: 10
@@ -1305,10 +1339,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: true,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: true,
-					CacheSize:          500,
-					DNSForwardMax:      100,
-					NegTTL:             10,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: true,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "",
+							Memory: "",
+						},
+					},
+					CacheSize:     500,
+					DNSForwardMax: 100,
+					NegTTL:        10,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
@@ -1339,10 +1379,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
@@ -1380,10 +1426,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers: false,
 				TTL:                 30,
@@ -1414,10 +1466,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
@@ -1449,10 +1507,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
@@ -1485,10 +1549,16 @@ kubeDns:
 				Provider:          "coredns",
 				NodeLocalResolver: false,
 				DNSMasq: api.DNSMasq{
-					EnableCoreDNSLocal: false,
-					CacheSize:          50000,
-					DNSForwardMax:      500,
-					NegTTL:             60,
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						Limits: api.CoreDNSLocalLimits{
+							CPU:    "50m",
+							Memory: "100Mi",
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
 				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,


### PR DESCRIPTION
This commit allows the user to specify that dnsmasq should be backed by a pod-local copy of CoreDNS rather than relying on the global CoreDNS service. If enabled, the dnsmasq-node DaemonSet will be configured to use a local copy of CoreDNS for its resolution while setting the global CoreDNS service as a fallback. This is handy in situations where the number of DNS requests within a cluster grows large and causes resolution issues as dnsmasq reaches out to the global CoreDNS service.

Additionally, several values passed to dnsmasq are now configurable, including its `--cache-size` and `--dns-forward-max`.

See [this postmortem](https://github.com/zalando-incubator/kubernetes-on-aws/blob/dev/docs/postmortems/jan-2019-dns-outage.md) for an investigation into this situation which was instrumental in understanding issues we were facing. Many thanks to @dominicgunn for providing the manifests which I codified into this commit.

---

These features can be enabled and tuned by setting the following values within cluster.yaml:

```yaml
kubeDns:
  dnsmasq:
    coreDNSLocal:
      # When enabled, this will run a copy of CoreDNS within each DNS-masq pod and
      # configure the utility to use it for resolution.
      enabled: true

      # Defines the resource requests/limits for the coredns-local container.
      # cpu and/or memory constraints can be removed by setting the appropriate value(s)
      # to an empty string.
      resources:
        requests:
          cpu: 50m
          memory: 100Mi
        limits:
          cpu: 50m
          memory: 100Mi

    # The size of dnsmasq's cache.
    cacheSize: 50000

    # The maximum number of concurrent DNS queries.
    dnsForwardMax: 500

    # This option gives a default value for time-to-live (in seconds) which dnsmasq
    # uses to cache negative replies even in the absence of an SOA record.
    negTTL: 60
```