### PR TITLE
[v0.16.x] Fix node name labelling in v0.16.x clusters.

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -490,6 +490,21 @@ coreos:
         RemainAfterExit=true
         ExecStart=/opt/bin/kubernetes-io-node-label
 
+    - name: kubernetes-io-node-worker-labels.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Label kubernetes worker nodes with kubernetes.io labels.
+
+        [Service]
+        Type=simple
+        Restart=on-failure
+        RestartSec=30
+        ExecStartPre=/usr/bin/systemctl is-active kubelet
+        ExecStart=/opt/bin/kubernetes-io-node-worker-labels
+
 {{if .Experimental.AwsNodeLabels.Enabled }}
     - name: kube-node-label.service
       enable: true
@@ -754,23 +769,43 @@ write_files:
       #!/bin/bash -e
       set -ue
 
-       # FIXME: Remove dependency on the apiserver insecure port
-       until /usr/bin/curl -s -f http://127.0.0.1:8080/version; do echo waiting until apiserver starts; sleep 1; done
+      vols="-v /srv/kubernetes:/srv/kubernetes:ro -v /etc/kubernetes:/etc/kubernetes:ro -v /srv/kube-aws:/srv/kube-aws:ro"
+      kubectl() {
+          /usr/bin/docker run -i --rm $vols --net=host {{.HyperkubeImage.RepoWithTag}} /kubectl --kubeconfig=/etc/kubernetes/kubeconfig/admin.yaml --request-timeout=1s "$@"
+      }
 
-       # FIXME: Remove dependency on the apiserver insecure port
-       /usr/bin/curl \
-         --retry 5 \
-         --request PATCH \
-         -H 'Content-Type: application/strategic-merge-patch+json' \
-         -d '{
-              "metadata": {
-                "labels": {
-                  "kubernetes.io/role": "master",
-                  "node-role.kubernetes.io/master": ""
-                 }
-              }
-            }' \
-         http://localhost:8080/api/v1/nodes/$(hostname)
+      while ! kubectl get ns kube-system; do
+        echo Waiting until kube-system created.
+        sleep 3
+      done
+
+      hostname=$(hostname)
+      kubectl label node $hostname kubernetes.io/role="master"
+      kubectl label node $hostname node-role.kubernetes.io/master=""
+
+  - path: /opt/bin/kubernetes-io-node-worker-labels
+    permissions: 0700
+    owner: root:root
+    content: |
+      #!/bin/bash -e
+      set -ue
+
+      vols="-v /srv/kubernetes:/srv/kubernetes:ro -v /etc/kubernetes:/etc/kubernetes:ro -v /srv/kube-aws:/srv/kube-aws:ro"
+      kubectl() {
+          /usr/bin/docker run -i --rm $vols --net=host {{.HyperkubeImage.RepoWithTag}} /kubectl --kubeconfig=/etc/kubernetes/kubeconfig/admin.yaml --request-timeout=1s "$@"
+      }
+
+      while true
+      do
+        for node in $(kubectl get nodes -l node.kubernetes.io/pending-node -oname); do
+            node_name=$(echo $node | cut -d '.' -f1).$(echo $node | cut -d '.' -f2).compute.internal
+            kubectl label "$node_name" node.kubernetes.io/pending-node-
+            kubectl label "$node_name" kubernetes.io/role="node"
+            kubectl label "$node_name" node-role.kubernetes.io/node=""
+        done
+
+        sleep 20
+      done
 
   {{if .Experimental.AwsNodeLabels.Enabled -}}
   - path: /opt/bin/kube-node-label

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -430,7 +430,6 @@ coreos:
 
         # FIXME: Remove dependency on the apiserver insecure port
         ExecStartPre=/usr/bin/bash -c "until /usr/bin/curl -s -k https://127.0.0.1/version; do echo waiting until apiserver starts; sleep 10; done"
-
         ExecStart=/opt/bin/retry 10 /opt/bin/install-kube-system
 
 {{ if $.ElasticFileSystemID }}

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -495,7 +495,7 @@ coreos:
       runtime: true
       content: |
         [Unit]
-        Description=Label kubernetes worker nodes with kubernetes.io labels.
+        Description=Label kubernetes worker nodes with kubernetes.io labels
 
         [Service]
         Type=simple

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -495,7 +495,7 @@ coreos:
       runtime: true
       content: |
         [Unit]
