### PR TITLE
[v0.17.x] Always create required dnsmasq resources

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -4440,88 +4440,86 @@ write_files:
                 - --v=2
                 - --logtostderr
 
-{{ if and .KubeDns.NodeLocalResolver .KubeDns.DNSMasq.CoreDNSLocal.Enabled }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml
     content: |
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: dnsmasq
-          namespace: kube-system
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRole
-        metadata:
-          name: dnsmasq
-        rules:
-          - apiGroups: [""]
-            resources: ["endpoints", "services", "pods", "namespaces"]
-            verbs: ["list", "watch"]
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          name: dnsmasq
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: dnsmasq
-        subjects:
-          - kind: ServiceAccount
-            name: dnsmasq
-            namespace: kube-system
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        metadata:
-          name: dnsmasq-privileged-psp
-          namespace: kube-system
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: privileged-psp
-        subjects:
-          - kind: ServiceAccount
-            name: dnsmasq
-            namespace: kube-system
-        ---
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: coredns-local
-          namespace: kube-system
-          labels:
-            application: coredns
-        data:
-          Corefile: |
-            {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: coredns-local
+        namespace: kube-system
+        labels:
+          application: coredns
+      data:
+        Corefile: |
+          {{- if and (eq .KubeDns.Provider "coredns") .KubeDns.AdditionalZoneCoreDNSConfig }}
 {{ .KubeDns.AdditionalZoneCoreDNSConfig | indent 12 }}
-            {{- end }}
+          {{- end }}
 
-            cluster.local:9254 {{ .PodCIDR }}:9254 {{ .ServiceCIDR }}:9254 {
-                errors
-                kubernetes {
-                    pods insecure
-                }
-                cache 30
-                log svc.svc.cluster.local.
-                prometheus :9153
-            }
+          cluster.local:9254 {{ .PodCIDR }}:9254 {{ .ServiceCIDR }}:9254 {
+              errors
+              kubernetes {
+                  pods insecure
+              }
+              cache 30
+              log svc.svc.cluster.local.
+              prometheus :9153
+          }
 
-            .:9254 {
-                errors
-                health :9154 # this is global for all servers
-                prometheus :9153
-                forward . /etc/resolv.conf
-                pprof 127.0.0.1:9156
-                cache 30
-                reload
-            }
-{{ end }}
+          .:9254 {
+              errors
+              health :9154 # this is global for all servers
+              prometheus :9153
+              forward . /etc/resolv.conf
+              pprof 127.0.0.1:9156
+              cache 30
+              reload
+          }
 
 {{ if .KubeDns.NodeLocalResolver }}
   - path: /srv/kubernetes/manifests/dnsmasq-node-ds.yaml
     content: |
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: dnsmasq
+        namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: dnsmasq
+      rules:
+        - apiGroups: [""]
+          resources: ["endpoints", "services", "pods", "namespaces"]
+          verbs: ["list", "watch"]
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: dnsmasq
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: dnsmasq
+      subjects:
+        - kind: ServiceAccount
+          name: dnsmasq
+          namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dnsmasq-privileged-psp
+        namespace: kube-system
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: privileged-psp
+      subjects:
+        - kind: ServiceAccount
+          name: dnsmasq
+          namespace: kube-system
+      ---
       apiVersion: apps/v1
       kind: DaemonSet
       metadata:


### PR DESCRIPTION
The dnsmasq-node ServiceAccount must exist whether or not CoreDNS-local
has been enabled. Therefore, it is created alongside the DaemonSet rather
than as part of the coredns-local manifest.

Additionally, always create dnsmasq-node-coredns-local.yaml. If this file
does not exist (as would be the case if the CoreDNS local feature has
not been enabled), controller nodes will fail to come up with the error:
> error: the path "/srv/kubernetes/manifests/dnsmasq-node-coredns-local.yaml" does not exist
This is caused when `kubectl delete` is called against the file because
of the line `remove "${mfdir}/dnsmasq-node-coredns-local.yaml`.

This manifest must always be generated because the CoreDNS-local
feature cannot be enabled and then later disabled without otherwise
requiring manual operator intervention.