### PR TITLE
[v0.17.x] Increase DNS autosacaler memory and add memory limit

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4419,9 +4419,9 @@ write_files:
               resources:
                   requests:
                       cpu: "20m"
+                      memory: "50Mi
+                  limits:
                       memory: "50Mi"
-		  limits:
-		      memory: "50Mi"
               command:
                 - /cluster-proportional-autoscaler
                 - --namespace=kube-system

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4419,7 +4419,9 @@ write_files:
               resources:
                   requests:
                       cpu: "20m"
-                      memory: "10Mi"
+                      memory: "50Mi"
+		  limits:
+		      memory: "50Mi"
               command:
                 - /cluster-proportional-autoscaler
                 - --namespace=kube-system


### PR DESCRIPTION
## Problem
When in large clusters memory allocation can be a challenge if `memory limit != memory requests`. Because of that we've some internal requirements for the platform and we're committing to be more aggressive and taking this very seriously in our platform.
We've some tooling around this in prometheus and as part of our memory allocation cleanup process we've found kube-dns-autoscaler consuming 250% times the requested memory. As we've this alert in our side, this component will trigger an alert: 
```
(
  avg(
    container_memory_usage_bytes{
      container!="POD",
      image!="",
    }
  ) by (container, namespace) 
  * 100
) / max(
  kube_pod_container_resource_requests_memory_bytes{
    job="kube-state-metrics",
    }
) by (container, namespace) > 90
```

## Solution

I've increased the memory request up to 50Mi and added a proper memory limit.

### Note

This cloud be improved by just adding parameters in the cluster.yaml but I didn't take the time as I think not so much people will face this issue