### PR TITLE
[v0.17.x] Allow dnsmasq to be backed by a local copy of CoreDNS

### DIFF
--- a/builtin/files/cluster.yaml.tmpl
+++ b/builtin/files/cluster.yaml.tmpl
@@ -1167,7 +1167,7 @@ kubernetes:
   # Tells Kubernetes to enable the autoscaler rest client (not using heapster) without the requirement to use metrics-server.
   podAutoscalerUseRestClient:
     enabled: false
-    
+
 #  controllerManager:
 #   resources:
 #     requests:
@@ -1325,6 +1325,35 @@ kubeDns:
   # - --neg-ttl=10
   # - --no-ping
 
+  # Settings for the dnsmasq-node DaemonSet which must be enabled by setting
+  # `kubeDns.nodeLocalResolver` to true.
+  dnsmasq:
+    coreDNSLocal:
+      # When enabled, this will run a copy of CoreDNS within each DNS-masq pod and
+      # configure the utility to use it for resolution.
+      enabled: false
+
+      # Defines the resource requests/limits for the coredns-local container.
+      # cpu and/or memory constraints can be removed by setting the appropriate value(s)
+      # to an empty string.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 100Mi
+        limits:
+          cpu: 50m
+          memory: 100Mi
+
+    # The size of dnsmasq's cache.
+    cacheSize: 50000
+
+    # The maximum number of concurrent DNS queries.
+    dnsForwardMax: 500
+
+    # This option gives a default value for time-to-live (in seconds) which dnsmasq
+    # uses to cache negative replies even in the absence of an SOA record.
+    # negTTL: 60
+
   # When enabled, will modify the TTL of the coredns service.
   # ttl: 30
 
@@ -1347,6 +1376,8 @@ kubeDns:
   #
   # This configuration is injected into the CoreDNS config map after the root
   # zone (".") and can be used to add configuration for additional zones.
+  # If corednsLocal has been enabled, this configuration will additionally be injected
+  # into its ConfigMap.
   # additionalZoneCoreDNSConfig: |
   #  global:53 {
   #      errors
@@ -1374,7 +1405,7 @@ kubeProxy:
 # When enabled, a security group rule is included on the generated kube-aws SG to allow ICMP Ping from all traffic (0.0.0.0/0).
 # This is applied to all nodes (worker & control plane) in the cluster.
 openICMP: true
- 
+
 # Addon features
 addons:
   # When enabled, Kubernetes rescheduler is deployed to the cluster controller(s)

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -1073,9 +1073,14 @@ write_files:
         "${mfdir}/kube-dns-autoscaler-de.yaml" \
         "${mfdir}/kube-dns-de.yaml"
       {{- end }}
-      {{ if .KubeDns.NodeLocalResolver -}}
+      {{- if .KubeDns.NodeLocalResolver }}
+      {{- if .KubeDns.dnsmasq.CoreDNSLocal.Enabled }}
+      deploy "${mfdir}/dnsmasq-node-coredns-local.yaml"
+      {{- else }}
+      remove "${mfdir}/dnsmasq-node-coredns-local.yaml"
+      {{- end }}
       deploy "${mfdir}/dnsmasq-node-ds.yaml"
-      {{ end -}}
+      {{- end }}
       forceapply "${mfdir}/kube-dns-pdb.yaml"
 
       {{ if .Addons.MetricsServer.Enabled -}}
@@ -4343,6 +4348,9 @@ write_files:
         namespace: kube-system
       data:
         Corefile: |
+          {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 10 }}
+          {{- end }}
           .:53 {
               errors
               health
@@ -4365,9 +4373,6 @@ write_files:
               reload
               loadbalance
           }
-          {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
-{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 10 }}
-          {{- end }}
 {{- else }}
   - path: /srv/kubernetes/manifests/kube-dns-sa.yaml
     content: |
@@ -4433,6 +4438,85 @@ write_files:
                 - --v=2
                 - --logtostderr
 
