### PR TITLE
[v0.14.x] Always create dnsmasq-node-coredns-local.yaml

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3978,6 +3978,42 @@ write_files:
   - path: /srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml
     content: |
         apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: coredns-local
+          namespace: kube-system
+          labels:
+            application: coredns
+        data:
+          Corefile: |
+            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
+            {{- end }}
+
+            cluster.local:9254 {{ .PodCIDR }}:9254 {{ .ServiceCIDR }}:9254 {
+                errors
+                kubernetes {
+                    pods insecure
+                }
+                cache 30
+                log svc.svc.cluster.local.
+                prometheus :9153
+            }
+
+            .:9254 {
+                errors
+                health :9154 # this is global for all servers
+                prometheus :9153
+                forward . /etc/resolv.conf
+                pprof 127.0.0.1:9156
+                cache 30
+                reload
+            }
+
+{{ if .KubeDns.NodeLocalResolver }}
+  - path: /srv/kubernetes/manifests/dnsmasq-node-ds.yaml
+    content: |
+        apiVersion: v1
         kind: ServiceAccount
         metadata:
           name: dnsmasq
@@ -4019,42 +4055,6 @@ write_files:
             name: dnsmasq
             namespace: kube-system
         ---
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: coredns-local
-          namespace: kube-system
-          labels:
-            application: coredns
-        data:
-          Corefile: |
-            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
-{{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
-            {{- end }}
-
-            cluster.local:9254 {{ .PodCIDR }}:9254 {{ .ServiceCIDR }}:9254 {
-                errors
-                kubernetes {
-                    pods insecure
-                }
-                cache 30
-                log svc.svc.cluster.local.
-                prometheus :9153
-            }
-
-            .:9254 {
-                errors
-                health :9154 # this is global for all servers
-                prometheus :9153
-                forward . /etc/resolv.conf
-                pprof 127.0.0.1:9156
-                cache 30
-                reload
-            }
-
-{{ if .KubeDns.NodeLocalResolver }}
-  - path: /srv/kubernetes/manifests/dnsmasq-node-ds.yaml
-    content: |
         apiVersion: extensions/v1beta1
         kind: DaemonSet
         metadata:

--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -3975,7 +3975,6 @@ write_files:
                   - --v=2
                   - --logtostderr
 
-{{ if and .KubeDns.NodeLocalResolver .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml
     content: |
         apiVersion: v1
@@ -4052,7 +4051,6 @@ write_files:
                 cache 30
                 reload
             }
-{{ end }}
 
 {{ if .KubeDns.NodeLocalResolver }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-ds.yaml


### PR DESCRIPTION
If this file does not exist (as would be the case if the CoreDNS local
feature has not been enabled), controller nodes will fail to come up
with the error:
> error: the path "/srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml" does not exist

This is caused when `kubectl delete` is called against the file because
of the line `remove "${mfdir}/dnsmasq-node-coredns-local.yaml`.

This manifest must always be generated because the CoreDNS-local
feature cannot be enabled and then later disabled without otherwise
requiring manual operator intervention.

---

Additionally, a previous change added a serviceaccount reference to the
dnsmasq-node daemonset; this PR updates the cloud-config-controller
template to create this SA alongside the daemonset.