-        Description=Label kubernetes worker nodes with kubernetes.io labels
+        Description=Label kubernetes worker nodes with kubernetes.io labels.
 
         [Service]
         Type=simple

--- a/builtin/files/userdata/cloud-config-worker
+++ b/builtin/files/userdata/cloud-config-worker
@@ -359,7 +359,7 @@ coreos:
         --cni-bin-dir=/opt/cni/bin \
         --network-plugin={{.K8sNetworkPlugin}} \
         --container-runtime={{.ContainerRuntime}} \
-        --node-labels=node.kubernetes.io/role="node",node.kubernetes.io/role="{{ toLabel .NodePoolName }}"{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
+        --node-labels=node.kubernetes.io/pending-node="",node.kubernetes.io/role="{{ toLabel .NodePoolName }}"{{if .NodeLabels.Enabled}},{{.NodeLabels.String}}{{end}} \
         --register-node=true \
         --config=/etc/kubernetes/config/kubelet.yaml \
         {{- if .Taints }}
@@ -763,23 +763,19 @@ write_files:
       #!/bin/bash -e
       set -ue
 
-       # FIXME: Remove dependency on the apiserver insecure port
-       until /usr/bin/curl -s -f http://127.0.0.1:8080/version; do echo waiting until apiserver starts; sleep 1; done
+      vols="-v /srv/kubernetes:/srv/kubernetes:ro -v /etc/kubernetes:/etc/kubernetes:ro -v /srv/kube-aws:/srv/kube-aws:ro"
+      kubectl() {
+          /usr/bin/docker run -i --rm $vols --net=host {{.HyperkubeImage.RepoWithTag}} /kubectl --kubeconfig=/etc/kubernetes/kubeconfig/admin.yaml --request-timeout=1s "$@"
+      }
 
-       # FIXME: Remove dependency on the apiserver insecure port
-       /usr/bin/curl \
-         --retry 5 \
-         --request PATCH \
-         -H 'Content-Type: application/strategic-merge-patch+json' \
-         -d '{
-              "metadata": {
-                "labels": {
-                  "kubernetes.io/role": "node",
-                  "node-role.kubernetes.io/node": ""
-                 }
-              }
-            }' \
-         http://localhost:8080/api/v1/nodes/$(hostname)
+      while ! kubectl get ns kube-system; do
+        echo Waiting until kube-system created.
+        sleep 3
+      done
+
+      hostname=$(hostname)
+      kubectl label node $hostname kubernetes.io/role="node"
+      kubectl label node $hostname node-role.kubernetes.io/node=""
 
   {{if .Experimental.AwsNodeLabels.Enabled -}}
   - path: /opt/bin/kube-node-label

--- a/make/test
+++ b/make/test
@@ -19,7 +19,7 @@ default() {
 with-cover() {
   test -z "$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)"
   for d in $(go list ./... | grep -v '/vendor/' | grep -v '/hack'); do
-    go test -timeout 45m -json -v --race -coverprofile=profile.out -covermode=atomic $d | tparse
+    KUBE_AWS_INTEGRATION_TEST=1 go test -timeout 45m -json -v --race -coverprofile=profile.out -covermode=atomic $d | tparse
     if [ -f profile.out ]; then
       cat profile.out >> coverage.txt
       rm profile.out

--- a/make/test
+++ b/make/test
@@ -19,7 +19,7 @@ default() {
 with-cover() {
   test -z "$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)"
   for d in $(go list ./... | grep -v '/vendor/' | grep -v '/hack'); do
-    KUBE_AWS_INTEGRATION_TEST=1 go test -timeout 45m -json -v --race -coverprofile=profile.out -covermode=atomic $d | tparse
+    go test -timeout 45m -json -coverprofile=profile.out -covermode=atomic $d | tparse
     if [ -f profile.out ]; then
       cat profile.out >> coverage.txt
       rm profile.out


### PR DESCRIPTION
## Changes

- New restrictions on the kubelets ability to label nodes means that we can no longer label worker nodes, from the worker nodes. Instead, we need to apply a temporary label & then have the masters properly label the nodes.