### PR TITLE
[v0.16.x] Fix etcd certificates when using private zones

### DIFF
--- a/pkg/model/etcd_cluster.go
+++ b/pkg/model/etcd_cluster.go
@@ -45,7 +45,7 @@ func (c EtcdCluster) DNSNames() []string {
 			dnsName = fmt.Sprintf("*.%s", c.region.PrivateDomainName())
 		}
 	}
-	return []string{dnsName}
+	return []string{dnsName, fmt.Sprintf("*.%s", c.region.PrivateDomainName())}
 }
 
 func (c EtcdCluster) LogicalName() string {

--- a/pkg/model/etcd_cluster.go
+++ b/pkg/model/etcd_cluster.go
@@ -45,7 +45,12 @@ func (c EtcdCluster) DNSNames() []string {
 			dnsName = fmt.Sprintf("*.%s", c.region.PrivateDomainName())
 		}
 	}
-	return []string{dnsName, fmt.Sprintf("*.%s", c.region.PrivateDomainName())}
+
+	privateDomainSan := fmt.Sprintf("*.%s", c.region.PrivateDomainName())
+	if dnsName != privateDomainSan && c.GetMemberIdentityProvider() == api.MemberIdentityProviderENI {
+		return []string{dnsName, privateDomainSan}
+	}
+	return []string{dnsName}
 }
 
 func (c EtcdCluster) LogicalName() string {

--- a/pkg/model/etcd_cluster_test.go
+++ b/pkg/model/etcd_cluster_test.go
@@ -22,7 +22,7 @@ func TestEtcdClusterDNSNames(t *testing.T) {
 				actual := cluster.DNSNames()
 				expected := []string{"*.ec2.internal"}
 				if !reflect.DeepEqual(actual, expected) {
-					t.Errorf("invalid dns names: expecetd=%v, got=%v", expected, actual)
+					t.Errorf("invalid dns names: expected=%v, got=%v", expected, actual)
 				}
 			})
 			t.Run("us-west-1", func(t *testing.T) {
@@ -30,7 +30,7 @@ func TestEtcdClusterDNSNames(t *testing.T) {
 				actual := cluster.DNSNames()
 				expected := []string{"*.us-west-1.compute.internal"}
 				if !reflect.DeepEqual(actual, expected) {
-					t.Errorf("invalid dns names: expecetd=%v, got=%v", expected, actual)
+					t.Errorf("invalid dns names: expected=%v, got=%v", expected, actual)
 				}
 			})
 		})
@@ -42,17 +42,17 @@ func TestEtcdClusterDNSNames(t *testing.T) {
 			t.Run("us-east-1", func(t *testing.T) {
 				cluster := NewEtcdCluster(config, usEast1, etcdNet, etcdCount)
 				actual := cluster.DNSNames()
-				expected := []string{"*.internal.example.com"}
+				expected := []string{"*.internal.example.com", "*.ec2.internal"}
 				if !reflect.DeepEqual(actual, expected) {
-					t.Errorf("invalid dns names: expecetd=%v, got=%v", expected, actual)
+					t.Errorf("invalid dns names: expected=%v, got=%v", expected, actual)
 				}
 			})
 			t.Run("us-west-1", func(t *testing.T) {
 				cluster := NewEtcdCluster(config, usWest1, etcdNet, etcdCount)
 				actual := cluster.DNSNames()
-				expected := []string{"*.internal.example.com"}
+				expected := []string{"*.internal.example.com", "*.us-west-1.compute.internal"}
 				if !reflect.DeepEqual(actual, expected) {
-					t.Errorf("invalid dns names: expecetd=%v, got=%v", expected, actual)
+					t.Errorf("invalid dns names: expected=%v, got=%v", expected, actual)
 				}
 			})
 		})
@@ -67,7 +67,7 @@ func TestEtcdClusterDNSNames(t *testing.T) {
 			actual := cluster.DNSNames()
 			expected := []string{"*.compute-1.amazonaws.com"}
 			if !reflect.DeepEqual(actual, expected) {
-				t.Errorf("invalid dns names: expecetd=%v, got=%v", expected, actual)
+				t.Errorf("invalid dns names: expected=%v, got=%v", expected, actual)
 			}
 		})
 		t.Run("us-west-1", func(t *testing.T) {
@@ -75,7 +75,7 @@ func TestEtcdClusterDNSNames(t *testing.T) {
 			actual := cluster.DNSNames()
 			expected := []string{"*.us-west-1.compute.amazonaws.com"}
 			if !reflect.DeepEqual(actual, expected) {
-				t.Errorf("invalid dns names: expecetd=%v, got=%v", expected, actual)
+				t.Errorf("invalid dns names: expected=%v, got=%v", expected, actual)
 			}
 		})
 	})


### PR DESCRIPTION
## Changes

The AWS Cloud Controller does not support private zones, so if you use it with etcd >=v2.4..5 then you will run into issues with cluster initialization, because of a feature introduced the does a reverse dns look up to ensure the IP making requests matches a host on the certificate SANs.

Worse, even if you add all reverse zones so that this *does* work with your private zone, the aws controller _does not_ name nodes after your private zone, and they instead come up using .compute.internal nodeNames. This causes problem elsewhere in the kube-aws stack where we try to update nodes using hostname, but in this scenario hostname != nodename. (*.myprivate.zone vs *...compute.internal). 

This is a hack that allowed us to move forward, but a better implementation is needed & should be revisited.