+{{ if and .KubeDns.NodeLocalResolver .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
+  - path: /srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml
+    content: |
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: dnsmasq
+          namespace: kube-system
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: dnsmasq
+        rules:
+          - apiGroups: [""]
+            resources: ["endpoints", "services", "pods", "namespaces"]
+            verbs: ["list", "watch"]
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: dnsmasq
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: dnsmasq
+        subjects:
+          - kind: ServiceAccount
+            name: dnsmasq
+            namespace: kube-system
+        ---
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: dnsmasq-privileged-psp
+          namespace: kube-system
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: privileged-psp
+        subjects:
+          - kind: ServiceAccount
+            name: dnsmasq
+            namespace: kube-system
+        ---
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: coredns-local
+          namespace: kube-system
+          labels:
+            application: coredns
+        data:
+          Corefile: |
+            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
+            {{- end }}
+
+            cluster.local:9254 {{ .PodCIDR }}:9254 {{ .ServiceCIDR }}:9254 {
+                errors
+                kubernetes {
+                    pods insecure
+                }
+                cache 30
+                log svc.svc.cluster.local.
+                prometheus :9153
+            }
+
+            .:9254 {
+                errors
+                health :9154 # this is global for all servers
+                prometheus :9153
+                forward . /etc/resolv.conf
+                pprof 127.0.0.1:9156
+                cache 30
+                reload
+            }
+{{ end }}
+
 {{ if .KubeDns.NodeLocalResolver }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-ds.yaml
     content: |
@@ -4444,9 +4528,12 @@ write_files:
         labels:
           k8s-app: dnsmasq-node
       spec:
+        selector:
+          matchLabels:
+            k8s-app: dnsmasq-node
         updateStrategy:
           rollingUpdate:
-            maxUnavailable: 100%
+            maxUnavailable: 10%
           type: RollingUpdate
         selector:
           matchLabels:
@@ -4464,22 +4551,29 @@ write_files:
               effect: NoSchedule
             - operator: Exists
               effect: NoExecute
-            - operator: Exists
-              key: CriticalAddonsOnly
             volumes:
             - name: kube-dns-config
               configMap:
                 name: kube-dns
                 optional: true
+            {{ if .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
+            - name: coredns-local-config
+              configMap:
+                name: coredns-local
+                items:
+                  - key: Corefile
+                    path: Corefile
+            {{ end }}
             containers:
             - name: dnsmasq
               image: {{ .KubeDnsMasqImage.RepoWithTag }}
               livenessProbe:
                 httpGet:
                   path: /healthcheck/dnsmasq
-                  port: 10054
+                  port: 9054
                   scheme: HTTP
                 initialDelaySeconds: 60
+                periodSeconds: 10
                 timeoutSeconds: 5
                 successThreshold: 1
                 failureThreshold: 5
@@ -4490,13 +4584,24 @@ write_files:
               - -restartDnsmasq=true
               - --
               - -k
-              - --min-port=1024
-              - --cache-size=1000
+              - --cache-size={{ .KubeDns.DNSMasq.CacheSize }}
+              - --dns-forward-max={{ .KubeDns.DNSMasq.DNSForwardMax }}
+              - --log-facility=-
+              {{ if .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
+              - --no-resolv
+              - --keep-in-foreground
+              - --neg-ttl={{ .KubeDns.DNSMasq.NegTTL }}
+              # Send requests to the last server (coredns-local) first and only
+              # fallback to the previous one (global coredns) if it's unreachable.
+              - --strict-order
+              - --server={{.DNSServiceIP}}#53
+              - --server=127.0.0.1#9254
+              {{ else }}
               - --server=//{{.DNSServiceIP}}
               - --server=/cluster.local/{{.DNSServiceIP}}
               - --server=/in-addr.arpa/{{.DNSServiceIP}}
               - --server=/ip6.arpa/{{.DNSServiceIP}}
-              - --log-facility=-
+              {{ end }}
               {{- if ne (len .KubeDns.NodeLocalResolverOptions) 0 }}
                 {{- range .KubeDns.NodeLocalResolverOptions }}
               - {{.}}
@@ -4511,9 +4616,11 @@ write_files:
                 protocol: TCP
               # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
               resources:
+                limits:
+                  cpu: 100m
+                  memory: 50Mi
                 requests:
-                  cpu: 150m
-                  memory: 20Mi
+                  ephemeral-storage: 256Mi
               volumeMounts:
               - name: kube-dns-config
                 mountPath: /etc/k8s/dns/dnsmasq-nanny
@@ -4522,7 +4629,7 @@ write_files:
               livenessProbe:
                 httpGet:
                   path: /metrics
-                  port: 10054
+                  port: 9054
                   scheme: HTTP
                 initialDelaySeconds: 60
                 timeoutSeconds: 5
@@ -4531,17 +4638,69 @@ write_files:
               args:
               - --v=2
               - --logtostderr
+              {{ if .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
+              - --probe=dnsmasq,127.0.0.1:9254,ec2.amazonaws.com,5,A
+              {{ else }}
               - --probe=dnsmasq,127.0.0.1:53,ec2.amazonaws.com,5,A
+              {{ end }}
               ports:
-              - containerPort: 10054
+              - containerPort: 9054
                 name: metrics
                 protocol: TCP
               resources:
                 requests:
-                  memory: 20Mi
+                  ephemeral-storage: 256Mi
+                limits:
+                  cpu: 10m
+                  memory: 45Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+            {{ if .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
+            - name: coredns
+              image: {{ .CoreDnsImage.RepoWithTag }}
+              args: ["-conf", "/etc/coredns/Corefile"]
+              volumeMounts:
+                - name: coredns-local-config
+                  mountPath: /etc/coredns
+              ports:
+                - containerPort: 9254
+                  name: dns
+                  protocol: UDP
+                - containerPort: 9254
+                  name: dns-tcp
+                  protocol: TCP
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: 9154
+                  scheme: HTTP
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                successThreshold: 1
+                failureThreshold: 5
+              resources:
+                requests:
+                  ephemeral-storage: 256Mi
+                  {{ if .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Requests.Cpu }}
+                  cpu: {{ .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Requests.Cpu }}
+                  {{ end }}
+                  {{ if .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Requests.Memory }}
+                  memory: {{ .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Requests.Memory }}
+                  {{ end }}
+                {{ if or .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Cpu .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Memory }}
+                limits:
+                  {{ if .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Cpu }}
+                  cpu: {{ .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Cpu }}
+                  {{ end }}
+                  {{ if .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Memory }}
+                  memory: {{ .KubeDns.DNSMasq.CoreDNSLocal.ComputeResources.Limits.Memory }}
+                  {{ end }}
+                {{ end }}
+            {{ end }}
             hostNetwork: true
             dnsPolicy: Default
-            automountServiceAccountToken: false
+            automountServiceAccountToken: true
+            serviceAccountName: dnsmasq
 {{ end }}
 
 {{- if eq .KubeDns.Provider "coredns" }}

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -184,8 +184,26 @@ func NewDefaultCluster() *Cluster {
 				IPVSMode: ipvsMode,
 			},
 			KubeDns: KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: DNSMasq{
+					CoreDNSLocal: CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: ComputeResources{
+							Requests: ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -194,6 +194,18 @@ type IPVSMode struct {
 	MinSyncPeriod string `yaml:"minSyncPeriod"`
 }
 
+type CoreDNSLocal struct {
+	Enabled          bool             `yaml:"enabled"`
+	ComputeResources ComputeResources `yaml:"resources,omitempty"`
+}
+
+type DNSMasq struct {
+	CoreDNSLocal  CoreDNSLocal `yaml:"coreDNSLocal"`
+	CacheSize     int          `yaml:"cacheSize"`
+	DNSForwardMax int          `yaml:"dnsForwardMax"`
+	NegTTL        int          `yaml:"negTTL"`
+}
+
 type KubeDnsAutoscaler struct {
 	CoresPerReplica int `yaml:"coresPerReplica"`
 	NodesPerReplica int `yaml:"nodesPerReplica"`
@@ -204,6 +216,7 @@ type KubeDns struct {
 	Provider                     string            `yaml:"provider"`
 	NodeLocalResolver            bool              `yaml:"nodeLocalResolver"`
 	NodeLocalResolverOptions     []string          `yaml:"nodeLocalResolverOptions"`
+	DNSMasq                      DNSMasq           `yaml:"dnsmasq"`
 	DeployToControllers          bool              `yaml:"deployToControllers"`
 	AntiAffinityAvailabilityZone bool              `yaml:"antiAffinityAvailabilityZone"`
 	TTL                          int               `yaml:"ttl"`

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1186,8 +1186,26 @@ func TestKubeDns(t *testing.T) {
 			conf: `
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1215,8 +1233,26 @@ kubeDns:
   deployToControllers: false
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1244,8 +1280,26 @@ kubeDns:
   antiAffinityAvailabilityZone: true
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: true,
 				TTL:                          30,
@@ -1273,8 +1327,26 @@ kubeDns:
   antiAffinityAvailabilityZone: true
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          true,
 				AntiAffinityAvailabilityZone: true,
 				TTL:                          30,
@@ -1306,8 +1378,26 @@ kubeDns:
     min: 15
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            true,
+				Provider:          "coredns",
+				NodeLocalResolver: true,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          true,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1331,11 +1421,88 @@ kubeDns:
 		{
 			conf: `
 kubeDns:
+  nodeLocalResolver: true
+  dnsmasq:
+    coreDNSLocal:
+      enabled: true
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "2000Mi"
+        limits:
+          cpu: ""
+          memory: ""
+    cacheSize: 500
+    dnsForwardMax: 100
+    negTTL: 10
+`,
+			kubeDns: api.KubeDns{
+				Provider:          "coredns",
+				NodeLocalResolver: true,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: true,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "100m",
+								Memory: "2000Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "",
+								Memory: "",
+							},
+						},
+					},
+					CacheSize:     500,
+					DNSForwardMax: 100,
+					NegTTL:        10,
+				},
+				DeployToControllers:          false,
+				AntiAffinityAvailabilityZone: false,
+				TTL:                          30,
+				Autoscaler: api.KubeDnsAutoscaler{
+					CoresPerReplica: 256,
+					NodesPerReplica: 16,
+					Min:             2,
+				},
+				DnsDeploymentResources: api.ComputeResources{
+					Requests: api.ResourceQuota{
+						Memory: "70Mi",
+						Cpu:    "100m",
+					},
+					Limits: api.ResourceQuota{
+						Memory: "170Mi",
+						Cpu:    "200m",
+					},
+				},
+			},
+		},
+		{
+			conf: `
+kubeDns:
   provider: coredns
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1369,8 +1536,26 @@ kubeDns:
       memory: "250Mi"
 `,
 			kubeDns: api.KubeDns{
-				Provider:            "coredns",
-				NodeLocalResolver:   false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers: false,
 				TTL:                 30,
 				Autoscaler: api.KubeDnsAutoscaler{
@@ -1397,8 +1582,26 @@ kubeDns:
   ttl: 5
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          5,
@@ -1426,8 +1629,26 @@ kubeDns:
   extraCoreDNSConfig: rewrite name substring demo.app.org app.default.svc.cluster.local
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,
@@ -1456,8 +1677,26 @@ kubeDns:
   additionalZoneCoreDNSConfig: global:53 { forward . 1.2.3.4 }
 `,
 			kubeDns: api.KubeDns{
-				Provider:                     "coredns",
-				NodeLocalResolver:            false,
+				Provider:          "coredns",
+				NodeLocalResolver: false,
+				DNSMasq: api.DNSMasq{
+					CoreDNSLocal: api.CoreDNSLocal{
+						Enabled: false,
+						ComputeResources: api.ComputeResources{
+							Requests: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+							Limits: api.ResourceQuota{
+								Cpu:    "50m",
+								Memory: "100Mi",
+							},
+						},
+					},
+					CacheSize:     50000,
+					DNSForwardMax: 500,
+					NegTTL:        60,
+				},
 				DeployToControllers:          false,
 				AntiAffinityAvailabilityZone: false,
 				TTL:                          30,


### PR DESCRIPTION
This commit allows the user to specify that dnsmasq should be
backed by a pod-local copy of CoreDNS rather than relying on
the global CoreDNS service. If enabled, the dnsmasq-node
DaemonSet will be configured to use a local copy of CoreDN
for its resolution while setting the global CoreDNS service as
a fallback. This is handy in situations where the number of DNS
requests within a cluster grows large and causes resolution issues
as dnsmasq reaches out to the global CoreDNS service.

Additionally, several values passed to dnsmasq are now configurable
including its `--cache-size` and `--dns-forward-max`.

See [this postmortem](https://github.com/zalando-incubator/kubernetes-on-aws/blob/dev/docs/postmortems/jan-2019-dns-outage.md)
for an investigation into this situation which was instrumental in
understanding issues we were facing. Many thanks to dominicgunn
for providing the manifests which I codified into this commit.

---

These features can be enabled and tuned by setting the following
values within cluster.yaml:

```yaml
kubeDns:
  dnsmasq:
    coreDNSLocal:
      # When enabled, this will run a copy of CoreDNS within each DNS-masq pod and
      # configure the utility to use it for resolution.
      enabled: true

      # Defines the resource requests/limits for the coredns-local container.
      # cpu and/or memory constraints can be removed by setting the appropriate value(s)
      # to an empty string.
      resources:
        requests:
          cpu: 50m
          memory: 100Mi
        limits:
          cpu: 50m
          memory: 100Mi

    # The size of dnsmasq's cache.
    cacheSize: 50000

    # The maximum number of concurrent DNS queries.
    dnsForwardMax: 500

    # This option gives a default value for time-to-live (in seconds) which dnsmasq
    # uses to cache negative replies even in the absence of an SOA record.
    negTTL: 60
```

Related:
* [v0.14.x](https://github.com/kubernetes-incubator/kube-aws/pull/1891)
* [v0.16.x](https://github.com/kubernetes-incubator/kube-aws/pull/1895)