### PR TITLE
Fix trailing whitespaces in template

### DIFF
--- a/builtin/files/userdata/cloud-config-controller
+++ b/builtin/files/userdata/cloud-config-controller
@@ -374,12 +374,12 @@ coreos:
         {{- end }}
         {{ if .Kubelet.Kubeconfig -}}
         --kubeconfig={{ .Kubelet.Kubeconfig }} \
-        {{- else }}
+        {{ else -}}
         --kubeconfig=/etc/kubernetes/kubeconfig/kubelet.yaml \
-        {{- end }}
-        {{- if checkVersion "<1.10" .K8sVer }}
+        {{ end -}}
+        {{if checkVersion "<1.10" .K8sVer -}}
         --require-kubeconfig \
-        {{- end }}
+        {{ end -}}
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
         {{/* Work-around until https://github.com/kubernetes/kubernetes/issues/43967 is fixed via https://github.com/kubernetes/kubernetes/pull/43995 */ -}}
         --cni-bin-dir=/opt/cni/bin \


### PR DESCRIPTION
Depending on the options combination you use, the controller
template may generate the kubelet.service unit with extra
white lines that break the format hence making it to fail.
   
I have hacked an example in playground comparing the previous
combination of - for trimming whitespaces and the new one
   
https://play.golang.org/p/OO5T7TZA1qR


